### PR TITLE
Approve design direction and harden execution plans

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Syntax-check tracked .mjs files
+        run: git ls-files -z '*.mjs' | xargs -0 -n1 node --check

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 .agents/
 .worktrees/
+.gitworktrees/
 node_modules/
 coverage/
 dist/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ This repository is the standalone Agents Can Communicate product. It is not part
 
 ## Development workflow
 
-- After the bootstrap commit, do not work directly on `main`. Create a project-local ignored worktree under `.worktrees/` and a focused branch.
+- After the bootstrap commit, do not work directly on `main`. Create a project-local ignored worktree under `.gitworktrees/<branch-name>` at the repository root and a focused branch.
 - Use test-driven development. Show the new or corrected gate failing on the intended mutation before claiming it protects anything.
 - Prefer Node built-ins and dependency-free code. Before adding a dependency, verify the latest stable release from its primary source and pin it exactly.
 - Keep production modules and focused test files below 300 lines or add an explicit header explaining why splitting would damage cohesion.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository is a design and migration handoff, not a released package.
 
 - The validated Papercut Warzone 2 prototype is preserved under `prototype/papercut-agent-comms/`.
 - Four independently verified but not yet combined hardening patch sets are preserved under `migration/patches/`.
-- The proposed standalone architecture and product UX are documented under `docs/`.
+- The approved standalone architecture and product UX are documented under `docs/`.
 - Detailed execution plans are under `docs/superpowers/plans/`.
 - No standalone runtime or published npm package exists yet.
 
@@ -41,7 +41,7 @@ The currently selected direction is:
 - project-wide awareness and claims;
 - optional workstreams and coordinators, rather than one permanent global orchestrator.
 
-Some items remain proposed rather than approved. The exact boundary is recorded in [`docs/DECISIONS.md`](docs/DECISIONS.md).
+The design direction was fully approved on 2026-08-15; the remaining open technical decisions (storage backend, package names, license, and similar) are recorded in [`docs/DECISIONS.md`](docs/DECISIONS.md).
 
 ## Prototype verification
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
-# Proposed architecture
+# Architecture
 
-This document describes the recommended target. Items not yet approved are marked in `docs/DECISIONS.md`.
+This document describes the approved target (design approved 2026-08-15). Approved decisions and the remaining open technical items are recorded in `docs/DECISIONS.md`.
 
 ## Control plane, not execution plane
 
@@ -115,6 +115,12 @@ Resolution order:
 
 Multiple Git worktrees of one repository share workspace awareness while retaining distinct checkout metadata. Non-Git directories remain fully supported.
 
+## Lazy workspace materialization
+
+Attachment is universal, but durable state is not created merely because a session opened somewhere (approved 2026-08-15). A lone session writes only ephemeral presence and Intent records in the runtime area. The Workspace materializes durable state — protocol identity, event log, materialized views — exactly once, at the first moment coordination actually exists: a second live session attaches, or the session creates its first durable object (claim, message, task, workstream, decision, artifact, or handoff). At that moment current ephemeral presence and Intents are recorded durably and the event log begins. Ephemeral-only workspaces vanish without a trace once their sessions close; `acc doctor` may garbage-collect any that were abandoned.
+
+A lone session also pays no attention cost: adapters inject no coordination context while the roster has no peers and no attention items, and tool guards short-circuit against the empty claim set.
+
 ## Event model
 
 Every meaningful mutation appends an immutable event and updates materialized state atomically.
@@ -165,9 +171,11 @@ If the coordinator disappears:
 - decisions requiring coordination become attention items;
 - another participant or the human may acquire the coordinator role according to policy.
 
+The coordinator is a planning convenience, never an information gatekeeper: any session can answer for the whole Workspace and relay human requests to any participant. Authority differences apply to mutation only, never to knowledge.
+
 ## Native subagents
 
-Adapters may report parent/child session relationships. Short-lived children remain collapsed unless they obtain a task, claim a resource, send an external message, or exceed the adapter's visibility threshold.
+Adapters may report parent/child session relationships. Short-lived children remain collapsed unless they obtain a task, claim a resource, send an external message, or exceed the adapter's visibility threshold. Collapse reduces noise; it is not secrecy — any session may query collapsed children on demand through a full-scope sync.
 
 ## Realtime and wake behavior
 
@@ -180,3 +188,7 @@ No universal wake guarantee exists. Capabilities distinguish:
 - managed process wake, reserved for a possible future runner.
 
 Delivery status must reflect the strongest observed fact, not intent.
+
+## Presence freshness
+
+Presence has three observable states: online, stale, and offline. Heartbeats arrive only at moments the harness actually exposes — hook safe points for native adapters, tool calls for MCP clients — so an idle but open session naturally degrades to stale. That is truthful reporting, not an error. Each adapter declares its expected heartbeat cadence, and the staleness window derives from that declaration rather than one global constant. The first release ships no heartbeat helper: an idle session is truthfully reported stale, and that display is expected, not an error (approved 2026-08-15). A detached helper (the prototype's watcher pattern) remains a possible later opt-in. Liveness probes and claim lease expiry, never presence staleness alone, decide when ownership may be replaced.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,6 +1,6 @@
 # Decisions
 
-This file separates explicit user decisions from proposals. A new session must preserve that distinction.
+This file separates explicit user decisions from open technical decisions. As of 2026-08-15 no design proposals remain unapproved; a new session must not silently resolve an open technical item.
 
 ## Approved by the user
 
@@ -16,23 +16,20 @@ This file separates explicit user decisions from proposals. A new session must p
 | Generic MCP integration exists as a fallback | Approved |
 | Setup should feel automatic, using hooks and skills where clients support them | Approved |
 | Product must be model-agnostic and allow agents from different companies to collaborate | Approved |
-
-## Strong direction inferred from the latest discussion
-
-These are central design recommendations but still need one explicit user confirmation before implementation treats them as locked.
-
-| Proposal | Rationale |
-|---|---|
-| Gemini CLI becomes a first-class native adapter in the first adapter wave | The product promise explicitly names Codex, Claude, and Gemini |
-| Sessions automatically attach to workspace awareness | Removes repetitive user commands |
-| No permanent project-wide orchestrator | Independent workstreams must not depend on whichever chat opened first |
-| Optional coordinator per workstream | Preserves subagent-team ergonomics without central ownership |
-| `Intent` is a first-class object | Agents need to expose informal exploration and review, not only formal tasks |
-| Claims are workspace-global even when workstreams are independent | Prevents cross-team collisions |
-| Runtime state lives outside the repository | Avoids dirty worktrees and makes the tool standalone |
-| Project config is optional and committed only when the team wants shared policies | Zero-config by default, reproducible customization when needed |
-| ACC does not launch or own agent processes in the first release | The core use case is attaching already-open human-driven sessions |
-| Durable state is authoritative; realtime delivery is an optional acceleration | Closed or dormant models cannot be universally awakened |
+| Every supported session silently attaches to workspace awareness | Approved 2026-08-15 |
+| No session becomes a permanent project-wide orchestrator | Approved 2026-08-15 |
+| Workstream coordinators are optional, scoped, and replaceable | Approved 2026-08-15 |
+| `Intent` is first-class; formal Tasks remain optional | Approved 2026-08-15 |
+| The first release does not launch or own agent processes | Approved 2026-08-15 |
+| Attach policy: attach everywhere with lazy durable materialization — durable state appears on the second live session or the first claim/message/other durable object; until then presence and Intent are ephemeral | Approved 2026-08-15 |
+| Idle presence: v1 ships no detached heartbeat helper; idle sessions are truthfully reported `stale` | Approved 2026-08-15 |
+| Gemini CLI is a first-class native adapter in the first adapter wave | Approved 2026-08-15 |
+| Claims are workspace-global even when workstreams are independent | Approved 2026-08-15 |
+| Runtime state lives outside the repository | Approved 2026-08-15 |
+| Project config is optional and committed only when the team wants shared policies | Approved 2026-08-15 |
+| Durable state is authoritative; realtime delivery is an optional acceleration | Approved 2026-08-15 |
+| Peer equality: any top-level session can represent the whole Workspace — it answers whole-system questions from shared state (including other participants' subagents) and relays human requests to any participant; authority differences apply to mutation only, never to knowledge | Approved 2026-08-15 |
+| Solo zero-overhead: a lone session pays nothing visible — no injected coordination context, no required protocol actions, guards short-circuit against the empty roster; coordination kicks in at the first safe point after a second session attaches or a durable object exists | Approved 2026-08-15 |
 
 ## Open technical decisions
 
@@ -43,6 +40,7 @@ These are central design recommendations but still need one explicit user confir
 5. Whether remote/cloud coordination belongs in v2 or a separate product.
 6. Whether an optional process-launching runner is ever part of ACC or remains an external integration.
 7. Multi-root workspace configuration and discovery rules.
+8. Default claim lease length and renewal cadence for hook-only adapters. The prototype pairs 1800-second leases with a 15-second watcher heartbeat; a hook-only session cannot sustain that cadence, so lease policy must not assume it.
 
 ## Rejected directions
 

--- a/docs/NEXT_SESSION.md
+++ b/docs/NEXT_SESSION.md
@@ -15,11 +15,12 @@ overlapping hardening diffs are preserved under migration/patches. Do not apply
 them blindly. Preserve storage's root-aware APIs while porting lifecycle and
 doctor semantics, and prove every combined gate with focused RED then GREEN.
 
-Before implementation, show me the proposed decisions in docs/DECISIONS.md that
-still require approval. Once I approve them, begin Task 1 of
+The ambient-model approval gate closed on 2026-08-15; docs/DECISIONS.md records
+what is approved and what remains open. Begin Task 1 of
 docs/superpowers/plans/2026-08-15-acc-prototype-reconciliation.md in an isolated
-worktree. Do not start standalone extraction until the combined prototype is
-green, and do not start adapters until the extracted core is green.
+worktree under .gitworktrees/. Do not start standalone extraction until the
+combined prototype is green, and do not start adapters until the extracted core
+is green.
 ```
 
 ## Expected first response
@@ -27,8 +28,8 @@ green, and do not start adapters until the extracted core is green.
 The new session should summarize:
 
 - what is approved;
-- what remains proposed;
+- which technical decisions remain open;
 - what was imported;
 - why the four patches cannot be blindly combined;
 - the first implementation task;
-- the single decision it needs from the user before coding.
+- confirmation that no approval gate blocks Phase 0.

--- a/docs/PLAN_COVERAGE.md
+++ b/docs/PLAN_COVERAGE.md
@@ -2,20 +2,26 @@
 
 Review date: 2026-08-15
 
+Revised 2026-08-15 after a plan audit: the core extraction plan gained Task 5 (filesystem storage adapter and recovery extraction, previously missing despite the package manifest existing since Task 1), later extraction tasks were renumbered 6–9, and the reconciliation plan's command errors were corrected.
+
+A second, deeper audit on the same date grounded the plans in the prototype code: the extraction plan now designs the event log explicitly (ported writer mutex, write-ahead journal generalized from the claims-audit pattern, sequence-ordered event files, crash-window replay), adds presence classification and claim lease/force-release semantics, and the adapter plan gained session-binding persistence, injection-safe peer rendering in the shared projector, and MCP client session identity.
+
 ## Spec coverage
 
 | Design requirement | Plan coverage |
 |---|---|
 | Preserve and reconcile four hardening sets | Prototype reconciliation Tasks 1–6 |
 | Strict protocol, IDs, errors, versions | Core extraction Tasks 2–3 |
-| Storage transaction boundary and recovery | Reconciliation Tasks 2–4; core extraction Task 4 |
-| Optional Git and non-Git Workspace discovery | Core extraction Task 5 |
-| Participant, Session, and first-class Intent | Core extraction Task 6 |
-| Optional Workstream coordinator | Core extraction Task 7 |
-| Task graph and dependencies | Core extraction Task 7 |
-| Workspace-global generic claims | Core extraction Task 7 |
-| Messages, decisions, artifacts, handoffs | Core extraction Task 8 |
-| Cursor sync and compact attention | Core extraction Task 8; adapter plan Task 1 |
+| Storage transaction boundary and recovery | Reconciliation Tasks 2–4; core extraction Tasks 4–5 |
+| Hardened filesystem backend extracted behind `CoordinationStore` | Core extraction Task 5 |
+| Standalone `status`/`doctor` surface | Core extraction Tasks 5 and 9; productization Task 3 |
+| Optional Git and non-Git Workspace discovery | Core extraction Task 6 |
+| Participant, Session, and first-class Intent | Core extraction Task 7 |
+| Optional Workstream coordinator | Core extraction Task 8 |
+| Task graph and dependencies | Core extraction Task 8 |
+| Workspace-global generic claims | Core extraction Task 8 |
+| Messages, decisions, artifacts, handoffs | Core extraction Task 9 |
+| Cursor sync and compact attention | Core extraction Task 9; adapter plan Task 1 |
 | Generic MCP fallback | Adapter plan Task 2 |
 | Codex native integration | Adapter plan Task 3 |
 | Claude Code native integration | Adapter plan Task 4 |
@@ -26,6 +32,14 @@ Review date: 2026-08-15
 | Public docs and adapter-author guide | Productization Task 4 |
 | Threat model and security suite | Productization Task 5 |
 | CI, tarball inspection, unpublished release candidate | Productization Task 6 |
+| Claim leases, stale owners, and audited force release | Core extraction Task 8; `docs/PROTOCOL.md` |
+| Presence freshness for hook-only adapters | Core extraction Task 7; `docs/ARCHITECTURE.md` |
+| Session binding across ephemeral hook processes | Adapter plan Task 1 |
+| MCP client session identity with truthful capabilities | Adapter plan Task 2 |
+| A2A-mappable vocabulary (spec §11) | Core extraction Task 3 |
+| Lazy workspace materialization | Core extraction Tasks 6–7; `docs/ARCHITECTURE.md` |
+| Peer equality: any session answers for the whole Workspace | Core extraction Task 9 (full-scope sync); adapter plan global skill constraint; `docs/VISION.md`, `docs/PROTOCOL.md` |
+| Solo zero-overhead and kick-off on the second session | Core extraction Task 9 (empty solo projection); adapter plan Task 1 and global constraint; `docs/UX.md`, spec §5.3–5.4 |
 
 ## Placeholder scan
 
@@ -37,8 +51,8 @@ The plans contain none of the placeholder patterns prohibited by the writing-pla
 - Storage root-aware helper signatures from migration are repeated exactly in the reconciliation plan.
 - Adapter capability names match `docs/ADAPTERS.md` and the adapter plan.
 - Model-facing operations remain `sync`, `work`, `claim`, `message`, `task`, and `finish` across architecture, protocol, adapters, and plans.
-- Human-only operations remain `status`, `doctor`, `install`, `uninstall`, and configuration commands.
+- Human-only operations remain `status`, `doctor`, `install`, `uninstall`, and configuration commands; `attach`, `heartbeat`, and `detach` are adapter-facing lifecycle commands and are not advertised as model tools.
 
-## Remaining approval gate
+## Approval gate status
 
-The plans are executable only after the user confirms the proposals listed in `docs/DECISIONS.md`. Phase 0 preservation/reconciliation can proceed without selecting the future transactional backend, package name, license, or remote architecture.
+The ambient-model gate closed on 2026-08-15 (see `docs/DECISIONS.md`). Phase 0 reconciliation can proceed. The future transactional backend, package name, license, remote architecture, and claim lease defaults remain open and do not block it.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -13,7 +13,7 @@ The project is at the standalone extraction handoff boundary.
 - [x] Competitor and native-harness research summarized.
 - [x] Standalone product direction documented.
 - [x] Core, adapter, and productization execution plans drafted.
-- [ ] User explicitly approves the proposed ambient-workspace/workstream model.
+- [x] User explicitly approves the proposed ambient-workspace/workstream model (2026-08-15).
 - [ ] Hardening patches integrated into one verified prototype snapshot.
 - [ ] Papercut assumptions removed behind project-agnostic interfaces.
 - [ ] Standalone package layout created.
@@ -25,17 +25,11 @@ The project is at the standalone extraction handoff boundary.
 
 ## Active gate
 
-Before implementation continues, review the proposed decisions in `docs/DECISIONS.md`. In particular, confirm:
-
-1. every supported session silently attaches to workspace awareness;
-2. no session becomes a permanent project-wide orchestrator;
-3. workstream coordinators are optional, scoped, and replaceable;
-4. `Intent` is first-class and tasks remain optional;
-5. the first product release does not launch or own agent processes.
+Closed 2026-08-15. The user approved all five ambient-model points and, the same day, every remaining design proposal: attach everywhere with lazy durable materialization, truthful `stale` presence with no heartbeat sidecar, peer equality (any session answers for the whole Workspace), solo zero-overhead, Gemini as a first-wave native adapter, workspace-global claims, runtime state outside the repository, optional project config, and durable-state authority. See `docs/DECISIONS.md` for exact wording. No design proposal remains unapproved; no gate blocks Phase 0.
 
 ## Next implementation action
 
-After approval, execute `docs/superpowers/plans/2026-08-15-acc-prototype-reconciliation.md` from Task 1. The first deliverable is one integrated prototype snapshot with all four hardening sets reconciled and verified together.
+Execute `docs/superpowers/plans/2026-08-15-acc-prototype-reconciliation.md` from Task 1 in an isolated worktree under `.gitworktrees/`. The first deliverable is one integrated prototype snapshot with all four hardening sets reconciled and verified together.
 
 Then execute the core extraction plan. Do not start native adapters before the project-agnostic core passes its complete regression suite.
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1,6 +1,6 @@
 # Protocol model
 
-This is the proposed model-facing and adapter-facing domain vocabulary.
+This is the approved model-facing and adapter-facing domain vocabulary (design approved 2026-08-15).
 
 ## Identity hierarchy
 
@@ -89,6 +89,10 @@ export interface ResourceClaim {
 
 Adapters may provide path-aware overlap logic, but core mutation is atomic and project-agnostic.
 
+### Claim lifetime and stale owners
+
+Claims are leases. `expiresAt` bounds every claim, and renewal requires the owner's exact session generation. A conflicting claim whose owner session has stale presence still conflicts: the staleness is reported to the requester, but only lease expiry or an explicit force release removes the claim. Force release requires human or policy authority and records actor, reason, and the replaced generation. Presence staleness alone never auto-releases a claim, because an idle-but-open session may resume at any moment.
+
 ## Messages
 
 Message types are semantic, not vendor-specific:
@@ -174,3 +178,5 @@ Adapters request deltas since a cursor. Core computes attention items from expli
 - capability failure that weakened protection.
 
 Semantic relevance may be assessed by the receiving model, but correctness cannot depend on a hidden central LLM classifier.
+
+Sync also supports an explicit full-Workspace scope: any session may request the complete snapshot — roster, intents, workstreams, tasks, claims, and other participants' collapsed child sessions — to answer whole-system questions. Bounded deltas are the ambient default; the full scope exists so no session ever has to say it cannot see the rest of the system.

--- a/docs/UX.md
+++ b/docs/UX.md
@@ -27,19 +27,9 @@ The exact package and binary names remain subject to publication checks.
 
 ## First session
 
-The first supported session in a directory silently creates or discovers a Workspace and registers itself. The user asks an ordinary question; no ACC-specific phrase is required.
+The first supported session in a directory silently creates or discovers a Workspace and registers itself. The user asks an ordinary question; no ACC-specific phrase is required. A lone session leaves only ephemeral presence behind; durable Workspace state appears the moment a second session attaches or the first claim, message, or other durable object is created.
 
-The adapter injects concise internal context such as:
-
-```text
-ACC workspace: Papercut Warzone 2
-Active: none
-Direct requests: none
-Conflicting claims: none
-Before tracked edits, publish a one-line work intent and acquire needed claims.
-```
-
-The model announces its Intent through a high-level tool without asking the user to operate the protocol.
+While the session is alone, the adapter injects nothing and asks nothing of the model: a simple solo task looks exactly as if ACC were not installed. Coordination context and the one-line Intent prompt appear at the first safe point after a second session attaches, and the model then announces its Intent through a high-level tool without asking the user to operate the protocol.
 
 ## Additional session
 
@@ -53,6 +43,19 @@ No direct requests. No claim conflicts.
 ```
 
 This context is normally hidden from the human-facing response.
+
+## Any session answers for the whole system
+
+The user may ask whichever chat is in front of them about the entire Workspace, and that session answers from shared state instead of claiming ignorance:
+
+```text
+User: what is happening in the project right now?
+Claude: visual-codex is editing the camera (2 subagents: shaders,
+lighting-review); physics-gemini is waiting for confirmation of the
+tank-scale contract. No conflicts; one decision is waiting on you.
+```
+
+The same session can relay a request to any participant — “tell Gemini the contract is confirmed” becomes an ACC message with the human's authority attributed, delivered at the recipient's next safe point.
 
 ## Workstream joining policy
 

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -60,6 +60,10 @@ Routine attachment, heartbeat, and non-conflicting awareness should not interrup
 
 Every supported session can participate in ambient workspace awareness. Workstreams, tasks, and coordinators appear only when the work needs them.
 
+### Any session speaks for the whole workspace
+
+The human may ask any open session about the entire system — who is active, what other models and their subagents are doing, what was decided — and route a request to any participant through it. This is collective work among equals, not one boss with dumb workers: knowledge is symmetric, and only mutation authority is scoped.
+
 ### Durable before realtime
 
 A state transition is recorded before delivery is attempted. Realtime notification accelerates delivery but never becomes the source of truth.

--- a/docs/superpowers/plans/2026-08-15-acc-adapters.md
+++ b/docs/superpowers/plans/2026-08-15-acc-adapters.md
@@ -8,6 +8,8 @@
 
 **Tech Stack:** Node.js ESM, Node built-in tests, official client plugin/extension formats, MCP stdio server.
 
+**Spec:** `docs/superpowers/specs/2026-08-15-standalone-acc-design.md` §7 plus `docs/ADAPTERS.md` (capability matrix, tiers, and conformance suite).
+
 ## Global Constraints
 
 - Precondition: the complete core extraction plan is green.
@@ -17,6 +19,8 @@
 - Installer changes are idempotent, preserve unrelated user configuration, and are exactly reversible.
 - Keep model-facing operations to the six high-level ACC tools.
 - Retain real-client evidence for every capability marked true.
+- Every adapter skill instructs the model to publish Intent, to answer whole-Workspace questions from `sync`/`status` data — including other vendors' sessions and their subagents — and to relay user requests to other participants as ACC messages, instead of claiming it cannot see other models (peer equality, approved 2026-08-15).
+- Solo sessions are zero-overhead (approved 2026-08-15): when the Workspace has no peers and no attention items, adapters inject no coordination context — zero bytes, not a "none" banner — and guards short-circuit; coordination surfaces at the first safe point after a peer attaches.
 
 ---
 
@@ -27,13 +31,15 @@
 - Create: `packages/adapter-sdk/src/capabilities.mjs`
 - Create: `packages/adapter-sdk/src/context-projector.mjs`
 - Create: `packages/adapter-sdk/src/config-merge.mjs`
+- Create: `packages/adapter-sdk/src/session-binding.mjs`
 - Create: `packages/adapter-sdk/src/index.mjs`
 - Create: `packages/adapter-sdk/test/capabilities.test.mjs`
 - Create: `packages/adapter-sdk/test/context-projector.test.mjs`
+- Create: `packages/adapter-sdk/test/session-binding.test.mjs`
 - Create: `tests/conformance/adapter-contract.mjs`
 
 **Interfaces:**
-- Produces `defineAdapter`, `assertCapabilities`, `projectContext`, `mergeOwnedConfig`, and `runAdapterConformance`
+- Produces `defineAdapter`, `assertCapabilities`, `projectContext`, `mergeOwnedConfig`, `storeSessionBinding`, `loadSessionBinding`, `clearSessionBinding`, and `runAdapterConformance`
 
 `defineAdapter` returns this contract:
 
@@ -46,6 +52,16 @@
 ```
 
 Each operation returns `{ ok, changes, diagnostics }`; `normalizeHook` returns `{ kind, sessionId, cwd, model, parentSessionId, tool }` with nullable optional fields.
+
+Hook executables are ephemeral processes, so the SDK also persists the harness-to-ACC session mapping under the runtime directory (never the project):
+
+```js
+storeSessionBinding({ runtimeDir, harnessSessionId, accSessionId, generation }): Promise<void>
+loadSessionBinding({ runtimeDir, harnessSessionId }): Promise<{ accSessionId, generation } | null>
+clearSessionBinding({ runtimeDir, harnessSessionId }): Promise<void>
+```
+
+Every hook after session start loads the binding to reuse the exact session generation; `clearSessionBinding` runs at session end.
 
 - [ ] **Step 1: Write capability RED**
 
@@ -61,7 +77,7 @@ Add tests that omitted capabilities resolve to false and unknown capability keys
 
 - [ ] **Step 2: Write context-budget RED**
 
-Create a `SyncResult` larger than the configured byte budget. Assert direct requests and conflicts remain, routine roster detail becomes references, and output is deterministic.
+Create a `SyncResult` larger than the configured byte budget. Assert direct requests and conflicts remain, routine roster detail becomes references, and output is deterministic. Include one hostile peer message containing fake system instructions and terminal escape sequences: the projected output must keep sender attribution and message-type labels, escape control sequences, and confine peer text to a clearly delimited data block that cannot read as ACC policy (`docs/SECURITY.md` rendering properties). Add the solo case: a `SyncResult` with no peers and no attention items projects to an empty string — zero bytes, never a "none" banner.
 
 - [ ] **Step 3: Run RED**
 
@@ -71,11 +87,11 @@ node --test packages/adapter-sdk/test/*.test.mjs
 
 - [ ] **Step 4: Implement SDK**
 
-`defineAdapter` freezes the manifest. `mergeOwnedConfig` stores an ACC ownership marker and removes only owned entries on uninstall.
+`defineAdapter` freezes the manifest. `mergeOwnedConfig` stores an ACC ownership marker and removes only owned entries on uninstall. Session bindings are single JSON files written atomically under the runtime directory. `projectContext` escapes terminal control sequences and renders peer content inside attributed data blocks.
 
 - [ ] **Step 5: Implement conformance runner**
 
-The runner accepts adapter factory plus fixture harness and checks detection, double install, unrelated-config preservation, normalization, context budgets, declared capabilities, double uninstall, and cleanup.
+The runner accepts adapter factory plus fixture harness and checks detection, double install, unrelated-config preservation, normalization, context budgets, injection-safe peer rendering, session-binding reuse across two consecutive hook events, solo zero-overhead (empty projection and guard short-circuit when no peers and no claims exist), declared capabilities, double uninstall, and cleanup.
 
 - [ ] **Step 6: Mutation proof and commit**
 
@@ -97,35 +113,42 @@ git commit -m "feat: define harness adapter contract"
 - Create: `packages/mcp-server/src/resources.mjs`
 - Create: `packages/mcp-server/test/server.test.mjs`
 - Create: `packages/mcp-server/test/tools.test.mjs`
+- Create: `packages/mcp-server/COMPATIBILITY.md`
 - Create: `bin/acc-mcp.mjs`
 
 **Interfaces:**
 - Produces MCP tools `acc_sync`, `acc_work`, `acc_claim`, `acc_message`, `acc_task`, `acc_finish`
 - Produces read-only resources for Workspace snapshot, roster, workstream, task, and inbox
 
-- [ ] **Step 1: Write MCP surface RED**
+- [ ] **Step 1: Choose and record the MCP transport implementation**
+
+Decide explicitly between a dependency-free JSON-RPC 2.0 stdio implementation targeting the current MCP specification revision and the official `@modelcontextprotocol/sdk` verified from its primary source and pinned exactly (the AGENTS.md dependency rule). Record the choice, the MCP protocol revision, and any pinned version in `packages/mcp-server/COMPATIBILITY.md`.
+
+- [ ] **Step 2: Write MCP surface RED**
 
 Start the stdio server in a test client. Assert exactly six public tools, strict JSON schemas, and descriptions that state polling semantics.
 
-- [ ] **Step 2: Run RED**
+- [ ] **Step 3: Run RED**
 
 ```bash
 node --test packages/mcp-server/test/*.test.mjs
 ```
 
-- [ ] **Step 3: Implement thin tool translation**
+- [ ] **Step 4: Implement thin tool translation**
 
 Each tool maps one request into a high-level core operation and returns structured content plus stable machine data. Tool code contains no duplicate claim or lifecycle rules.
 
-- [ ] **Step 4: Add hostile peer-content test**
+Session identity: the server opens one ACC session during the MCP `initialize` handshake (participant name derived from `clientInfo`, Workspace discovered from the server's launch directory), heartbeats it on every tool call, and closes it on stdin EOF or a termination signal. Conversation boundaries inside the client remain unobservable, so the capability manifest still declares no lifecycle capability — process attach is what actually happens, and `acc status` must label it that way.
+
+- [ ] **Step 5: Add hostile peer-content test**
 
 Store a message containing fake system instructions and terminal escapes. The resource output must preserve attribution and escape display control sequences rather than promoting text to protocol policy.
 
-- [ ] **Step 5: Add polling truthfulness test**
+- [ ] **Step 6: Add polling truthfulness test**
 
 The adapter manifest declares `polling: true`, `activeNotification: false`, `wakeDormantSession: false`, and no lifecycle or guard capabilities.
 
-- [ ] **Step 6: Verify and commit**
+- [ ] **Step 7: Verify and commit**
 
 ```bash
 node --test packages/mcp-server/test/*.test.mjs
@@ -148,6 +171,8 @@ git commit -m "feat: add generic MCP coordination fallback"
 - Create: `packages/adapter-codex/test/adapter.test.mjs`
 - Create: `packages/adapter-codex/test/hooks.test.mjs`
 - Create: `packages/adapter-codex/test/install.test.mjs`
+- Create: `tests/conformance/codex.test.mjs`
+- Create: `packages/adapter-codex/COMPATIBILITY.md`
 
 **Interfaces:**
 - Consumes: adapter SDK and CLI
@@ -196,6 +221,7 @@ git commit -m "feat: integrate Codex sessions"
 - Create: `packages/adapter-claude-code/test/adapter.test.mjs`
 - Create: `packages/adapter-claude-code/test/hooks.test.mjs`
 - Create: `packages/adapter-claude-code/test/install.test.mjs`
+- Create: `tests/conformance/claude-code.test.mjs`
 
 **Interfaces:**
 - Consumes: adapter SDK and CLI
@@ -244,6 +270,7 @@ git commit -m "feat: integrate Claude Code sessions"
 - Create: `packages/adapter-gemini-cli/test/adapter.test.mjs`
 - Create: `packages/adapter-gemini-cli/test/hooks.test.mjs`
 - Create: `packages/adapter-gemini-cli/test/install.test.mjs`
+- Create: `tests/conformance/gemini-cli.test.mjs`
 
 **Interfaces:**
 - Consumes: adapter SDK and CLI

--- a/docs/superpowers/plans/2026-08-15-acc-core-extraction.md
+++ b/docs/superpowers/plans/2026-08-15-acc-core-extraction.md
@@ -8,6 +8,8 @@
 
 **Tech Stack:** Node.js ESM, Node built-in `node:test`, npm workspaces, dependency-free runtime during extraction.
 
+**Spec:** `docs/superpowers/specs/2026-08-15-standalone-acc-design.md` §§6–10 plus `docs/ARCHITECTURE.md` and `docs/PROTOCOL.md` (canonical interfaces and vocabulary).
+
 ## Global Constraints
 
 - Precondition: `prototype/integrated/COMBINED_VERIFICATION.md` is green and committed.
@@ -65,10 +67,12 @@ Root `package.json` gains:
 ```json
 "workspaces": ["packages/*"],
 "scripts": {
-  "test": "node --test tests/*.test.mjs tests/*/*.test.mjs packages/*/test/*.test.mjs",
+  "test": "node --test tests packages",
   "check": "find packages -name '*.mjs' -print0 | xargs -0 -n1 node --check"
 }
 ```
+
+Node's test runner searches directory arguments recursively for `*.test.mjs`, so the script stays correct while packages and test folders are still being created; shell globs would pass unmatched patterns through and fail. It never descends into `prototype/` because only `tests` and `packages` are listed.
 
 Each package manifest sets `private: true`, `type: module`, and explicit `exports`. Do not add runtime dependencies.
 
@@ -140,6 +144,8 @@ export function createId(kind, randomBytes = defaultRandomBytes) {
 
 JSON failure envelopes include `ok: false`, stable `code`, human `message`, and structured `details` without stack traces.
 
+The reconciled prototype also defines `TIMEOUT: 3` and uses `REQUIRED: 6` where this table says `ATTENTION: 6`. Keep numeric slot 3 reserved for timeout semantics rather than reassigning it, and map `REQUIRED` to `ATTENTION` when porting tests, so ported process tests keep their exit-code meaning.
+
 - [ ] **Step 4: Mutation proof**
 
 Temporarily permit `/` in `assertPortableId`. Run `ids.test.mjs`; expected failure names path-safety behavior. Restore and rerun green.
@@ -200,7 +206,7 @@ node --test packages/protocol/test/{schema,states}.test.mjs
 
 - [ ] **Step 3: Implement strict validators**
 
-Reject unknown schema versions and unknown required enum values. Preserve optional forward-compatible metadata only under a named `extensions` object.
+Reject unknown schema versions and unknown required enum values. Preserve optional forward-compatible metadata only under a named `extensions` object. Keep record and field names mappable to the A2A Agent Card, Task, Message, and Artifact concepts (spec §11) without importing any A2A transport.
 
 - [ ] **Step 4: Mutation proof**
 
@@ -234,9 +240,10 @@ tx.get(kind, id): object | null
 tx.put(kind, id, record, expectedGeneration): void
 tx.list(kind, predicate): object[]
 store.eventsSince(workspaceId, cursor, limit): Promise<EventPage>
+store.snapshot(workspaceId): Promise<WorkspaceSnapshot>
 ```
 
-`CoordinationTransaction` is the object exposing `append`, `get`, `put`, and `list` above. `CoordinationService` is an object whose methods are added in Tasks 6–8; the factory freezes injected ports and exposes no global singleton.
+`CoordinationTransaction` is the object exposing `append`, `get`, `put`, and `list` above. `CoordinationService` is an object whose methods are added in Tasks 7–9; the factory freezes injected ports and exposes no global singleton.
 
 - [ ] **Step 1: Write RED for atomic event/state behavior**
 
@@ -250,7 +257,7 @@ node --test packages/core/test/service-contract.test.mjs
 
 - [ ] **Step 3: Implement the memory contract and service factory**
 
-Use copied maps inside a transaction and swap only after callback success. Production core accepts no global clock or random source.
+Use copied maps inside a transaction and swap only after callback success. Implement `snapshot` from the materialized maps. Production core accepts no global clock or random source.
 
 - [ ] **Step 4: Add optimistic generation conflict test**
 
@@ -266,7 +273,95 @@ git commit -m "feat: add coordination storage port"
 
 ---
 
-### Task 5: Extract Workspace discovery and runtime paths
+### Task 5: Extract the filesystem storage adapter and recovery
+
+**Files:**
+- Create: `packages/storage-filesystem/src/store.mjs`
+- Create: `packages/storage-filesystem/src/atomic-json.mjs`
+- Create: `packages/storage-filesystem/src/safe-file.mjs`
+- Create: `packages/storage-filesystem/src/safe-directory.mjs`
+- Create: `packages/storage-filesystem/src/record-id.mjs`
+- Create: `packages/storage-filesystem/src/recovery.mjs`
+- Create: `packages/storage-filesystem/test/store-contract.test.mjs`
+- Create: `packages/storage-filesystem/test/recovery.test.mjs`
+- Create: `tests/process/store-concurrency.test.mjs`
+- Modify: `packages/core/test/service-contract.test.mjs`
+
+**Interfaces:**
+- Consumes: `CoordinationStore`/`CoordinationTransaction` ports from Task 4; reconciled storage behavior preserved under `prototype/integrated/tools/agents/lib/`
+- Produces:
+
+```js
+openFilesystemStore({ root, clock, ids }): Promise<CoordinationStore>
+diagnoseFilesystemStore({ root }): Promise<RepairReport>
+repairFilesystemStore({ root, clock }): Promise<RepairReport>
+/** @typedef {{ healthy: boolean, repaired: string[], blocked: string[],
+ * corrupt: string[] }} RepairReport */
+```
+
+`diagnoseFilesystemStore` is read-only; `repairFilesystemStore` applies only unambiguous repairs and fails closed on everything listed under `blocked` or `corrupt`.
+
+- [ ] **Step 1: Make the store contract suite store-agnostic**
+
+Refactor `packages/core/test/service-contract.test.mjs` so every contract test runs through an exported factory runner:
+
+```js
+export function runStoreContract(name, makeStore) {
+  test(`${name}: transaction rollback hides state and events`, async () => { /* existing body */ });
+  test(`${name}: stale generation write fails with EXIT.CONFLICT`, async () => { /* existing body */ });
+}
+```
+
+Keep the memory-store invocation in the same file. Create `packages/storage-filesystem/test/store-contract.test.mjs` that calls `runStoreContract("filesystem", () => openFilesystemStore({ root, clock, ids }))` inside a temp directory from `withTempWorkspace`.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+node --test packages/storage-filesystem/test/store-contract.test.mjs
+```
+
+Expected: module-not-found failure for `openFilesystemStore`.
+
+- [ ] **Step 3: Port the reconciled storage behavior**
+
+Port from `prototype/integrated/tools/agents/lib/` without changing semantics: atomic write plus no-replace publication (`atomic-json.mjs`), no-follow regular-file reads and managed-root containment (`safe-file.mjs`, `safe-directory.mjs`), record/filename binding (`record-id.mjs`), and the directory-based owner mutex from `repair-mutex.mjs` as the per-workspace writer mutex (owner file with pid, token, and acquisition time; stale takeover only under its existing rules). Preserve injected opener and directory-reader seams as final arguments.
+
+The event log is new code built on those ported primitives — the prototype has no event feed. Inside the writer mutex a transaction allocates the next sequence number, writes one write-ahead journal entry listing every intended record and event publication (the generalization of the prototype's claims-audit pattern), publishes each file with no-replace semantics, and then retires the journal entry. Event filenames embed the zero-padded sequence so lexicographic directory order equals event order; the cursor is the last consumed sequence. A failed callback publishes nothing and appends no event.
+
+- [ ] **Step 4: Port recovery and audits**
+
+Port the reconciled claims-audit and recovery-audit semantics into `recovery.mjs`: an audit with the exact still-active source generation and absent destination is pending and replayable; a replacement generation, mismatched bytes, orphan target, or conflicting destination is corrupt and blocks repair. Neither function mutates a store whose protocol identity or schema version does not validate.
+
+- [ ] **Step 5: Add the crash-window replay test**
+
+In `packages/storage-filesystem/test/recovery.test.mjs`, use the injected failure seam to abort a transaction (a) after the journal entry is written but before any publication, and (b) after the event file is published but before the state record. Reopening the store, and running `repairFilesystemStore`, must either complete the journaled publications exactly or roll them back; `eventsSince` never exposes a partially published transaction, and running repair twice changes nothing.
+
+- [ ] **Step 6: Run focused GREEN**
+
+```bash
+node --test packages/storage-filesystem/test/*.test.mjs packages/core/test/service-contract.test.mjs
+```
+
+Expected: the same contract suite passes against both memory and filesystem stores; recovery and crash-window tests pass.
+
+- [ ] **Step 7: Add the process-level concurrency test**
+
+`tests/process/store-concurrency.test.mjs` spawns independent Node child processes that perform conflicting `put` calls with the same expected generation against one filesystem store. Exactly one process succeeds; every other exits with `EXIT.CONFLICT`; the event log afterward has no gaps and no duplicate sequence numbers.
+
+- [ ] **Step 8: Mutation proof**
+
+Temporarily allow replacement in the publication step through the injected seam. The no-replace contract test and the concurrency test must fail by name. Restore production behavior and rerun green.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/storage-filesystem packages/core tests/process
+git commit -m "feat: extract filesystem coordination store"
+```
+
+---
+
+### Task 6: Extract Workspace discovery and runtime paths
 
 **Files:**
 - Create: `packages/cli/src/workspace-discovery.mjs`
@@ -286,8 +381,10 @@ runtimePaths({ dataHome, workspaceId }): RuntimePaths
 
 ```js
 /** @typedef {{ root: string, protocol: string, events: string, state: string,
- * locks: string, quarantine: string }} RuntimePaths */
+ * locks: string, quarantine: string, ephemeral: string }} RuntimePaths */
 ```
+
+`ephemeral` holds presence and Intent records for workspaces that have not yet materialized durable state (`docs/ARCHITECTURE.md`, “Lazy workspace materialization”).
 
 - [ ] **Step 1: Write discovery RED fixtures**
 
@@ -301,7 +398,7 @@ node --test packages/cli/test/{workspace-discovery,runtime-paths}.test.mjs
 
 - [ ] **Step 3: Implement non-Git discovery first**
 
-Canonicalize the selected root and derive a stable directory-source ID. Runtime path uses the platform user-data root and portable Workspace ID.
+Canonicalize the selected root and derive a stable directory-source ID. Runtime path uses the platform user-data root and portable Workspace ID. Keep `workspace-discovery.mjs` free of CLI side effects — no argument parsing, no `process.exit`, no stdout — because `packages/mcp-server` and native adapters import it directly.
 
 - [ ] **Step 4: Add optional Git enrichment**
 
@@ -318,7 +415,7 @@ git commit -m "feat: discover standalone workspaces"
 
 ---
 
-### Task 6: Implement participant, session, and Intent services
+### Task 7: Implement participant, session, and Intent services
 
 **Files:**
 - Create: `packages/core/src/sessions.mjs`
@@ -333,13 +430,16 @@ git commit -m "feat: discover standalone workspaces"
 openSession(input): Promise<Session>
 heartbeatSession(input): Promise<Session>
 closeSession(input): Promise<Session>
+classifySessionPresence(session, now, probe): "online" | "stale" | "offline"
 setIntent(input): Promise<WorkIntent>
 clearIntent(input): Promise<void>
 ```
 
 - [ ] **Step 1: Write lifecycle and Intent RED**
 
-Test unique generation, duplicate-live rejection, stale generation replacement policy, old-close cannot close successor, heartbeat boundary, exact Intent owner, and no raw prompt field accepted.
+Test unique generation, duplicate-live rejection, stale generation replacement policy, old-close cannot close successor, heartbeat boundary, exact Intent owner, and no raw prompt field accepted. Also test presence classification: a recent heartbeat is `online`; a heartbeat older than the session's declared cadence window is `stale` (hook-only adapters cannot heartbeat while the harness is idle, so `stale` is a normal truthful state, not an error); a closed session or a failed liveness probe is `offline`.
+
+Also test lazy materialization (approved 2026-08-15): a lone session with no durable objects leaves only ephemeral presence and Intent records; the workspace materializes durable state exactly once — when a second live session attaches or the first durable object is created — and current presence and Intents are recorded durably at that moment; closing the only session of an ephemeral-only workspace leaves nothing behind.
 
 - [ ] **Step 2: Run RED**
 
@@ -349,7 +449,9 @@ node --test packages/core/test/{sessions,intents}.test.mjs
 
 - [ ] **Step 3: Implement transactional lifecycle**
 
-Every lifecycle mutation checks Workspace and generation inside one store transaction. A Session close transitions state; it does not delete durable history.
+Every lifecycle mutation checks Workspace and generation inside one store transaction. A Session close transitions state; it does not delete durable history. `heartbeatSession` updates an ephemeral presence view without appending to the semantic event feed (spec §6.4); only open/close and online/stale/offline transitions surface through cursor sync.
+
+`openSession` writes ephemeral presence while the workspace has no durable state. Materialization is a single transaction that establishes protocol identity, starts the event log, and records current presence and Intents; it is triggered by the second live session or the first durable object, never by a lone quiet session.
 
 - [ ] **Step 4: Implement Intent rules**
 
@@ -366,7 +468,7 @@ git commit -m "feat: track sessions and work intent"
 
 ---
 
-### Task 7: Implement workstreams, tasks, and claims
+### Task 8: Implement workstreams, tasks, and claims
 
 **Files:**
 - Create: `packages/core/src/workstreams.mjs`
@@ -388,11 +490,12 @@ transitionTask(input): Promise<Task>
 acquireClaim(input): Promise<ResourceClaim>
 renewClaim(input): Promise<ResourceClaim>
 releaseClaim(input): Promise<void>
+forceReleaseClaim(input): Promise<void>
 ```
 
 - [ ] **Step 1: Write RED for optional coordination**
 
-Test Workspace with Intents but no Workstream, Workstream with no coordinator, coordinator lease replacement only after policy permits it, task dependency unblocking, and global claim conflict across two Workstreams.
+Test Workspace with Intents but no Workstream, Workstream with no coordinator, coordinator lease replacement only after policy permits it, task dependency unblocking, and global claim conflict across two Workstreams. Also test claim lease expiry (an expired claim stops conflicting and its old generation cannot renew), staleness metadata (a conflict against a claim whose owner session is stale reports that staleness but still blocks until expiry or force release), and force-release authority (a peer session cannot force-release; a human or policy actor can).
 
 - [ ] **Step 2: Run RED**
 
@@ -408,9 +511,11 @@ Coordinator is a scoped lease. Completing a dependency updates derived claimabil
 
 Claims compare canonical resource namespace plus adapter-provided overlap key. Workspace-global conflict is independent of Workstream ID.
 
+Port the prototype's lease semantics: every claim carries `expiresAt` and renewal demands the exact owner generation. Replace the prototype's orchestrator-only force release with the standalone authority model — `forceReleaseClaim` requires human or policy authority (a coordinator lease does not extend outside its Workstream) and appends an audit event recording actor, reason, and the replaced generation. Presence staleness alone never auto-releases a claim.
+
 - [ ] **Step 5: Concurrent claim process test**
 
-Add `tests/process/concurrent-claim.test.mjs` that starts independent processes against the filesystem store. Exactly one exclusive contender succeeds; the others return conflict.
+Add `tests/process/concurrent-claim.test.mjs` that starts independent processes against the filesystem store from Task 5. Exactly one exclusive contender succeeds; the others return conflict.
 
 - [ ] **Step 6: Verify mutation and commit**
 
@@ -423,7 +528,7 @@ git commit -m "feat: coordinate workstreams tasks and claims"
 
 ---
 
-### Task 8: Implement communication, sync, status, and CLI composition
+### Task 9: Implement communication, sync, status, and CLI composition
 
 **Files:**
 - Create: `packages/core/src/communication.mjs`
@@ -431,18 +536,22 @@ git commit -m "feat: coordinate workstreams tasks and claims"
 - Create: `packages/core/src/status.mjs`
 - Create: `packages/core/test/communication.test.mjs`
 - Create: `packages/core/test/sync.test.mjs`
+- Create: `packages/core/test/status.test.mjs`
 - Create: `packages/cli/src/main.mjs`
 - Create: `packages/cli/src/args.mjs`
+- Create: `packages/cli/src/doctor-command.mjs`
 - Create: `packages/cli/test/integration.test.mjs`
 - Create: `bin/acc.mjs`
 
 **Interfaces:**
+- Consumes: session lifecycle services from Task 7 (`openSession`, `heartbeatSession`, `closeSession`) and `diagnoseFilesystemStore`/`repairFilesystemStore` from Task 5
 - Produces high-level operations `sync`, `work`, `claim`, `message`, `task`, `finish`, `status`, `doctor`
+- Produces adapter-facing lifecycle commands `attach`, `heartbeat`, `detach` (they map to `openSession`, `heartbeatSession`, `closeSession`; they are not advertised as model tools)
 - Produces stable `--json` envelopes from `@agents-can-communicate/protocol`
 
 - [ ] **Step 1: Write communication and sync RED**
 
-Test typed message, per-recipient delivery state, immutable acknowledgement, Decision authority, artifact digest, handoff evidence, cursor replay, attention ordering, and bounded projection.
+Test typed message, per-recipient delivery state, immutable acknowledgement, Decision authority, artifact digest, handoff evidence, cursor replay, attention ordering, and bounded projection. Also test full-scope sync (peer equality, approved 2026-08-15): any session requests `scope: "full"` and receives the complete Workspace snapshot including another participant's collapsed child sessions; the ambient default remains a bounded delta; no session gets a reduced full view because of its role. Also test the solo case (solo zero-overhead, approved 2026-08-15): a Workspace with one live session, no claims, and no messages yields empty attention and an empty bounded projection.
 
 - [ ] **Step 2: Write CLI RED**
 
@@ -450,11 +559,13 @@ Spawn `node bin/acc.mjs --json status` in a temp non-Git Workspace. Expected ini
 
 - [ ] **Step 3: Implement communication and sync**
 
-Use one transaction for message plus recipient queues. Sync returns a new cursor and priority-sorted attention without changing delivery to seen unless the caller explicitly confirms injection/visibility.
+Use one transaction for message plus recipient queues. Sync returns a new cursor and priority-sorted attention without changing delivery to seen unless the caller explicitly confirms injection/visibility. `sync` accepts `scope: "delta" | "full"`; the full scope returns `store.snapshot(workspaceId)` with collapsed child sessions included and is available to every session equally.
 
 - [ ] **Step 4: Implement CLI composition**
 
 `bin/acc.mjs` delegates to `packages/cli/src/main.mjs` and exits with `AccError.code`. Human errors use stderr; JSON mode writes exactly one JSON object to stdout and no human diagnostics.
+
+`attach` opens a session and prints the session ID plus generation token so the adapter can later heartbeat and `detach` the exact generation; `detach` with a stale generation fails with `EXIT.CONFLICT`. `doctor` composes `diagnoseFilesystemStore` (read-only) with core health rules; `doctor --repair` calls `repairFilesystemStore` and fails closed when the report lists `blocked` or `corrupt` entries.
 
 - [ ] **Step 5: Run focused and complete tests**
 
@@ -468,7 +579,7 @@ git diff --check
 - [ ] **Step 6: Project-specific token scan**
 
 ```bash
-rg -n 'PW2_|Papercut|papercut-warzone|docs/plan|game/' packages bin tests
+rg -n 'PW2_|Papercut|papercut-warzone|docs/plan|game/|orchestrator' packages bin tests
 ```
 
 Expected: no matches outside an explicit migration fixture.

--- a/docs/superpowers/plans/2026-08-15-acc-productization.md
+++ b/docs/superpowers/plans/2026-08-15-acc-productization.md
@@ -8,6 +8,8 @@
 
 **Tech Stack:** npm workspaces, Node.js current LTS selected at execution time from official release data, GitHub Actions pinned to exact current stable revisions, Markdown documentation.
 
+**Spec:** `docs/superpowers/specs/2026-08-15-standalone-acc-design.md` §§5, 9–11 plus `docs/UX.md` and `docs/SECURITY.md`.
+
 ## Global Constraints
 
 - Precondition: cross-vendor adapter acceptance is green.
@@ -34,6 +36,8 @@
 - [ ] **Step 1: Check publication namespaces**
 
 Query npm registry for `agents-can-communicate`, the selected organization scope, and `acc` binary collisions. Record results in the PR description. If the unscoped package is unavailable, use the approved organization scope without changing the binary name unless that binary also conflicts.
+
+This step also resolves two open decisions from `docs/DECISIONS.md` with the user before any manifest changes: the public license (open decision 3) and the publication model — one publishable CLI package that bundles the workspaces versus scoped per-package publication (part of open decision 2). `npx agents-can-communicate install` from `docs/UX.md` requires the entry package to be publishable, so the root manifest cannot stay `private: true` unless a dedicated entry package replaces it. Record both answers in `docs/DECISIONS.md` as user-approved.
 
 - [ ] **Step 2: Verify current Node LTS**
 
@@ -255,7 +259,7 @@ Run supported Node LTS on macOS, Linux, and Windows. Gates: clean install, synta
 
 - [ ] **Step 3: Write package verifier**
 
-`scripts/verify-package.mjs` installs the tarball into a clean temp directory, runs `acc --json doctor`, exercises a non-Git Workspace, and proves uninstall cleanup.
+`scripts/verify-package.mjs` packs every publishable workspace, rewrites inter-package dependency specifiers to the freshly packed local tarballs (before first publication they cannot resolve from the public registry), installs the entry tarball into a clean temp directory, runs `acc --json doctor`, exercises a non-Git Workspace, and proves uninstall cleanup.
 
 - [ ] **Step 4: Prove CI gate liveness locally**
 

--- a/docs/superpowers/plans/2026-08-15-acc-prototype-reconciliation.md
+++ b/docs/superpowers/plans/2026-08-15-acc-prototype-reconciliation.md
@@ -8,6 +8,8 @@
 
 **Tech Stack:** Node.js ESM, Node built-in `node:test`, dependency-free filesystem storage, Git patches as evidence.
 
+**Spec:** `docs/superpowers/specs/2026-08-15-standalone-acc-design.md` §13 plus `docs/MIGRATION.md` (semantic contents, conflict points, required combined regressions).
+
 ## Global Constraints
 
 - Do not edit `prototype/papercut-agent-comms/` or `migration/patches/*.patch`.
@@ -42,12 +44,10 @@ npm run test:prototype
 
 Expected historical baseline: 181 tests. Record the exact observed count and outcome in `prototype/integrated/SOURCE.md`; do not hide the known fixed-delay failure if it occurs.
 
-Also run the focused SIGTERM test and the parallel diagnostic:
+Also run the focused SIGTERM test and the parallel diagnostic using the scripts that already exist in the root `package.json`:
 
 ```bash
-cd prototype/papercut-agent-comms
-node --test --test-name-pattern='SIGTERM is accepted' tests/tools/agent_comms/cli-round1.test.mjs
-cd ../../..
+npm run test:prototype:sigterm
 npm run test:prototype
 ```
 
@@ -125,7 +125,7 @@ listJsonFiles(dir, { root, readDirectory })
 
 - [ ] **Step 1: Reconstruct storage tests from the archived patch**
 
-Port only test additions from `0003-storage-and-messages.patch`. Adjust paths so they target `prototype/integrated/tools/agents/`.
+Port every test change from `0003-storage-and-messages.patch`: the new `*-storage.test.mjs` and `*-process-storage.test.mjs` files plus the patch's modifications to the existing `atomic-json.test.mjs` and `cli-round1.test.mjs` (those hunks pass the new explicit `root` argument into the safe-read helpers; without them the legacy tests break as soon as Step 3 lands the new signatures). The `cli-round1.test.mjs` hunk does not overlap Task 1's SIGTERM readiness change; keep both. Do not port production changes yet. Adjust paths so they target `prototype/integrated/tools/agents/`.
 
 - [ ] **Step 2: Run focused tests to verify RED**
 
@@ -151,14 +151,16 @@ return publishWithoutReplacement(source, destination);
 
 Run the Step 2 command. Expected: every focused test passes.
 
-- [ ] **Step 5: Run compatibility tests**
+- [ ] **Step 5: Run compatibility tests and the full integrated suite**
 
 ```bash
 cd prototype/integrated
-node --test tests/tools/agent_comms/{atomic-json,identity,messages,paths,schema,claims,status,repair-mutex}.test.mjs
+node --test tests/tools/agent_comms/{atomic-json,identity,messages,paths,schema,claims,status,repair-mutex,cli-round1}.test.mjs
+cd ../..
+npm run test:integrated
 ```
 
-Expected: all selected legacy behavior remains green.
+Expected: all legacy behavior remains green, including `cli-round1.test.mjs`, which now exercises the ported root-aware read signature. Do not commit a snapshot whose full suite is red.
 
 - [ ] **Step 6: Commit**
 
@@ -193,15 +195,15 @@ Expected: the baseline permits at least protocol mutation, stale open identity r
 
 - [ ] **Step 3: Port lifecycle behavior, not old helper signatures**
 
-Implement these command preconditions:
+Implement these command preconditions using the guard name the archived patch actually introduces (`requireCheckoutProtocol` in `tools/agents/lib/identity.mjs`; `comms.mjs` calls it for every command outside `init` and `prompt`):
 
 ```js
-if (command !== "init" && command !== "prompt") {
-  await requireCompatibleWorkspace(context);
+if (!["init", "prompt"].includes(parsed.command)) {
+  await requireCheckoutProtocol(context);
 }
 ```
 
-`requireCompatibleWorkspace` must validate schema version, protocol version, workspace identity, and root before mutation. Preserve Task 2's managed-root reads.
+`requireCheckoutProtocol` must validate schema version, protocol version, workspace identity, and root before mutation. Keep the archived prototype vocabulary here; renaming to standalone Workspace terms belongs to the extraction plan, not this one. Preserve Task 2's managed-root reads.
 
 Serialize register, resume, close, watcher start, and watcher stop through one per-participant ownership critical section.
 
@@ -327,7 +329,8 @@ git commit -m "fix: complete integrated protocol prompt"
 
 **Files:**
 - Create: `prototype/integrated/COMBINED_VERIFICATION.md`
-- Create: `prototype/integrated/tests/tools/agent_comms/combined-hardening.test.mjs`
+- Create: `prototype/integrated/tests/tools/agent_comms/combined-hardening.test.mjs` (split into `combined-hardening-<area>.test.mjs` files if the 300-line test limit requires it)
+- Modify: `docs/PROGRESS.md`
 
 **Interfaces:**
 - Consumes: Tasks 1–5
@@ -335,7 +338,7 @@ git commit -m "fix: complete integrated protocol prompt"
 
 - [ ] **Step 1: Add cross-patch regressions**
 
-The focused file must exercise all twelve cases listed in `docs/MIGRATION.md` under “Required combined regressions.” Use real CLI subprocesses for workspace identity and stdout/exit-code assertions; use deterministic injected seams for race windows.
+The focused file must exercise all twelve cases listed in `docs/MIGRATION.md` under “Required combined regressions.” Use real CLI subprocesses for workspace identity and stdout/exit-code assertions; use deterministic injected seams for race windows. Subprocess-heavy cases are verbose: if one file cannot hold all twelve under the 300-line limit, split them into at most three `combined-hardening-<area>.test.mjs` files (for example `-storage`, `-lifecycle`, `-doctor`), keeping each case in exactly one file.
 
 - [ ] **Step 2: Capture RED liveness for each protection group**
 
@@ -347,7 +350,7 @@ For storage, lifecycle, and doctor groups, temporarily neutralize one exact pred
 find prototype/integrated/tools/agents -name '*.mjs' -print0 | xargs -0 -n1 node --check
 npm run test:integrated
 git diff --check
-find prototype/integrated/tools prototype/integrated/tests -name '*.mjs' -print0 | xargs -0 wc -l | awk '$1 >= 300 { print; failed=1 } END { exit failed }'
+find prototype/integrated/tools prototype/integrated/tests -name '*.mjs' -print0 | xargs -0 wc -l | awk '$2 != "total" && $1 >= 300 { print; failed=1 } END { exit failed }'
 ```
 
 Expected: syntax green; all tests pass; diff check green; no listed file reaches 300 lines.
@@ -356,9 +359,13 @@ Expected: syntax green; all tests pass; diff check green; no listed file reaches
 
 `COMBINED_VERIFICATION.md` must contain exact HEAD, commands, exit codes, test counts, mutation RED evidence, and remaining limitations. Do not copy historical counts.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Update the progress ledger**
+
+In `docs/PROGRESS.md`, mark “Hardening patches integrated into one verified prototype snapshot” complete and change “Next implementation action” to the core extraction plan. Do not change any other checkbox.
+
+- [ ] **Step 6: Commit**
 
 ```bash
-git add prototype/integrated
+git add prototype/integrated docs/PROGRESS.md
 git commit -m "test: certify combined protocol hardening"
 ```

--- a/docs/superpowers/specs/2026-08-15-standalone-acc-design.md
+++ b/docs/superpowers/specs/2026-08-15-standalone-acc-design.md
@@ -1,6 +1,6 @@
 # Standalone Agents Can Communicate Design
 
-**Status:** Proposed design handoff
+**Status:** Approved design (gate closed 2026-08-15; see §14)
 
 **Date:** 2026-08-15
 
@@ -28,6 +28,7 @@ The imported Papercut implementation proves much of the low-level messaging, own
 8. Degrade honestly on clients that support only MCP or CLI.
 9. Keep protocol state independent of any model's context window or lifetime.
 10. Provide a clean adapter contract for future clients.
+11. Let any session answer for the whole Workspace: every top-level session can read the complete coordination state — including other participants' subagents — and relay human requests to any participant. Knowledge is symmetric; only mutation authority is scoped.
 
 ### 2.2 Engineering goals
 
@@ -58,9 +59,13 @@ A Workspace is the durable collaboration boundary. It may represent one director
 
 Runtime state is stored outside the project. An optional project config provides stable identity and shared policy but never stores presence, messages, locks, or credentials.
 
+Materialization is lazy (approved 2026-08-15): a lone session writes only ephemeral presence and Intent records. Durable state — protocol identity, event log, materialized views — is created exactly once, when a second live session attaches or the first durable object (claim, message, task, workstream, decision, artifact, or handoff) is created; current ephemeral records are recorded durably at that moment. An ephemeral-only Workspace vanishes once its sessions close.
+
 ### 4.2 Participant and Session
 
 A Participant is a persistent human or agent identity. A Session is one concrete harness conversation. All mutable ownership uses the Session's exact generation token so a restarted or duplicate process cannot impersonate a prior generation.
+
+Session presence is online, stale, or offline. Heartbeats arrive only at moments the harness exposes, so an idle but open hook-only session is truthfully reported stale; the first release ships no detached heartbeat helper (approved 2026-08-15). Liveness probes and claim lease expiry, never staleness alone, govern ownership replacement.
 
 ### 4.3 Intent
 
@@ -69,6 +74,8 @@ Intent answers “what is this session doing now?” with one concise summary, m
 ### 4.4 Workstream and coordinator
 
 A Workstream groups related collaboration. It may have a coordinator lease but does not require one for transport or persistence. The first session is never made global Workspace orchestrator merely because it arrived first.
+
+The coordinator is a planning role, never an information gatekeeper (approved 2026-08-15): any session answers about any Workstream from durable state, and the human may route a request to any participant through whichever session they happen to be talking to.
 
 ### 4.5 Task
 
@@ -96,7 +103,7 @@ The CLI detects installed harnesses and offers native adapter installation. Chan
 A lifecycle-capable adapter:
 
 1. discovers Workspace;
-2. validates protocol identity;
+2. validates protocol identity where durable state exists (§4.1 lazy materialization);
 3. acquires exact session ownership;
 4. starts heartbeat;
 5. obtains a compact snapshot/delta;
@@ -106,9 +113,13 @@ A lifecycle-capable adapter:
 
 The adapter supplies a skill instruction. After understanding the request, the model publishes one-line Intent. The user does not manually register an agent or create a task.
 
+While the session is alone in the Workspace (approved 2026-08-15), the adapter injects no coordination context and demands no protocol action: a simple solo task pays zero visible overhead. The Intent prompt appears at the first safe point after a peer attaches; until then the peer sees the session as active with intent pending.
+
 ### 5.4 Before mutation
 
 Where supported, a pre-tool hook extracts the target resource and asks core to guard it. A conflict blocks or asks; an unclaimed non-conflicting resource can trigger an internal claim workflow. The guard cannot claim to protect out-of-band writes.
+
+When the Workspace has no other live sessions and no claims, the guard short-circuits against the ephemeral roster and adds no perceptible latency.
 
 ### 5.5 Sync and delivery
 
@@ -122,7 +133,7 @@ The semantic skill creates a handoff while the model is active. Session-end hook
 
 ### 6.1 Packages
 
-Proposed monorepo layout:
+Monorepo layout:
 
 ```text
 packages/
@@ -220,7 +231,7 @@ The first native wave targets Codex, Claude Code, and Gemini CLI. Generic MCP ex
 
 Prefer six high-level operations:
 
-1. `sync`: snapshot/delta and attention.
+1. `sync`: snapshot/delta and attention; supports an explicit full-Workspace scope so any session can answer whole-system questions, including collapsed child sessions of other participants.
 2. `work`: announce/update Intent and workstream membership.
 3. `claim`: acquire/renew/release generic resources atomically.
 4. `message`: send/reply/mark/ack typed communication.
@@ -331,12 +342,14 @@ Every protection gate requires an intentional mutation showing the expected non-
 9. Add installer and public product documentation.
 10. Perform real cross-vendor acceptance before first release.
 
-## 14. Open approval gate
+## 14. Approval gate status
 
-Implementation beyond preservation requires explicit user confirmation of the proposed ambient model:
+Closed 2026-08-15. The user explicitly approved the ambient model:
 
 - every supported session silently attaches to Workspace awareness;
 - no first-session global orchestrator;
 - optional coordinator per Workstream;
 - Intent is always available while formal Tasks remain optional;
 - first release does not own or launch agent processes.
+
+Two follow-up decisions were approved the same day: attach everywhere with lazy durable materialization (§4.1), and truthful stale presence with no heartbeat helper in the first release (§4.2). `docs/DECISIONS.md` records the exact wording, the remaining proposals, and the open technical decisions; none of them block Phase 0.


### PR DESCRIPTION
## Summary

- Close the ambient-model approval gate (2026-08-15) and record every design decision as user-approved: lazy workspace materialization, truthful stale presence without a heartbeat sidecar, peer equality (any session answers for the whole Workspace), solo zero-overhead, Gemini as a first-wave native adapter, workspace-global claims, runtime state outside the repository, optional project config, and durable-state authority.
- Harden the execution plans after a two-pass audit against the preserved prototype:
  - core extraction gains Task 5 extracting the filesystem store behind CoordinationStore (writer mutex, write-ahead journal, sequenced event log, recovery replay, crash-window tests); later tasks renumbered 6-9
  - sessions gain presence classification; claims gain lease expiry, staleness metadata, and audited force release replacing the prototype's orchestrator-only authority
  - sync gains an explicit full-Workspace scope and an empty solo projection; the CLI gains attach/heartbeat/detach and doctor composition
  - the adapter SDK gains session-binding persistence, injection-safe peer rendering, and solo zero-overhead conformance; the MCP fallback gains explicit session identity
  - the reconciliation plan's command errors are fixed (worktree-relative cd, wc total line, ported test modifications, archived guard name)
  - stale approval language removed across the spec, README, ARCHITECTURE, PROTOCOL, UX, and NEXT_SESSION
- Align the worktree convention with the global policy (.gitworktrees/ at the repository root).

## Verification

- All relative documentation links resolve; no placeholder patterns remain in the plans; step numbering is sequential in all four plans.
- `git diff --check` clean; `node --check` passes for every tracked .mjs file (pre-push hook).
- Fresh-session entry path verified: AGENTS.md -> README -> PROGRESS -> DECISIONS -> spec -> MIGRATION -> active plan is coherent, with the next action named explicitly.
