### PR TITLE
Reconcile all four hardening sets into one certified prototype snapshot

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -4,8 +4,18 @@
 # Never bypass with --no-verify; fix the failure instead.
 set -e
 
+# The lint step runs first, while git's own repository variables are still set,
+# so `git ls-files` resolves this repository without relying on discovery.
 echo "pre-push: syntax-checking tracked .mjs files"
 git ls-files -z '*.mjs' | xargs -0 -n1 node --check
+
+# Git exports GIT_DIR, GIT_WORK_TREE and friends into every hook. The suite
+# spawns git inside temporary fixture repositories, and inheriting these makes
+# those commands operate on THIS repository instead. The fixtures strip the
+# variables themselves; this is the second barrier, so a future test that
+# forgets cannot damage the working repository.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_OBJECT_DIRECTORY
+unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_PREFIX GIT_QUARANTINE_PATH
 
 if node -e "process.exit(require('./package.json').scripts?.['test:integrated'] ? 0 : 1)" 2>/dev/null
 then

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Pre-push gate: lint validation plus the protocol regression suite.
+# Enable once per clone with:  git config core.hooksPath .githooks
+# Never bypass with --no-verify; fix the failure instead.
+set -e
+
+echo "pre-push: syntax-checking tracked .mjs files"
+git ls-files -z '*.mjs' | xargs -0 -n1 node --check
+
+if node -e "process.exit(require('./package.json').scripts?.['test:integrated'] ? 0 : 1)" 2>/dev/null
+then
+  echo "pre-push: running the integrated protocol suite"
+  npm run test:integrated
+else
+  echo "pre-push: no test:integrated script in this revision; skipping the suite"
+fi
+
+echo "pre-push: all gates passed"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ This repository is the standalone Agents Can Communicate product. It is not part
 - Prefer Node built-ins and dependency-free code. Before adding a dependency, verify the latest stable release from its primary source and pin it exactly.
 - Keep production modules and focused test files below 300 lines or add an explicit header explaining why splitting would damage cohesion.
 - Keep adapter-specific behavior inside adapter packages. Core code must not branch on vendor names.
+- Enable the tracked pre-push gate once per clone with `git config core.hooksPath .githooks`. It syntax-checks every tracked `.mjs` file and runs the protocol suite.
 - Never bypass hooks with `--no-verify`.
 - Commit changes in focused, independently reviewable commits. Do not push or merge unless the user explicitly requests it.
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -14,7 +14,7 @@ The project is at the standalone extraction handoff boundary.
 - [x] Standalone product direction documented.
 - [x] Core, adapter, and productization execution plans drafted.
 - [x] User explicitly approves the proposed ambient-workspace/workstream model (2026-08-15).
-- [ ] Hardening patches integrated into one verified prototype snapshot.
+- [x] Hardening patches integrated into one verified prototype snapshot.
 - [ ] Papercut assumptions removed behind project-agnostic interfaces.
 - [ ] Standalone package layout created.
 - [ ] Native Codex adapter implemented.
@@ -29,9 +29,9 @@ Closed 2026-08-15. The user approved all five ambient-model points and, the same
 
 ## Next implementation action
 
-Execute `docs/superpowers/plans/2026-08-15-acc-prototype-reconciliation.md` from Task 1 in an isolated worktree under `.gitworktrees/`. The first deliverable is one integrated prototype snapshot with all four hardening sets reconciled and verified together.
+Execute `docs/superpowers/plans/2026-08-15-acc-core-extraction.md` from Task 1 in an isolated worktree under `.gitworktrees/`. Its precondition is met: `prototype/integrated/COMBINED_VERIFICATION.md` records 269/269 passing with mutation evidence for every protection group.
 
-Then execute the core extraction plan. Do not start native adapters before the project-agnostic core passes its complete regression suite.
+Do not start native adapters before the project-agnostic core passes its complete regression suite.
 
 ## Historical verification evidence
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "description": "Model- and harness-agnostic coordination for independent AI agent sessions.",
   "scripts": {
     "test:prototype": "cd prototype/papercut-agent-comms && node --test tests/tools/agent_comms/*.test.mjs",
-    "test:prototype:sigterm": "cd prototype/papercut-agent-comms && node --test --test-name-pattern='SIGTERM is accepted' tests/tools/agent_comms/cli-round1.test.mjs"
+    "test:prototype:sigterm": "cd prototype/papercut-agent-comms && node --test --test-name-pattern='SIGTERM is accepted' tests/tools/agent_comms/cli-round1.test.mjs",
+    "test:integrated": "cd prototype/integrated && node --test tests/tools/agent_comms/*.test.mjs"
   }
 }

--- a/prototype/integrated/COMBINED_VERIFICATION.md
+++ b/prototype/integrated/COMBINED_VERIFICATION.md
@@ -30,7 +30,7 @@ All commands were run from the repository root unless noted.
 
 | Command | Result |
 |---|---|
-| `npm run test:integrated` | **269 tests, 269 pass, 0 fail**, exit 0, three consecutive runs (~50 s each) |
+| `npm run test:integrated` | **271 tests, 271 pass, 0 fail**, exit 0 (269 at certification, plus 2 harness-hermeticity regressions) |
 | `find prototype/integrated/tools/agents -name '*.mjs' \| xargs -n1 node --check` | exit 0 |
 | `git diff --check` | exit 0 |
 | line-count policy, `$1 >= 300` | exit 0; the largest file is 299 lines |
@@ -150,6 +150,20 @@ recovery state. Restored, 4/4 pass.
    fail, and since every scanner wraps its read in `catch { corrupt.add(...) }`,
    the reconciled tree would have declared all recovery artifacts corrupt. Root
    is now threaded through every managed read; a multi-line scan verifies it.
+5. **The fixtures were not hermetic, and it caused real damage.** Git exports
+   `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE` into every hook environment.
+   The first run of the new pre-push hook therefore executed the suite with
+   those variables set, and `createGitWorktreeFixture` spawned `git` without
+   stripping them, so every fixture operated on the real repository: it flipped
+   `core.bare` to `true`, created a stray `linked` branch, registered a stray
+   worktree under `/tmp`, and stacked empty `fixture` commits onto the working
+   branch. No content was lost — the branch tree stayed byte-identical to its
+   last real commit — and the repository was fully restored. The flaw is latent
+   in the preserved baseline and only manifests when the suite runs with git
+   repository variables set. Fixtures now build their environment through
+   `hermeticEnv()`, which strips every `GIT_*` variable, and the hook unsets
+   them as a second barrier. `harness-hermeticity.test.mjs` guards both: with
+   the filter removed, it fails.
 
 ## Remaining limitations
 
@@ -172,3 +186,11 @@ recovery state. Restored, 4/4 pass.
    are unchanged here by design. Renaming belongs to the extraction plan.
 5. **Not certified beyond this platform.** All evidence is from one macOS arm64
    host on Node 24.4.0. No Linux or Windows run exists yet.
+6. **Production git resolution still inherits the ambient environment.**
+   `defaultGitQuery` in `tools/agents/comms.mjs` runs `git` with the inherited
+   environment, so running the CLI from inside a git hook would resolve another
+   repository's identity. Only the test harness was made hermetic here, because
+   changing production git resolution is a behaviour change no archived patch
+   covers. The extraction plan already injects a `gitProbe` port
+   (`docs/superpowers/plans/2026-08-15-acc-core-extraction.md`, Task 6), which is
+   the right place to fix this — ACC adapters are hook-driven by design.

--- a/prototype/integrated/COMBINED_VERIFICATION.md
+++ b/prototype/integrated/COMBINED_VERIFICATION.md
@@ -1,0 +1,174 @@
+# Combined hardening verification
+
+This snapshot reconciles all four archived hardening sets on the preserved
+Papercut layout. It is the certified source for standalone extraction. It is not
+the standalone package layout.
+
+## Provenance
+
+| Item | Value |
+|---|---|
+| Baseline commit | `9a866cf16f97a0aa1af7ea792acc79bc02278633` |
+| Verified at HEAD | `c7057365ac91fdd344338d505eba44b0a58f37b4` |
+| Branch | `chore/prototype-reconciliation` |
+| Node | `v24.4.0` |
+| Platform | `Darwin 25.5.0 arm64`, 18 CPUs |
+
+Integration commits, in order:
+
+```text
+1689407 chore: create integrated protocol snapshot
+0f16446 fix: harden integrated message storage
+e192939 fix: harden integrated agent lifecycle
+862b0cd fix: complete integrated recovery audits
+c705736 fix: complete integrated protocol prompt
+```
+
+## Final verification
+
+All commands were run from the repository root unless noted.
+
+| Command | Result |
+|---|---|
+| `npm run test:integrated` | **269 tests, 269 pass, 0 fail**, exit 0, three consecutive runs (~50 s each) |
+| `find prototype/integrated/tools/agents -name '*.mjs' \| xargs -n1 node --check` | exit 0 |
+| `git diff --check` | exit 0 |
+| line-count policy, `$1 >= 300` | exit 0; the largest file is 299 lines |
+
+Per-area combined regressions:
+
+| File | Result |
+|---|---|
+| `combined-hardening-lifecycle.test.mjs` | 7 tests, 7 pass |
+| `combined-hardening-storage.test.mjs` | 6 tests, 6 pass |
+| `combined-hardening-doctor.test.mjs` | 4 tests, 4 pass |
+
+Test growth across the reconciliation: 181 baseline → 210 after storage → 232
+after lifecycle → 251 after doctor → 252 after prompt → 269 with the combined
+regressions.
+
+## Coverage of the twelve required combined regressions
+
+Each case in `docs/MIGRATION.md` under "Required combined regressions" is
+exercised in exactly one combined file.
+
+| # | Case | Where |
+|---|---|---|
+| 1 | foreign-workspace protocol blocks every non-init command before mutation | lifecycle |
+| 2 | malformed or unknown foreign protocol also blocks `doctor --repair` | lifecycle |
+| 3 | `init` validates an existing protocol identity before creating layout | lifecycle |
+| 4 | lifecycle register/close/start shares one ownership critical section | lifecycle |
+| 5 | broadcast recipients are live, not merely registered open | lifecycle |
+| 6 | managed-root reads reject symlinked parent directories | storage |
+| 7 | inbox and archive filenames bind to message IDs | storage |
+| 8 | acknowledgements cannot overwrite immutable archives | storage |
+| 9 | two doctors plus a concurrent publisher cannot delete the new generation | doctor |
+| 10 | audit-published/pre-mutation claim and mutex operations replay safely | doctor |
+| 11 | all recovery artifacts are continuously inventoried | doctor |
+| 12 | unknown protocol/schema versions fail closed before any repair | lifecycle |
+
+Case 1 enumerates all fourteen gated command forms, asserts exit 4, asserts JSON
+stdout purity where the command supports `--json` (`watch` does not), and
+compares a base64 snapshot of the entire foreign workspace tree before and after
+each attempt.
+
+## Mutation evidence
+
+Every protection group was proven live by neutralising an exact production
+predicate, observing the named failure, and restoring the file immediately.
+
+The central finding is that **no single predicate carries a group**. Each group
+is defence in depth, and a single-predicate mutation is not sufficient to make
+the combined tests fail. That is a property worth recording, not a gap.
+
+### Storage group
+
+| Mutation | Outcome |
+|---|---|
+| `safe-directory.mjs`: `!details.isDirectory() \|\| details.isSymbolicLink()` neutralised | 6/6 still pass |
+| `safe-directory.mjs`: canonical `realpath(current) !== expected` neutralised | 6/6 still pass |
+| **both neutralised** | **2 fail**: cases 6a and 6b |
+
+With both barriers gone, `acc status` exits 0 and returns a full status payload
+containing the registry records read through the symlinked parent, and the
+assertion prints that payload. Restored, 6/6 pass.
+
+### Lifecycle group
+
+| Mutation | Outcome |
+|---|---|
+| `comms.mjs`: the `requireCheckoutProtocol` call for every non-`init`/`prompt` command neutralised | **2 fail**: cases 1 and 2 |
+
+Cases 3 and 12 correctly keep passing under this mutation, because `initBus`
+asserts checkout identity itself and `validateProtocol` rejects unknown versions
+wherever the protocol is read. The independence is deliberate. Restored, 7/7.
+
+### Doctor group
+
+| Mutation | Outcome |
+|---|---|
+| `status.mjs`: outer `corruptAudit` gate neutralised | 4/4 still pass |
+| `status.mjs`: both `corruptAudit` and the mutex-held `lockedCorruptAudit` recheck neutralised | **1 fail**: case 11 |
+
+Exact failure:
+
+```text
+✖ 11: every recovery artifact family is inventoried and blocks unrelated repair
+  Error [CommsError]: corrupt claim recovery audit
+      at repairPendingForceReleases (tools/agents/lib/claims.mjs:258:42)
+      at async performRepairs (tools/agents/lib/status.mjs:254:19)
+```
+
+A third barrier inside `repairPendingForceReleases` fires once the two doctor
+gates are gone, so repair still fails closed rather than acting on ambiguous
+recovery state. Restored, 4/4 pass.
+
+### Earlier per-task mutation evidence
+
+| Gate | Mutation | Failure |
+|---|---|---|
+| watcher SIGTERM lifecycle | drop the `SIGTERM` registration in `signal-stop.mjs` | `watcher did not stop gracefully: {"code":null,"signal":"SIGTERM"}` |
+| stdin liveness | make `messageInput` read stdin unconditionally | `send waited for stdin for 30000ms despite an explicit body source` |
+| init layout ordering | move `ensureBusLayout` ahead of the identity assertion | `init mutated a foreign checkout bus` |
+| force-release replay | remove the scanner check **and** the replay generation check | replay runs and the replacement claim generation is unlinked |
+
+## Corrections made during reconciliation
+
+1. The preserved SIGTERM test terminated the watcher after a fixed 80 ms. Watcher
+   ownership is published at ~103 ms and online presence at ~109 ms, so the child
+   died from the default signal disposition (`code: null, signal: "SIGTERM"`)
+   before installing its handler. Replaced with a bounded condition wait on the
+   ownership lock plus an online presence record carrying the child's own pid.
+2. `explicit body sources ... with stdin left open` encoded a liveness property
+   as a 300 ms latency budget. Measured: 40-64 ms idle, 175-840 ms under suite
+   load, always exit 0. Replaced with a 30 s liveness ceiling.
+3. That ceiling initially made the suite four times slower, because
+   `Promise.race` does not cancel the loser and the timer kept the runner alive.
+   Clearing it returned `cli-round1.test.mjs` from 31 s to 2.87 s.
+4. The archived doctor scanners passed their injected opener in the managed-root
+   position. Under the ported storage API that made every recovery artifact read
+   fail, and since every scanner wraps its read in `catch { corrupt.add(...) }`,
+   the reconciled tree would have declared all recovery artifacts corrupt. Root
+   is now threaded through every managed read; a multi-line scan verifies it.
+
+## Remaining limitations
+
+1. **Ancestor-swap race.** A deliberately adversarial same-user process can
+   transiently swap and restore an ancestor directory between pathname checks.
+   Preserved from `docs/MIGRATION.md` as documented residual hardening; a
+   portable dependency-free Node fix is not small. Revisit if the storage
+   backend changes.
+2. **Suite wall time is contention-bound.** No single test file exceeds ~4.2 s in
+   isolation, but the suite saturates 18 cores with CLI subprocesses, so
+   individual test durations inflate roughly tenfold under parallel execution.
+   This is throughput, not a defect; it does matter for any future CI timeout.
+3. **Some focused commands are working-directory sensitive.** The prompt CLI
+   resolves its template relative to the process working directory, so focused
+   commands must run from `prototype/integrated`, the way `npm run
+   test:integrated` does. Running the plan's Task 5 focused command from the
+   repository root produces one spurious failure.
+4. **Papercut vocabulary is intentionally retained.** `PW2_AGENT_BUS_DIR`,
+   checkout identity, agent/task wording, and the `tools/agents/comms.mjs` path
+   are unchanged here by design. Renaming belongs to the extraction plan.
+5. **Not certified beyond this platform.** All evidence is from one macOS arm64
+   host on Node 24.4.0. No Linux or Windows run exists yet.

--- a/prototype/integrated/SOURCE.md
+++ b/prototype/integrated/SOURCE.md
@@ -1,0 +1,67 @@
+# Integrated prototype provenance
+
+Baseline: `9a866cf16f97a0aa1af7ea792acc79bc02278633`
+Archived source: `../papercut-agent-comms/`
+Hardening evidence: `../../migration/patches/`
+
+This directory is the mutable reconciliation target. It is not the standalone
+package layout.
+
+## Baseline verification recorded before copying
+
+Environment: Node `v24.4.0`, `Darwin 25.5.0 arm64`, repository HEAD
+`23ed1951478eae2b66d2ca47d36af41914beb494` on branch
+`chore/prototype-reconciliation`.
+
+| Command | Observed |
+|---|---|
+| `npm run test:prototype` | 181 tests, 180 pass, **1 fail**, duration 8501 ms |
+| `npm run test:prototype:sigterm` | 1 test, 0 pass, **1 fail**, exit 1 |
+
+Both failures are the same case, `SIGTERM is accepted by the executable watcher
+lifecycle` in `tests/tools/agent_comms/cli-round1.test.mjs:108`, asserting
+`null !== 0`.
+
+This deviates from the transfer-staging record in `docs/PROGRESS.md`, which
+reported the focused run passing and only serial/parallel runs failing. On this
+machine the focused run fails as well. The deviation is recorded here rather
+than hidden.
+
+### Measured root cause
+
+The failure was diagnosed by measurement, not by inference. A diagnostic run
+against the immutable baseline observed, over three repetitions:
+
+- `locks/watcher-models.json` published at ~103 ms after `spawn`;
+- `presence/models.json` with `status: "online"` and the child's own pid at
+  ~109 ms after `spawn`;
+- terminating at the baseline's fixed 80 ms yields `code: null`,
+  **`signal: "SIGTERM"`** — death by the default signal disposition, meaning the
+  child had not yet installed its handler;
+- terminating at 300 ms and at 1000 ms yields `code: 0`, `signal: null`;
+- terminating after a condition-based wait yields `code: 0` in every repetition.
+
+`withSignalStop` registers `SIGINT`/`SIGTERM` synchronously before `main` runs,
+so handler installation strictly precedes watcher-ownership publication. The
+80 ms constant simply sits below this machine's ~103 ms startup cost. This is a
+test-harness timing flaw in preserved source behavior, not a production watcher
+defect, and it is not transfer corruption: all 49 archived blobs match source
+commit `9a866cf` exactly.
+
+### Correction applied to this snapshot
+
+`tests/tools/agent_comms/cli-round1.test.mjs` now waits, on a bounded 10-second
+loop, until the watcher-ownership lock exists **and** the presence record
+validates as `online` with the child's own pid, then sends `SIGTERM`. Timeout and
+premature-exit failures report the last observed child stdout and stderr. The
+assertion compares `{ code, signal }` so a future regression names its failure
+mode instead of reporting `null !== 0`. No sleep was lengthened.
+
+Gate liveness was demonstrated: removing the `SIGTERM` registration from
+`tools/agents/lib/signal-stop.mjs` makes the corrected test fail with
+`watcher did not stop gracefully: {"code":null,"signal":"SIGTERM"}`. The
+production file was restored immediately and verified byte-identical to the
+immutable baseline.
+
+This is the only intentional difference between `../papercut-agent-comms/` and
+this snapshot at the Task 1 boundary. Production trees are identical.

--- a/prototype/integrated/docs/AGENT_COMMS.md
+++ b/prototype/integrated/docs/AGENT_COMMS.md
@@ -73,7 +73,9 @@ node tools/agents/comms.mjs reply --from models --message MESSAGE_ID --type cont
 `handoff` requires all of `--id`, `--to`, `--task`, `--result`, `--branch`,
 `--base`, `--verification-file`, `--contracts-file`, and `--limitations-file`,
 plus either `--commit SHA` or `--uncommitted` (never both). `--changed`,
-`--follow-up`, and `--artifact` may repeat. A committed handoff is:
+`--follow-up`, `--artifact`, and `--ephemeral-artifact` may repeat. Use
+`--artifact` for a committed repository file and `--ephemeral-artifact` for
+ignored evidence under `.agents/artifacts/`. A committed handoff is:
 
 ```bash
 node tools/agents/comms.mjs handoff --id visual --to orchestrator --task M2.7 --result ready --branch m2/visual --commit COMMIT_SHA --base BASE_SHA --changed game/presentation/view.gd --verification-file verification.json --contracts-file contracts.json --limitations-file limitations.json
@@ -125,6 +127,10 @@ handoff, release claims, stop `watch` orderly with SIGINT/SIGTERM, and `close`.
 | `5` | Identity, claim, or lock conflict. |
 | `6` | Required agent is stale/offline or a required acknowledgement is pending. |
 
+With `--json`, success and failure each produce exactly one JSON value on
+stdout. Failures use `{ "error": { "message", "exit_code", "details" } }` and
+leave stderr empty; human mode prints the error on stderr.
+
 Records are plaintext local files: never send secrets, tokens, credentials, or
 personal data that does not belong in the repository. JSON schema/version
 errors fail closed with exit 4. `doctor --repair` quarantines corrupt immutable
@@ -132,6 +138,13 @@ records and may repair proven stale locks or complete safe archive transitions;
 it never silently resets a bus, steals a live claim, or migrates an unknown
 schema. Investigate the reported path, use `status`/`doctor`, and coordinate
 with the orchestrator before any repair affecting shared work.
+
+The transport rejects symlinked managed paths, canonical escapes, and observed
+directory-generation changes. Its security boundary is cooperative same-user
+agents: portable dependency-free Node cannot make path traversal atomic against
+a deliberately adversarial local process that swaps and restores an ancestor
+directory between checks. Do not use the bus as a secret store or cross-user
+security boundary.
 
 ## Rollout boundary
 

--- a/prototype/integrated/docs/AGENT_COMMS.md
+++ b/prototype/integrated/docs/AGENT_COMMS.md
@@ -1,0 +1,148 @@
+# Local agent communication protocol
+
+This is the operator guide for the local, Git-ignored `.agents/` mailbox bus.
+It coordinates independent agent sessions on one checkout and machine. It does
+not replace `AGENTS.md`, `TRACKS.md`, committed contracts, Git, PR review, or
+the user's merge decision.
+
+## Discovery and startup
+
+`comms.mjs` uses the absolute `PW2_AGENT_BUS_DIR` when supplied. Otherwise it
+asks Git for the absolute common `.git` directory and uses its checkout parent
+as the bus root: `<checkout-root>/.agents/`. Main and linked worktrees therefore
+share one bus. If that root cannot be determined unambiguously, set the explicit
+absolute override. The runtime directory is intentionally ignored and must
+never be committed.
+
+Read [the canonical bootstrap prompt](AGENT_COMMS_PROMPT.md), or print a
+substituted copy with:
+
+```bash
+node tools/agents/comms.mjs prompt --id visual --role visual --task M2.7 --ownership game/presentation
+```
+
+Start each working agent with `init`, `register`, an initial `inbox` poll, and a
+dedicated long-lived `watch` process. Keep its output visible. `watch` emits
+JSONL and a terminal signal, maintains heartbeat, and must be stopped before
+`close`. It cannot force host software to inject output into an active reasoning
+turn, so every agent must poll at the eight checkpoints in the canonical prompt.
+Failure to register or run the watcher blocks local parallel work; it does not
+apply to a solitary read-only session.
+
+## Lifecycle and commands
+
+All normal commands are `node tools/agents/comms.mjs <command>`. Add `--json`
+where supported for one machine-readable JSON value; watcher output is JSONL.
+
+| Command | Operation |
+| --- | --- |
+| `init` | Create or validate the shared protocol layout. |
+| `register --id --role --task [--ownership ...] [--client ...] [--resume]` | Open a unique agent identity for its worktree/task. |
+| `prompt --id --role --task --ownership scope [--ownership scope ...]` | Print the canonical prompt with literal values substituted; every ownership scope must contain non-whitespace content. |
+| `inbox --id [--type ...] [--severity ...]` | List unacknowledged mail and mark successfully presented entries seen. |
+| `watch --id [--heartbeat seconds] [--scan-interval seconds]` | Block, maintain presence, and print unseen events. |
+| `wait --id [--timeout seconds] [--scan-interval seconds]` | One-shot wait for an unseen event; use only when no other work is available. |
+| `send --from --to --type --severity --subject (--body \| --body-file \| stdin)` | Send one addressed immutable message. Attachments may repeat. |
+| `broadcast --from --severity --subject ...` | Send an individually addressable copy to every active peer. |
+| `reply --from --message --type --severity --subject ...` | Send a linked response; use it for answers, progress, or pending explanations. |
+| `ack --id --message` | Persist receipt/handling acknowledgement and archive the message. |
+| `claim --id --scope --reason [--lease seconds]` | Claim a path or named contract before editing it. |
+| `release --id --scope` | Release your own claim. |
+| `release --id --scope --force-stale --owner agent` | Orchestrator-only audited release of a stale foreign claim. |
+| `handoff --id --to --task --result --branch --base ...` | Create typed handoff mail plus immutable evidence record. |
+| `status [--fail-on-stale] [--fail-on-pending]` | Report protocol, agents, mail, claims, and handoffs; optionally enforce checks. |
+| `doctor [--require-live id,...] [--repair]` | Diagnose corruption/state; repair only safe stale or corrupt transport records. |
+| `close --id` | Stop an identity after its watcher is stopped; releases owned claims but retains history. |
+
+Use `--body-file` or stdin for multi-line text to avoid shell quoting. Message
+types are `status`, `question`, `contract_request`, `contract_response`,
+`blocker`, `handoff`, and `broadcast`; severities are `info`, `action`, and
+`blocker`.
+
+### Mandatory message and handoff forms
+
+Use `--requires-ack` whenever the recipient must explicitly complete or record
+the work; it is accepted by `send`, `broadcast`, and `reply`:
+
+```bash
+node tools/agents/comms.mjs send --from visual --to models --type contract_request --severity action --subject "slots" --body "Need stable names" --requires-ack
+node tools/agents/comms.mjs broadcast --from orchestrator --severity action --subject "checkpoint" --body "Poll inbox" --requires-ack
+node tools/agents/comms.mjs reply --from models --message MESSAGE_ID --type contract_response --severity info --subject "slots" --body "hull_paper" --requires-ack
+```
+
+`handoff` requires all of `--id`, `--to`, `--task`, `--result`, `--branch`,
+`--base`, `--verification-file`, `--contracts-file`, and `--limitations-file`,
+plus either `--commit SHA` or `--uncommitted` (never both). `--changed`,
+`--follow-up`, and `--artifact` may repeat. A committed handoff is:
+
+```bash
+node tools/agents/comms.mjs handoff --id visual --to orchestrator --task M2.7 --result ready --branch m2/visual --commit COMMIT_SHA --base BASE_SHA --changed game/presentation/view.gd --verification-file verification.json --contracts-file contracts.json --limitations-file limitations.json
+```
+
+An uncommitted diagnostic handoff replaces `--commit COMMIT_SHA` with
+`--uncommitted`; it cannot be ready-to-merge. `verification.json` is a nonempty
+array of `{ "command", "exitCode", "summary" }` objects. `contracts.json` is
+an object with `added`, `changed`, and `consumed` string arrays.
+`limitations.json` is a string array. The files are validated before handoff
+publication, so include failed verification evidence rather than omitting it.
+
+## States, delivery, and coordination
+
+An open registry record plus fresh online presence is live. Presence becomes
+stale after 45 seconds without heartbeat; the watcher heartbeats every 15
+seconds and polls the filesystem every two seconds as a fallback. A watcher may
+be offline, stale, or live. A message is unseen until delivered to terminal
+output, seen-but-unacked after presentation, and archived only after `ack`.
+`requires_ack` action/blocker mail is required-unacked and makes pending checks
+red; a seen receipt never substitutes for acknowledgement.
+
+Before the first edit and at each documented checkpoint, inspect `inbox`. Claim
+the exact file scope or `contract:name-vN` before editing. Claims overlap on
+path segments; `game/presentation` conflicts with its child but not
+`game/presentations`. A claim is an explicit warning, not permission to violate
+track ownership. Request and receive a peer acknowledgement before a shared
+contract edit. `reply` communicates the answer or blocked progress; `ack`
+closes its delivery/action state. Required action and blocker messages need both
+when a substantive response is necessary.
+
+## Handoffs and closure
+
+Every task, including a blocked one, ends with a handoff and closure. The
+handoff must name the result, task, branch, commit/base (or explicit
+uncommitted state), changed paths, verification commands with exit summaries,
+contracts added/changed/consumed, follow-up agent ids, artifact paths/checksums,
+and known limitations. A failed verification cannot be ready-to-merge. After
+handoff, release claims, stop `watch` orderly with SIGINT/SIGTERM, and `close`.
+
+## Exit codes and recovery
+
+| Exit | Meaning |
+| --- | --- |
+| `0` | Command succeeded. |
+| `2` | CLI usage error. |
+| `3` | `wait` timed out with no event. |
+| `4` | Invalid, missing, or corrupt protocol data. |
+| `5` | Identity, claim, or lock conflict. |
+| `6` | Required agent is stale/offline or a required acknowledgement is pending. |
+
+Records are plaintext local files: never send secrets, tokens, credentials, or
+personal data that does not belong in the repository. JSON schema/version
+errors fail closed with exit 4. `doctor --repair` quarantines corrupt immutable
+records and may repair proven stale locks or complete safe archive transitions;
+it never silently resets a bus, steals a live claim, or migrates an unknown
+schema. Investigate the reported path, use `status`/`doctor`, and coordinate
+with the orchestrator before any repair affecting shared work.
+
+## Rollout boundary
+
+This v1 transport is local and has no network, daemon, or external dependency.
+It is deliberately not CI infrastructure: runtime `.agents/` state is ignored,
+and CI rollout is a separate follow-up after local acceptance proves the
+operator flow. Host-specific push adapters remain out of scope; polling is the
+portable delivery guarantee.
+
+The feature-worktree proof is `git check-ignore -v .agents/protocol.json`; it
+must name the `.agents/` entry in `.gitignore`. The shared bus itself lives
+outside a linked worktree, so do not use an outside-worktree `../../.agents`
+path with Git. After this change is merged, run the same feature-local command
+from the main checkout to prove the tracked ignore rule there as well.

--- a/prototype/integrated/docs/AGENT_COMMS_PROMPT.md
+++ b/prototype/integrated/docs/AGENT_COMMS_PROMPT.md
@@ -5,13 +5,17 @@ ownership is `<OWNERSHIP>`. This local transport coordinates parallel work; it
 does not replace `AGENTS.md`, `TRACKS.md`, Git, committed contracts, or the
 human merge decision.
 
+First, read `AGENTS.md` and `docs/AGENT_COMMS.md` completely before running
+commands or editing files. After registration, report your id, task, and
+ownership scopes to the orchestrator so the active coordination map is explicit.
+
 Before editing files, start the bus and register this exact identity:
 
 ```bash
 node tools/agents/comms.mjs init
-node tools/agents/comms.mjs register --id <AGENT_ID> --role <ROLE> --task <TASK> --ownership <OWNERSHIP>
-node tools/agents/comms.mjs inbox --id <AGENT_ID>
-node tools/agents/comms.mjs watch --id <AGENT_ID>
+node tools/agents/comms.mjs register --id <AGENT_ID_SHELL> --role <ROLE_SHELL> --task <TASK_SHELL> --ownership <OWNERSHIP_SHELL>
+node tools/agents/comms.mjs inbox --id <AGENT_ID_SHELL>
+node tools/agents/comms.mjs watch --id <AGENT_ID_SHELL>
 ```
 
 Run the blocking watcher in a dedicated, long-lived terminal or process and
@@ -53,5 +57,5 @@ changed paths, verification command exit/result evidence, contracts
 added/changed/consumed, artifacts with checksums, follow-up owners, and known
 limitations. Create that evidence-bearing handoff even when blocked; say what
 is blocked and what evidence was obtained. Release claims, stop the watcher
-orderly with SIGINT/SIGTERM, then run `close --id <AGENT_ID>`. Never put
+orderly with SIGINT/SIGTERM, then run `close --id <AGENT_ID_SHELL>`. Never put
 secrets, tokens, or credentials in this plaintext local mailbox.

--- a/prototype/integrated/docs/AGENT_COMMS_PROMPT.md
+++ b/prototype/integrated/docs/AGENT_COMMS_PROMPT.md
@@ -1,0 +1,57 @@
+# Local agent-communication bootstrap
+
+You are `<AGENT_ID>` in role `<ROLE>` for task `<TASK>`. Your declared
+ownership is `<OWNERSHIP>`. This local transport coordinates parallel work; it
+does not replace `AGENTS.md`, `TRACKS.md`, Git, committed contracts, or the
+human merge decision.
+
+Before editing files, start the bus and register this exact identity:
+
+```bash
+node tools/agents/comms.mjs init
+node tools/agents/comms.mjs register --id <AGENT_ID> --role <ROLE> --task <TASK> --ownership <OWNERSHIP>
+node tools/agents/comms.mjs inbox --id <AGENT_ID>
+node tools/agents/comms.mjs watch --id <AGENT_ID>
+```
+
+Run the blocking watcher in a dedicated, long-lived terminal or process and
+keep its output visible to you. It maintains presence and prints incoming
+events, but its output may not interrupt an active reasoning-turn on this host.
+Polling remains mandatory. If `register` fails, or the watcher cannot start and
+stay running, stop: **Відмова `register` або неможливість запустити watcher —
+блокер** for local parallel work. A solitary read-only session is the only
+exception.
+
+Run `node tools/agents/comms.mjs inbox --id <AGENT_ID>` at all of these eight
+checkpoints:
+
+1. одразу після `register`;
+2. перед першою зміною файлів;
+3. після кожної довгої команди або повернення до задачі;
+4. перед зміною shared contract;
+5. перед commit;
+6. перед push/PR;
+7. перед переходом до нового етапу;
+8. через `wait`, коли агент не має іншої роботи.
+
+Before **any** edit, inspect the inbox and claim the exact scope with `claim`.
+Do not edit first and claim later. Respect another agent's live claim and
+resolve overlaps before editing. Before a shared-contract edit, request the contract and obtain explicit peer
+підтвердження from the relevant peer before changing the shared contract. A
+claim is coordination only; it never authorizes work outside `TRACKS.md`.
+
+`reply` sends the substantive response to a message and retains its
+`reply_to` link. `ack` records that the recipient has received and handled the
+message and archives it; seeing watcher output is not an ack. For every
+`action` or `blocker` message, send a `reply` when an answer, progress, or a
+reason it remains pending is needed, then `ack` after the required action is
+understood or complete. Do not leave required action/blocker messages
+unacknowledged.
+
+At the end, create a `handoff` with task/result, branch and base/commit,
+changed paths, verification command exit/result evidence, contracts
+added/changed/consumed, artifacts with checksums, follow-up owners, and known
+limitations. Create that evidence-bearing handoff even when blocked; say what
+is blocked and what evidence was obtained. Release claims, stop the watcher
+orderly with SIGINT/SIGTERM, then run `close --id <AGENT_ID>`. Never put
+secrets, tokens, or credentials in this plaintext local mailbox.

--- a/prototype/integrated/docs/superpowers/plans/2026-08-14-agent-communication-protocol.md
+++ b/prototype/integrated/docs/superpowers/plans/2026-08-14-agent-communication-protocol.md
@@ -1,0 +1,998 @@
+# Agent Communication Protocol Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a dependency-free local mailbox CLI that lets independent agents in every worktree register, exchange acknowledged messages, claim scopes, publish handoffs, and monitor one shared ignored bus.
+
+**Architecture:** A thin Node CLI delegates to focused ES modules. Runtime state lives as atomic JSON records under the common checkout's ignored `.agents/` directory; immutable messages, receipts, acknowledgements, handoffs, and audit records are never edited in place, while each agent is the sole writer of its own registry and presence records. The primary PR deliberately excludes CI workflow changes; after the user merges it, a separate shared-file micro-PR will add the canonical Node test command.
+
+**Tech Stack:** Node.js 22+ standard library only, ECMAScript modules, `node:test`, Git worktrees, JSON schema validation implemented locally.
+
+## Global Constraints
+
+- Work only in `.gitworktrees/ops-agent-comms-protocol` on branch `ops/agent-comms-protocol`; the main checkout remains read-only.
+- Runtime has no npm dependencies and does not introduce `package.json` or `node_modules` requirements.
+- The protocol version and every persisted record schema version are exactly `1`.
+- Default heartbeat is 15 seconds, stale threshold is 45 seconds, fallback inbox scan is 2 seconds, claim lease is 1,800 seconds, and stale claim-lock threshold is 60 seconds.
+- Runtime state is plaintext and must never contain secrets, tokens, or credentials.
+- `.agents/` is local transport only; accepted contracts and decisions still go through Git and the existing plan documents.
+- Every new executable gate must be demonstrated against a real bad input before its final GREEN run.
+- `git add`, `git commit`, and `git push` are separate commands; never use `--no-verify`.
+- No `.github/workflows/` change belongs in this primary branch.
+- Keep every implementation module below 300 lines; if one crosses the limit, split by responsibility rather than adding a size exception.
+
+---
+
+## File Map
+
+### Runtime
+
+- `tools/agents/comms.mjs` — executable entry point, global option handling, command dispatch, and exit-code mapping only.
+- `tools/agents/lib/errors.mjs` — `CommsError` plus the stable exit-code constants.
+- `tools/agents/lib/args.mjs` — strict command-line parsing, repeated options, stdin/body selection, and human-versus-JSON output selection.
+- `tools/agents/lib/paths.mjs` — shared-root discovery and complete bus directory layout.
+- `tools/agents/lib/atomic-json.mjs` — strict JSON reads, exclusive atomic publication, fsync, same-filesystem replacement, listing, and immutable receipt helpers.
+- `tools/agents/lib/schema.mjs` — protocol, registry, presence, message, acknowledgement, claim, handoff, and lock validation.
+- `tools/agents/lib/attachments.mjs` — allowed-root resolution plus SHA-256 and byte-size evidence for message and handoff attachments.
+- `tools/agents/lib/identity.mjs` — `init`, `register`, `resume`, and `close` lifecycle.
+- `tools/agents/lib/messages.mjs` — `send`, `broadcast`, `inbox`, `ack`, and `reply`.
+- `tools/agents/lib/presence.mjs` — heartbeat lifecycle, `watch`, and one-shot `wait`.
+- `tools/agents/lib/claims.mjs` — scope normalization, overlap detection, leases, claim lock, claim, and release.
+- `tools/agents/lib/handoff.mjs` — committed and explicitly uncommitted handoff creation and validation.
+- `tools/agents/lib/status.mjs` — aggregate status, doctor diagnostics, and narrowly scoped repair operations.
+- `tools/agents/lib/prompt.mjs` — committed-template loading and literal placeholder substitution.
+
+### Tests
+
+- `tests/tools/agent_comms/helpers.mjs` — isolated bus fixture, fake clock, CLI subprocess helper, and JSON readers used by all protocol tests.
+- `tests/tools/agent_comms/errors.test.mjs` — stable exit codes and structured protocol errors.
+- `tests/tools/agent_comms/paths.test.mjs` — environment override and common-dir discovery.
+- `tests/tools/agent_comms/atomic-json.test.mjs` — atomicity, exclusivity, and corrupt JSON behavior.
+- `tests/tools/agent_comms/schema.test.mjs` — strict versions, types, enums, ids, and attachment paths.
+- `tests/tools/agent_comms/attachments.test.mjs` — allowed roots, existence, checksum, size, and committed-artifact metadata.
+- `tests/tools/agent_comms/identity.test.mjs` — init/register/resume/close and duplicate identity.
+- `tests/tools/agent_comms/messages.test.mjs` — concurrent delivery, seen/ack/archive/reply/broadcast, and crash recovery.
+- `tests/tools/agent_comms/presence.test.mjs` — heartbeat, watcher uniqueness, stale/offline transitions, delivery, and timeout.
+- `tests/tools/agent_comms/claims.test.mjs` — path and named-contract overlap, lease extension, stale claims, and lock recovery.
+- `tests/tools/agent_comms/handoff.test.mjs` — evidence completeness and ready-to-merge semantics.
+- `tests/tools/agent_comms/status.test.mjs` — counts, fail flags, corruption, stale locks, repair, and required agents.
+- `tests/tools/agent_comms/args.test.mjs` — strict options, repeated values, body sources, and usage errors.
+- `tests/tools/agent_comms/prompt.test.mjs` — byte-for-byte template rendering and checkpoint coverage.
+- `tests/tools/agent_comms/integration.test.mjs` — black-box multi-process and linked-worktree acceptance.
+
+### Documentation and bootstrap
+
+- `docs/AGENT_COMMS.md` — lifecycle, command reference, semantics, recovery, and troubleshooting.
+- `docs/AGENT_COMMS_PROMPT.md` — canonical copy-paste prompt with four literal placeholders.
+- `AGENTS.md` — mandatory local-agent bootstrap and checkpoint polling rule.
+- `.gitignore` — ignore the checkout-shared `.agents/` directory.
+
+---
+
+### Task 1: Durable bus foundation and strict schemas
+
+**Files:**
+
+- Create: `tools/agents/lib/errors.mjs`
+- Create: `tools/agents/lib/paths.mjs`
+- Create: `tools/agents/lib/atomic-json.mjs`
+- Create: `tools/agents/lib/schema.mjs`
+- Create: `tests/tools/agent_comms/helpers.mjs`
+- Create: `tests/tools/agent_comms/errors.test.mjs`
+- Create: `tests/tools/agent_comms/paths.test.mjs`
+- Create: `tests/tools/agent_comms/atomic-json.test.mjs`
+- Create: `tests/tools/agent_comms/schema.test.mjs`
+
+**Interfaces:**
+
+- Produces `EXIT = Object.freeze({ OK: 0, USAGE: 2, TIMEOUT: 3, DATA: 4, CONFLICT: 5, REQUIRED: 6 })`.
+- Produces `class CommsError extends Error { constructor(message, exitCode, details = null) }`.
+- Produces `resolveBusDir({ cwd, env, runGit }) -> Promise<string>` and `createBusPaths(busDir) -> Readonly<object>`.
+- Produces `ensureBusLayout(paths) -> Promise<void>`.
+- Produces `readJsonStrict(filePath, validate)`, `writeJsonAtomic(filePath, value, { tmpDir, exclusive })`, `listJsonFiles(dirPath)`, and `moveFileAtomic(source, destination)`.
+- Produces all `validate*` functions consumed by later modules; every validator returns the original value or throws `CommsError` with exit code `4`.
+- Test helper exports are `createBusFixture()`, `createGitWorktreeFixture()`, `createFakeClock(startIso)`, `runCli(fixture, argv, options)`, `pathExists(path)`, `seedOpenAgent(context, input)`, `seedPresence(context, input)`, and `seedMessage(context, input)`. Small semantic builders such as `validMessage()` or `registration()` are declared locally in the test that uses them.
+
+- [ ] **Step 1: Write discovery tests that prove main and linked worktrees converge**
+
+```js
+test("environment override wins", async () => {
+  const bus = await resolveBusDir({
+    cwd: fixture.root,
+    env: { PW2_AGENT_BUS_DIR: fixture.bus },
+    runGit: failIfCalled,
+  });
+  assert.equal(bus, fixture.bus);
+});
+
+test("main and linked worktree resolve one shared bus", async () => {
+  assert.equal(await fixture.resolveFrom(fixture.main), fixture.bus);
+  assert.equal(await fixture.resolveFrom(fixture.worktree), fixture.bus);
+});
+
+test("exit codes are stable", () => {
+  assert.deepEqual(EXIT, { OK: 0, USAGE: 2, TIMEOUT: 3, DATA: 4, CONFLICT: 5, REQUIRED: 6 });
+  assert.equal(new CommsError("bad data", EXIT.DATA).exitCode, 4);
+});
+```
+
+- [ ] **Step 2: Run the discovery tests and capture the RED**
+
+Run: `node --test tests/tools/agent_comms/errors.test.mjs tests/tools/agent_comms/paths.test.mjs`
+
+Expected: exit `1`, with `ERR_MODULE_NOT_FOUND` for `tools/agents/lib/paths.mjs`.
+
+- [ ] **Step 3: Implement explicit override and conservative Git common-dir discovery**
+
+```js
+export async function resolveBusDir({ cwd, env = process.env, runGit }) {
+  if (env.PW2_AGENT_BUS_DIR) return path.resolve(env.PW2_AGENT_BUS_DIR);
+  const commonDir = path.resolve(cwd, (await runGit(cwd)).trim());
+  if (path.basename(commonDir) !== ".git") {
+    throw new CommsError("cannot infer checkout root; set PW2_AGENT_BUS_DIR", EXIT.DATA);
+  }
+  return path.join(path.dirname(commonDir), ".agents");
+}
+```
+
+`createBusPaths()` must expose `protocol`, `registry`, `presence`, `inbox`, `seen`, `acknowledgements`, `claims`, `handoffs`, `archive`, `artifacts`, `locks`, `quarantine`, and `tmp`. `ensureBusLayout()` creates all directories and never deletes an existing record.
+
+- [ ] **Step 4: Run discovery tests GREEN**
+
+Run: `node --test tests/tools/agent_comms/errors.test.mjs tests/tools/agent_comms/paths.test.mjs`
+
+Expected: all path tests pass and exit `0`.
+
+- [ ] **Step 5: Write atomic storage and schema tests**
+
+```js
+test("exclusive writes never replace an immutable record", async () => {
+  await writeJsonAtomic(target, { value: 1 }, { tmpDir, exclusive: true });
+  await assert.rejects(
+    writeJsonAtomic(target, { value: 2 }, { tmpDir, exclusive: true }),
+    error => error.exitCode === EXIT.CONFLICT,
+  );
+  assert.deepEqual(JSON.parse(await readFile(target, "utf8")), { value: 1 });
+});
+
+test("unknown message versions fail loudly", () => {
+  assert.throws(
+    () => validateMessage({ ...validMessage, schema_version: 2 }),
+    error => error.exitCode === EXIT.DATA,
+  );
+});
+```
+
+Add cases for malformed JSON, invalid agent ids, every message/severity enum, absolute attachment paths, paths escaping the repository, invalid SHA-256, absent required fields, and wrong scalar/array types.
+
+- [ ] **Step 6: Run storage/schema tests and capture the RED**
+
+Run: `node --test tests/tools/agent_comms/atomic-json.test.mjs tests/tools/agent_comms/schema.test.mjs`
+
+Expected: exit `1` because the storage and validation exports do not exist.
+
+- [ ] **Step 7: Implement durable writes and strict validators**
+
+`writeJsonAtomic()` must serialize once, open a unique file under `tmpDir` with flag `wx`, write the complete buffer, call `FileHandle.sync()`, and close it. Mutable records publish with same-filesystem rename. Immutable `exclusive` records publish with `fs.link(temp, destination)`, Node's atomic no-replace operation on the same filesystem, then unlink the temp name. This avoids both overwrite races and a visible empty/partial destination; a reader only opens the final `.json` path. Sync the destination directory after publication.
+
+```js
+export function validateAgentId(value) {
+  if (typeof value !== "string" || !/^[a-z0-9][a-z0-9_-]{1,31}$/.test(value)) {
+    throw new CommsError("invalid agent id", EXIT.DATA, { value });
+  }
+  return value;
+}
+```
+
+Validators must reject unknown keys for protocol-owned records so misspelled fields cannot silently bypass a gate. Attachment validation accepts normalized repo-relative paths and normalized `.agents/artifacts` paths only.
+
+- [ ] **Step 8: Demonstrate the corrupt-data gate and restore GREEN**
+
+Create malformed JSON only inside the test fixture, run the atomic test, and retain the assertion that `readJsonStrict()` returns exit code `4`. Then run:
+
+`node --test tests/tools/agent_comms/paths.test.mjs tests/tools/agent_comms/atomic-json.test.mjs tests/tools/agent_comms/schema.test.mjs`
+
+Expected: all foundation tests pass and exit `0`.
+
+- [ ] **Step 9: Commit the foundation**
+
+```bash
+git add tools/agents/lib/errors.mjs tools/agents/lib/paths.mjs tools/agents/lib/atomic-json.mjs tools/agents/lib/schema.mjs tests/tools/agent_comms/helpers.mjs tests/tools/agent_comms/errors.test.mjs tests/tools/agent_comms/paths.test.mjs tests/tools/agent_comms/atomic-json.test.mjs tests/tools/agent_comms/schema.test.mjs
+git commit -m "feat: add durable agent bus foundation"
+```
+
+---
+
+### Task 2: Bus initialization and agent identity lifecycle
+
+**Files:**
+
+- Create: `tools/agents/lib/identity.mjs`
+- Create: `tests/tools/agent_comms/identity.test.mjs`
+
+**Interfaces:**
+
+- Consumes `createBusPaths`, `ensureBusLayout`, `readJsonStrict`, `writeJsonAtomic`, identity schemas, `CommsError`, and `EXIT` from Task 1.
+- Produces `initBus(context) -> Promise<ProtocolRecord>`.
+- Produces `registerAgent(context, input) -> Promise<RegistryRecord>`.
+- Produces `closeAgent(context, agentId) -> Promise<RegistryRecord>`.
+- `context` is `{ paths, now: () => Date, pidIsAlive: (pid) => boolean, gitState: (cwd) => Promise<{ branch, head }>, releaseOwnedClaims: (agentId) => Promise<void> }`; tests inject a no-op claim releaser until Task 5 provides the real implementation.
+
+- [ ] **Step 1: Write lifecycle tests**
+
+```js
+test("a live duplicate id is rejected", async () => {
+  await registerAgent(context, registration("visual", worktreeA));
+  await writeLivePresence(context, "visual", 1234);
+  await assert.rejects(
+    registerAgent(context, registration("visual", worktreeB)),
+    error => error.exitCode === EXIT.CONFLICT,
+  );
+});
+
+test("resume requires the same worktree and task", async () => {
+  const first = await registerAgent(context, registration("models", worktreeA));
+  const resumed = await registerAgent(context, { ...first, resume: true });
+  assert.equal(resumed.agent_id, "models");
+  await assert.rejects(
+    registerAgent(context, { ...first, task: "M2.8", resume: true }),
+    error => error.exitCode === EXIT.CONFLICT,
+  );
+});
+```
+
+Also cover an initialized record exactly shaped as `{ schema_version: 1, protocol_version: 1, checkout_id, checkout_root, initialized_at }`, idempotent compatible `init`, refusal to replace protocol version `2`, captured branch/HEAD, registration becoming stale without heartbeat, `close` refusal while a live watcher exists, and close releasing only that agent's claims. `checkout_id` is the SHA-256 of the canonical realpath of the Git common directory, so copied display names cannot alias one bus.
+
+- [ ] **Step 2: Run lifecycle tests and capture the RED**
+
+Run: `node --test tests/tools/agent_comms/identity.test.mjs`
+
+Expected: exit `1` with missing `identity.mjs`.
+
+- [ ] **Step 3: Implement lifecycle state transitions**
+
+```js
+export async function registerAgent(context, input) {
+  const agentId = validateAgentId(input.agentId);
+  const existing = await readRegistryIfPresent(context.paths, agentId);
+  assertRegistrationAllowed(existing, input, await readPresenceIfPresent(context.paths, agentId), context);
+  const git = await context.gitState(input.worktree);
+  const record = makeRegistryRecord(input, git, context.now().toISOString());
+  await writeJsonAtomic(context.paths.registryFile(agentId), record, {
+    tmpDir: context.paths.tmp,
+    exclusive: existing === null,
+  });
+  return record;
+}
+```
+
+`closeAgent()` first proves the watcher PID is not live, marks the registry record `closed`, writes presence `offline`, and calls the injected `releaseOwnedClaims(agentId)` without deleting registry history. Task 8 wires this callback to Task 5's implementation.
+
+- [ ] **Step 4: Demonstrate duplicate-live-identity refusal**
+
+Temporarily point the duplicate test at two different worktrees with the same live id. Run the focused test and record exit `1` with an asserted conflict. Keep that test permanently, then run the complete identity file.
+
+Run: `node --test tests/tools/agent_comms/identity.test.mjs`
+
+Expected: all identity tests pass and exit `0`.
+
+- [ ] **Step 5: Commit identity lifecycle**
+
+```bash
+git add tools/agents/lib/identity.mjs tests/tools/agent_comms/identity.test.mjs
+git commit -m "feat: add agent identity lifecycle"
+```
+
+---
+
+### Task 3: Immutable messaging, receipts, acknowledgements, and broadcast
+
+**Files:**
+
+- Create: `tools/agents/lib/messages.mjs`
+- Create: `tools/agents/lib/attachments.mjs`
+- Create: `tests/tools/agent_comms/messages.test.mjs`
+- Create: `tests/tools/agent_comms/attachments.test.mjs`
+
+**Interfaces:**
+
+- Consumes Task 1 storage/schema APIs and Task 2 open-registry checks.
+- Produces `describeAttachment(context, input) -> Promise<AttachmentRecord>` and `verifyAttachment(context, record) -> Promise<void>`.
+- Produces `sendMessage(context, input) -> Promise<MessageRecord>`.
+- Produces `listInbox(context, input) -> Promise<Array<InboxItem>>` where each item is `{ message, state: "unseen" | "seen" }`.
+- Produces `markSeen(context, message, recipient)`, `ackMessage(context, input)`, `replyToMessage(context, input)`, and `broadcastMessage(context, input)`.
+- `context.randomUUID()` is injected for deterministic unit tests and uses `crypto.randomUUID` in production.
+
+- [ ] **Step 1: Write message state-machine and concurrency tests**
+
+```js
+test("seen is delivery, ack is completion", async () => {
+  const message = await sendMessage(context, requestFromVisualToModels);
+  await markSeen(context, message, "models");
+  assert.equal((await listInbox(context, { agentId: "models" }))[0].state, "seen");
+  await ackMessage(context, { agentId: "models", messageId: message.id });
+  assert.equal((await listInbox(context, { agentId: "models" })).length, 0);
+  assert.equal(await exists(context.paths.ackFile(message.id, "models")), true);
+  assert.equal(await exists(context.paths.archiveFile("models", message.id)), true);
+});
+
+test("one hundred parallel senders lose no messages", async () => {
+  await Promise.all(Array.from({ length: 100 }, (_, index) =>
+    sendMessage(contextFor(index), messageInput(index))));
+  const inbox = await listInbox(context, { agentId: "models" });
+  assert.equal(inbox.length, 100);
+  assert.equal(new Set(inbox.map(item => item.message.id)).size, 100);
+});
+```
+
+Also cover unregistered sender, unknown recipient, filters, stdin/body-file equivalence at the API boundary, reply linkage, sender-visible ack, separate broadcast copies, inactive recipients excluded from broadcast, per-recipient broadcast acknowledgement, and an ack record left in inbox after a simulated crash.
+
+Write attachment tests proving that a repo-relative committed file and a file inside `.agents/artifacts` receive the actual SHA-256 and byte size, while an absolute external path, `../` escape, missing file, mismatched checksum, and ephemeral attachment with a commit SHA are rejected.
+
+- [ ] **Step 2: Run message tests and capture the RED**
+
+Run: `node --test tests/tools/agent_comms/attachments.test.mjs tests/tools/agent_comms/messages.test.mjs`
+
+Expected: exit `1` with missing message exports.
+
+- [ ] **Step 3: Implement immutable message delivery**
+
+```js
+export async function sendMessage(context, input) {
+  await requireOpenAgent(context, input.from);
+  await requireOpenAgent(context, input.to);
+  const message = validateMessage(buildMessage(context, input));
+  await writeJsonAtomic(context.paths.inboxFile(input.to, message.id), message, {
+    tmpDir: context.paths.tmp,
+    exclusive: true,
+  });
+  return message;
+}
+```
+
+Message ids use the compact UTC timestamp, sender id, and full UUID. `markSeen` and acknowledgement records are immutable exclusive writes. `ackMessage` writes the ack first and then moves the message; if the ack already exists it still completes the move. `listInbox` excludes acked messages even if a crash left their source files in inbox. Broadcast snapshots active recipients and calls the same delivery primitive once per recipient.
+
+`describeAttachment()` resolves symlinks before applying allowed-root checks, streams the file through `createHash("sha256")`, reads byte size from `stat`, and returns normalized paths only. `verifyAttachment()` recomputes both values rather than trusting caller input.
+
+- [ ] **Step 4: Run concurrency and lifecycle GREEN**
+
+Run: `node --test tests/tools/agent_comms/attachments.test.mjs tests/tools/agent_comms/messages.test.mjs`
+
+Expected: 100 unique messages, all state-machine cases pass, exit `0`.
+
+- [ ] **Step 5: Commit messaging**
+
+```bash
+git add tools/agents/lib/attachments.mjs tools/agents/lib/messages.mjs tests/tools/agent_comms/attachments.test.mjs tests/tools/agent_comms/messages.test.mjs
+git commit -m "feat: add acknowledged agent messaging"
+```
+
+---
+
+### Task 4: Presence heartbeat, watcher, and dormant wait
+
+**Files:**
+
+- Create: `tools/agents/lib/presence.mjs`
+- Create: `tests/tools/agent_comms/presence.test.mjs`
+
+**Interfaces:**
+
+- Consumes registry checks, message listing/seen receipts, schemas, and atomic storage.
+- Produces `presenceState(record, now, pidIsAlive) -> "online" | "stale" | "offline"`.
+- Produces `startWatcher(context, input) -> Promise<{ stop: () => Promise<void>, done: Promise<void> }>`; `context.extendOwnedClaims` is an injected no-op until Task 5 is wired by Task 8.
+- Produces `waitForMessage(context, input) -> Promise<MessageRecord | null>`; `null` maps to exit code `3` in the CLI.
+- Watcher output callback receives one validated object `{ event: "message", message, state: "unseen" }` per message id.
+
+- [ ] **Step 1: Write deterministic presence and watcher tests**
+
+```js
+test("heartbeat transitions online to stale to offline", () => {
+  const record = presenceAt("2026-08-14T18:00:00.000Z", 42, "online");
+  assert.equal(presenceState(record, instant(44), () => true), "online");
+  assert.equal(presenceState(record, instant(46), () => true), "stale");
+  assert.equal(presenceState(record, instant(46), () => false), "offline");
+});
+
+test("wait distinguishes delivery from timeout", async () => {
+  assert.equal(await waitForMessage(fastContext, { agentId: "visual", timeoutMs: 5 }), null);
+  const pending = waitForMessage(fastContext, { agentId: "visual", timeoutMs: 100 });
+  await sendMessage(fastContext, messageToVisual);
+  assert.equal((await pending).subject, messageToVisual.subject);
+});
+```
+
+Also test rejection of a second live watcher, immediate scan before filesystem events, 2-second fallback scanning through an injected scheduler, one print per process, restart behavior for unseen versus seen-but-unacked, heartbeat writes every 15 seconds, claim extension callback, and offline write on `stop()`.
+
+- [ ] **Step 2: Run presence tests and capture the RED**
+
+Run: `node --test tests/tools/agent_comms/presence.test.mjs`
+
+Expected: exit `1` with missing presence exports.
+
+- [ ] **Step 3: Implement watcher and wait without relying solely on `fs.watch`**
+
+```js
+export function presenceState(record, now, pidIsAlive) {
+  if (record.status === "offline" || !pidIsAlive(record.pid)) return "offline";
+  return now.getTime() - Date.parse(record.heartbeat_at) > 45_000 ? "stale" : "online";
+}
+```
+
+`startWatcher()` must acquire the id by writing presence with watcher PID, perform an immediate scan, use both `fs.watch` and a 2-second interval, update heartbeat every 15 seconds, extend owned claims on heartbeat, write one complete JSONL object plus `\u0007`, then create the seen receipt. It never acknowledges a message. Signal handling is installed by the executable entry point, which awaits `stop()` before exit.
+
+- [ ] **Step 4: Demonstrate stale required presence in the focused tests**
+
+Advance the fake clock beyond 45 seconds while the recorded PID remains live and assert the state is `stale`. Restore the clock fixture and run:
+
+`node --test tests/tools/agent_comms/presence.test.mjs`
+
+Expected: all presence tests pass and exit `0`.
+
+- [ ] **Step 5: Commit presence**
+
+```bash
+git add tools/agents/lib/presence.mjs tests/tools/agent_comms/presence.test.mjs
+git commit -m "feat: add agent presence watcher"
+```
+
+---
+
+### Task 5: Ownership claims and recoverable claim locking
+
+**Files:**
+
+- Create: `tools/agents/lib/claims.mjs`
+- Create: `tests/tools/agent_comms/claims.test.mjs`
+
+**Interfaces:**
+
+- Produces `normalizeScope(scope) -> { kind: "path" | "contract", value: string }`.
+- Produces `scopesOverlap(left, right) -> boolean`.
+- Produces `claimScope(context, input)`, `releaseScope(context, input)`, `forceReleaseStaleScope(context, input)`, `extendClaims(context, agentId)`, and `repairStaleClaimLock(context)`.
+- Claim-lock record is `{ schema_version: 1, owner_agent, pid, acquired_at }` inside `.agents/locks/claims.lock/owner.json`.
+
+- [ ] **Step 1: Write exact overlap and lock tests**
+
+```js
+test("path overlap uses segments rather than string prefixes", () => {
+  assert.equal(scopesOverlap("game/presentation", "game/presentation/camera"), true);
+  assert.equal(scopesOverlap("game/presentation", "game/presentations"), false);
+});
+
+test("named contracts overlap only on exact normalized name", () => {
+  assert.equal(scopesOverlap("contract:tank-registration-v1", "contract:tank-registration-v1"), true);
+  assert.equal(scopesOverlap("contract:tank-registration-v1", "contract:tank-registration-v2"), false);
+});
+```
+
+Add tests for same-agent idempotent renewal, different-agent conflict, stale claim remaining unavailable, watcher lease extension, owner-only release, orchestrator-only forced release of a stale foreign claim with immutable audit record, refusal to force-release an active claim, atomic `mkdir` contention, a live lock never repaired, and a dead-PID lock younger than 60 seconds never repaired.
+
+- [ ] **Step 2: Run claim tests and capture the RED**
+
+Run: `node --test tests/tools/agent_comms/claims.test.mjs`
+
+Expected: exit `1` with missing claim exports.
+
+- [ ] **Step 3: Implement normalization, conflict detection, and lock discipline**
+
+```js
+export function scopesOverlap(leftInput, rightInput) {
+  const left = normalizeScope(leftInput);
+  const right = normalizeScope(rightInput);
+  if (left.kind !== right.kind) return false;
+  if (left.kind === "contract") return left.value === right.value;
+  const a = left.value.split("/");
+  const b = right.value.split("/");
+  return a.slice(0, Math.min(a.length, b.length)).every((part, index) => part === b[index]);
+}
+```
+
+Acquire the global critical section using `mkdir(claims.lock)`. Write and fsync `owner.json` before inspecting claims. Always release the lock directory in `finally`. A stale claim is reported as conflict rather than overwritten. `forceReleaseStaleScope()` requires an open registry record whose role is exactly `orchestrator`, proves the target claim is stale, writes an immutable audit record, and only then removes it. `repairStaleClaimLock()` succeeds only when the lock is older than 60 seconds and `pidIsAlive(pid)` is false; it writes an immutable audit record before removal.
+
+- [ ] **Step 4: Demonstrate duplicate-claim refusal**
+
+Run a test where `visual` holds `game/presentation` and `models` requests `game/presentation/camera`. Record the asserted conflict with exit code `5`; retain the test and run:
+
+`node --test tests/tools/agent_comms/claims.test.mjs`
+
+Expected: all claim tests pass and exit `0`.
+
+- [ ] **Step 5: Commit claims**
+
+```bash
+git add tools/agents/lib/claims.mjs tests/tools/agent_comms/claims.test.mjs
+git commit -m "feat: add agent ownership claims"
+```
+
+---
+
+### Task 6: Evidence-bearing handoffs
+
+**Files:**
+
+- Create: `tools/agents/lib/handoff.mjs`
+- Create: `tests/tools/agent_comms/handoff.test.mjs`
+
+**Interfaces:**
+
+- Produces `createHandoff(context, input) -> Promise<{ record, message }>`.
+- Required committed input is `{ from, to, task, result, branch, commit, base, changedPaths, verification, contracts, followUp, artifacts, limitations, uncommitted: false }`.
+- Verification entries are `{ command, exitCode, summary }`; artifacts reuse the strict attachment schema.
+
+- [ ] **Step 1: Write handoff validation tests**
+
+```js
+test("committed handoff requires branch, commit, base, paths, and verification", async () => {
+  await assert.rejects(
+    createHandoff(context, { ...validHandoff, verification: [] }),
+    error => error.exitCode === EXIT.DATA && error.message.includes("verification"),
+  );
+});
+
+test("uncommitted handoff is never ready to merge", async () => {
+  const { record } = await createHandoff(context, { ...validHandoff, commit: null, uncommitted: true });
+  assert.equal(record.ready_to_merge, false);
+  assert.equal(record.state, "UNCOMMITTED");
+});
+```
+
+Cover commit/base as full 40-character hexadecimal SHA values, repo-relative changed paths, per-artifact checksum/size, follow-up agent ids, immutable handoff record, and typed `handoff` message requiring acknowledgement.
+
+- [ ] **Step 2: Run handoff tests and capture the RED**
+
+Run: `node --test tests/tools/agent_comms/handoff.test.mjs`
+
+Expected: exit `1` with missing handoff export.
+
+- [ ] **Step 3: Implement handoff record plus addressed message**
+
+```js
+export async function createHandoff(context, input) {
+  const record = validateHandoff(buildHandoff(context, input));
+  await writeJsonAtomic(context.paths.handoffFile(record.id), record, {
+    tmpDir: context.paths.tmp,
+    exclusive: true,
+  });
+  const message = await sendMessage(context, handoffMessage(record));
+  return { record, message };
+}
+```
+
+The message body summarizes result, commit state, verification, and limitations; its `attachments` match the record. A committed handoff with any failed verification may exist, but `ready_to_merge` must be false.
+
+- [ ] **Step 4: Demonstrate the evidence gate and restore GREEN**
+
+Run the missing-verification case and retain its asserted exit code `4`. Then run:
+
+`node --test tests/tools/agent_comms/handoff.test.mjs`
+
+Expected: all handoff tests pass and exit `0`.
+
+- [ ] **Step 5: Commit handoffs**
+
+```bash
+git add tools/agents/lib/handoff.mjs tests/tools/agent_comms/handoff.test.mjs
+git commit -m "feat: add evidence-bearing agent handoffs"
+```
+
+---
+
+### Task 7: Orchestrator status, diagnostics, and safe repair
+
+**Files:**
+
+- Create: `tools/agents/lib/status.mjs`
+- Create: `tests/tools/agent_comms/status.test.mjs`
+
+**Interfaces:**
+
+- Produces `collectStatus(context) -> Promise<StatusReport>`.
+- Produces `runDoctor(context, input) -> Promise<DoctorReport>`.
+- Produces `enforcementExit(report, options) -> 0 | 4 | 6`.
+- `StatusReport` begins with `protocol: { schema_version: 1, protocol_version: 1, checkout_id }` and contains exact arrays and counts for live/stale/offline agents, unseen, seen-but-unacked, required-unacked, blockers, active/stale claims, and handoffs.
+- `DoctorReport` is `{ ok, issues, repairs }`; each issue is `{ code, severity, path, message }`.
+
+- [ ] **Step 1: Write status and doctor tests**
+
+```js
+test("seen required action stays pending until ack", async () => {
+  const message = await seedRequiredAction(context);
+  await markSeen(context, message, "models");
+  const report = await collectStatus(context);
+  assert.equal(report.counts.seen_but_unacked, 1);
+  assert.equal(report.counts.required_unacked, 1);
+});
+
+test("doctor reports a corrupt message instead of skipping it", async () => {
+  await writeFile(context.paths.inboxFile("models", "broken"), "{not-json");
+  const report = await runDoctor(context, {});
+  assert.equal(report.ok, false);
+  assert.equal(report.issues[0].code, "CORRUPT_JSON");
+});
+```
+
+Also cover `--require-live`, stale registry, pending blocker, informational unacked message not failing enforcement, acked-but-not-archived recovery, compatible init state, unknown protocol version, stale lock, quarantine only under repair, and immutable repair audit records.
+
+- [ ] **Step 2: Run status tests and capture the RED**
+
+Run: `node --test tests/tools/agent_comms/status.test.mjs`
+
+Expected: exit `1` with missing status exports.
+
+- [ ] **Step 3: Implement aggregation and narrowly scoped repair**
+
+```js
+export function enforcementExit(report, options) {
+  if (options.failOnStale && report.agents.stale.length > 0) return EXIT.REQUIRED;
+  if (options.failOnPending && report.messages.required_unacked.length > 0) return EXIT.REQUIRED;
+  if (report.corrupt.length > 0) return EXIT.DATA;
+  return EXIT.OK;
+}
+```
+
+Normal doctor is read-only. Repair may only: finish archive moves already backed by acknowledgement, move corrupt JSON to quarantine with an audit record, and invoke the proven stale-lock repair. It never removes stale agents, claims, registry history, or an unknown protocol version.
+
+- [ ] **Step 4: Demonstrate stale-required and corrupt-message failures**
+
+Run the two focused fixtures through `enforcementExit`: stale required watcher must produce `6`; corrupt message must produce `4`. Retain both tests, restore valid fixture data, then run:
+
+`node --test tests/tools/agent_comms/status.test.mjs`
+
+Expected: all status tests pass and exit `0`.
+
+- [ ] **Step 5: Commit status and doctor**
+
+```bash
+git add tools/agents/lib/status.mjs tests/tools/agent_comms/status.test.mjs
+git commit -m "feat: add agent bus diagnostics"
+```
+
+---
+
+### Task 8: Strict CLI and machine-readable output
+
+**Files:**
+
+- Create: `tools/agents/lib/args.mjs`
+- Create: `tools/agents/comms.mjs`
+- Modify: `tests/tools/agent_comms/helpers.mjs`
+- Create: `tests/tools/agent_comms/args.test.mjs`
+- Create: `tests/tools/agent_comms/integration.test.mjs`
+
+**Interfaces:**
+
+- `parseArgs(argv) -> { command, options }`; unknown commands/options and missing values throw usage exit `2`.
+- `main(argv, runtime) -> Promise<number>` where runtime injects `cwd`, `env`, stdin, stdout, stderr, time, PID liveness, UUID, scheduler, and Git query.
+- Human commands write only human text; `--json` writes exactly one JSON value; `watch` writes JSONL only.
+- Repeated-value grammar is fixed: `register --ownership <scope>` may repeat; `send`/`reply` use exactly one of `--body`, `--body-file`, or stdin and may repeat `--attachment <repo-path>` or `--ephemeral-attachment <artifact-path>`; `handoff` repeats `--changed <path>`, `--follow-up <agent>`, and `--artifact <path>`, while structured verification/contracts and limitations are supplied by `--verification-file`, `--contracts-file`, and `--limitations-file`; `release --force-stale` also requires `--owner <agent>`.
+
+- [ ] **Step 1: Write parser and black-box CLI tests for every currently implemented command and exit code**
+
+```js
+test("wait timeout exits three without stderr noise", async () => {
+  const result = await runCli(fixture, ["wait", "--id", "visual", "--timeout", "0.01"]);
+  assert.equal(result.code, 3);
+  assert.equal(result.stderr, "");
+});
+
+test("json status is one parseable value", async () => {
+  const result = await runCli(fixture, ["status", "--json"]);
+  assert.equal(result.code, 0);
+  assert.deepEqual(JSON.parse(result.stdout).protocol, { schema_version: 1 });
+});
+
+test("unknown options are usage errors", () => {
+  assert.throws(
+    () => parseArgs(["status", "--mystery"]),
+    error => error.exitCode === EXIT.USAGE,
+  );
+});
+```
+
+Exercise `init`, `register`, `close`, `send` with body/body-file/stdin, `broadcast`, `inbox`, `ack`, `reply`, `watch`, `wait`, `claim`, `release`, `handoff`, `status`, and `doctor`. Assert exit codes `0`, `2`, `3`, `4`, `5`, and `6` through actual subprocesses. Verify `comms.mjs` is executable and its shebang is `#!/usr/bin/env node`. Task 9 adds and tests `prompt` after the committed template exists.
+
+`release` accepts `--force-stale --owner <agent>` only when `--id` belongs to the registered orchestrator; ordinary release remains owner-only.
+
+- [ ] **Step 2: Run black-box tests and capture the RED**
+
+Run: `node --test tests/tools/agent_comms/integration.test.mjs`
+
+Expected: exit `1` because the executable and parser do not exist.
+
+- [ ] **Step 3: Implement strict parsing and thin dispatch**
+
+```js
+const COMMANDS = Object.freeze({
+  init: runInit,
+  register: runRegister,
+  close: runClose,
+  send: runSend,
+  broadcast: runBroadcast,
+  inbox: runInbox,
+  ack: runAck,
+  reply: runReply,
+  watch: runWatch,
+  wait: runWait,
+  claim: runClaim,
+  release: runRelease,
+  handoff: runHandoff,
+  status: runStatus,
+  doctor: runDoctorCommand,
+});
+```
+
+The executable catches only `CommsError`, prints its message to stderr, and returns its stable exit code; unexpected exceptions print a stack and return `1`. It discovers bus paths once and passes a shared context to command modules. `SIGINT` and `SIGTERM` call the active watcher's async `stop()` before process exit.
+
+- [ ] **Step 4: Run complete protocol tests GREEN**
+
+Run: `node --test tests/tools/agent_comms/*.test.mjs`
+
+Expected: all protocol tests pass and exit `0`.
+
+- [ ] **Step 5: Commit executable CLI**
+
+```bash
+git add tools/agents/comms.mjs tools/agents/lib/args.mjs tests/tools/agent_comms/helpers.mjs tests/tools/agent_comms/args.test.mjs tests/tools/agent_comms/integration.test.mjs
+git commit -m "feat: expose agent communication CLI"
+```
+
+---
+
+### Task 9: Canonical bootstrap prompt and operator documentation
+
+**Files:**
+
+- Create: `tools/agents/lib/prompt.mjs`
+- Create: `tests/tools/agent_comms/prompt.test.mjs`
+- Create: `docs/AGENT_COMMS.md`
+- Create: `docs/AGENT_COMMS_PROMPT.md`
+- Modify: `AGENTS.md`
+- Modify: `.gitignore`
+- Modify: `tools/agents/comms.mjs`
+
+**Interfaces:**
+
+- Produces `renderPrompt({ templatePath, agentId, role, task, ownership }) -> Promise<string>`.
+- Template contains exactly `<AGENT_ID>`, `<ROLE>`, `<TASK>`, and `<OWNERSHIP>` as replaceable tokens.
+- CLI command is `node tools/agents/comms.mjs prompt --id visual --role visual --task M2.7 --ownership game/presentation`.
+
+- [ ] **Step 1: Write prompt contract tests**
+
+```js
+test("rendered prompt is the committed template with literal substitutions", async () => {
+  const template = await readFile(templatePath, "utf8");
+  const rendered = await renderPrompt({
+    templatePath,
+    agentId: "visual-m2-7",
+    role: "visual",
+    task: "M2.7",
+    ownership: "game/presentation",
+  });
+  const expected = template
+    .replaceAll("<AGENT_ID>", "visual-m2-7")
+    .replaceAll("<ROLE>", "visual")
+    .replaceAll("<TASK>", "M2.7")
+    .replaceAll("<OWNERSHIP>", "game/presentation");
+  assert.equal(rendered, expected);
+});
+```
+
+Assert the rendered prompt contains all eight polling checkpoints, refuses work after failed register/watcher startup, requires peer acknowledgement before shared-contract edits, requires replies and acknowledgements for action/blocker messages, and requires handoff plus close even when blocked.
+
+- [ ] **Step 2: Run prompt tests and capture the RED**
+
+Run: `node --test tests/tools/agent_comms/prompt.test.mjs`
+
+Expected: exit `1` because template and renderer do not exist.
+
+- [ ] **Step 3: Write the canonical prompt and operational guide**
+
+The prompt must tell an agent to execute this lifecycle with its substituted values:
+
+```bash
+node tools/agents/comms.mjs init
+node tools/agents/comms.mjs register --id <AGENT_ID> --role <ROLE> --task <TASK> --ownership <OWNERSHIP>
+node tools/agents/comms.mjs inbox --id <AGENT_ID>
+node tools/agents/comms.mjs watch --id <AGENT_ID>
+```
+
+It explicitly says the blocking watcher runs in a dedicated long-lived terminal/process whose output remains visible to the agent. It then states the checkpoint polls, the host limitation that watcher output may not interrupt an active reasoning turn, claim-before-edit rule, `reply`/`ack` distinction, handoff evidence requirements, and orderly watcher stop followed by `close`.
+
+`docs/AGENT_COMMS.md` must document discovery, lifecycle, every CLI command, message states, status categories, claims, handoffs, stable exit codes, plaintext/security boundary, stale thresholds, corruption/repair behavior, host push limitation, and the separate-CI rollout.
+
+- [ ] **Step 4: Implement literal template rendering and wire `prompt`**
+
+```js
+export async function renderPrompt(input) {
+  const template = await readFile(input.templatePath, "utf8");
+  return template
+    .replaceAll("<AGENT_ID>", input.agentId)
+    .replaceAll("<ROLE>", input.role)
+    .replaceAll("<TASK>", input.task)
+    .replaceAll("<OWNERSHIP>", input.ownership);
+}
+```
+
+Reject values containing a NUL byte. Validate the id with the shared schema. Keep the template as the sole source of prompt prose.
+
+Add `prompt: runPrompt` to the executable's command map and add a black-box case proving stdout equals `renderPrompt()` exactly and stderr is empty.
+
+- [ ] **Step 5: Add mandatory bootstrap to `AGENTS.md` and ignore runtime state**
+
+Add an early section named `Локальний протокол зв'язку агентів` that requires reading `docs/AGENT_COMMS.md`, generating or following the canonical prompt, registering, polling at the documented checkpoints, respecting claims, and closing presence. State that inability to start the protocol is a blocker for local parallel-agent work, but does not apply to a solitary read-only session.
+
+Add exactly this ignore entry near other project-local state:
+
+```gitignore
+# Спільна локальна mailbox-шина агентів; transport state ніколи не комітиться.
+.agents/
+```
+
+- [ ] **Step 6: Run prompt and documentation contract tests GREEN**
+
+Run: `node --test tests/tools/agent_comms/prompt.test.mjs tests/tools/agent_comms/integration.test.mjs`
+
+Expected: prompt is byte-for-byte derived from the committed template, bootstrap checkpoints are present, CLI command passes, exit `0`.
+
+- [ ] **Step 7: Prove `.agents/` is ignored from main and linked worktree contexts**
+
+Run from the task worktree:
+
+```bash
+git check-ignore -v ../../.agents/protocol.json
+git status --short
+```
+
+Run from the main checkout:
+
+```bash
+git check-ignore -v .agents/protocol.json
+git status --short
+```
+
+Expected: both paths resolve to the new `.agents/` rule; runtime records do not appear in status. Existing unrelated status in main must be reported, not changed.
+
+- [ ] **Step 8: Commit prompt, docs, and bootstrap**
+
+```bash
+git add tools/agents/lib/prompt.mjs tools/agents/comms.mjs tests/tools/agent_comms/prompt.test.mjs docs/AGENT_COMMS.md docs/AGENT_COMMS_PROMPT.md AGENTS.md .gitignore
+git commit -m "docs: require local agent communication"
+```
+
+---
+
+### Task 10: Live multi-agent acceptance and primary PR
+
+**Files:**
+
+- Modify only if a verified defect is found: files already introduced by Tasks 1–9.
+- Create runtime evidence only under ignored `.agents/artifacts/`; do not stage it.
+
+**Interfaces:**
+
+- Validates the public CLI as a user or independent agent will invoke it.
+- Produces no committed runtime state and no `.github/workflows/` changes.
+
+- [ ] **Step 1: Run static and focused verification**
+
+```bash
+node --check tools/agents/comms.mjs
+node --test tests/tools/agent_comms/*.test.mjs
+git diff --check main...HEAD
+```
+
+Expected: all commands exit `0` and every protocol test file executes.
+
+- [ ] **Step 2: Demonstrate the required live failures through the executable**
+
+Using a fresh temp bus via `PW2_AGENT_BUS_DIR`, demonstrate and retain command/output excerpts for:
+
+1. malformed inbox JSON → `doctor` exit `4`;
+2. overlapping claim by a second agent → `claim` exit `5`;
+3. required watcher older than 45 seconds → `doctor --require-live visual` exit `6`;
+4. handoff without verification evidence → `handoff` exit `4`.
+
+Remove only the exact temporary fixture after each demonstration. Do not mutate source to fake a RED.
+
+- [ ] **Step 3: Run cross-worktree live acceptance**
+
+Initialize the real ignored bus once, then invoke the branch CLI with `cwd` in the main checkout and in this linked worktree. Register `orchestrator-probe`, `visual-probe`, `models-probe`, and `physics-probe` with distinct tasks and ownership scopes. Start watchers for all four and verify `status --json` reports them online.
+
+Send a `contract_request` from `visual-probe` to `models-probe`, observe one watcher JSONL event, reply from `models-probe`, acknowledge the request, and verify the sender-visible acknowledgement. Claim `game/presentation` as `visual-probe`, prove `models-probe` cannot claim `game/presentation/camera`, then release it. Create a committed-form handoff with a real branch/base SHA and passing verification summary. Stop watchers, close all four probe identities, and verify their status is offline with no active claims.
+
+- [ ] **Step 4: Verify existing project gates remain green**
+
+```bash
+gdformat --check game/ tests/ content/
+gdlint game/ tests/ content/
+./tools/ci/check_gdscript.sh game tests content
+./tools/ci/run_tests.sh tests/
+./tools/ci/check_sim_invariants.sh game/sim
+```
+
+Expected: formatting/lint/static/invariant commands exit `0`; gdUnit wrapper executes every declared suite and case with zero failures.
+
+- [ ] **Step 5: Audit scope, structure, and cleanliness**
+
+```bash
+find tools/agents/lib -name '*.mjs' -print0 | xargs -0 wc -l
+git diff --name-only main...HEAD
+git diff --check main...HEAD
+git status --short
+```
+
+Expected: every runtime module is below 300 lines; only the file map declared in this plan changed; diff check is clean; task worktree is clean; `.agents/` is absent from tracked and untracked status.
+
+- [ ] **Step 6: Request two-stage review and fix verified findings**
+
+Use `superpowers:requesting-code-review`. First reviewer checks exact conformance to the approved design and this plan. Second reviewer checks implementation quality, race safety, recovery semantics, tests, and documentation. For every accepted finding, reproduce the defect before changing code, add or strengthen a failing test, implement the narrow correction, and rerun the focused plus full protocol suites.
+
+- [ ] **Step 7: Push the primary branch**
+
+```bash
+git push -u origin ops/agent-comms-protocol
+```
+
+Expected: pre-push gates pass and the branch is published without modifying `main`.
+
+- [ ] **Step 8: Open the primary PR**
+
+Create a PR whose description includes:
+
+- task name `OPS — local agent communication protocol`;
+- concise user-facing behavior;
+- each acceptance criterion with command evidence;
+- protocol-test and existing Godot-suite summaries;
+- the four demonstrated RED failures and their exit codes;
+- cross-worktree live acceptance result;
+- statement that `.agents/` contains local plaintext transport state and is ignored;
+- explicit note that CI wiring is deferred to the required post-merge shared-file micro-PR.
+
+End the handoff with the PR link. Do not merge it.
+
+---
+
+## Post-Merge Follow-up Boundary
+
+After the user merges the primary PR, create a new branch and new plan for one shared-file micro-PR that modifies only `.github/workflows/ci.yml` (and a directly necessary CI test script if the existing workflow cannot count Node tests reliably). Its gate must invoke `node --test tests/tools/agent_comms/*.test.mjs`, prove a deliberately failing Node test makes CI non-zero, and leave all existing Godot checks intact. Do not begin that micro-PR from this branch.
+
+## Execution amendment — accepted review support files
+
+This amendment reconciles the original per-task `Create`/`Modify` lists with
+the files added during the plan's mandatory review-and-fix rounds. It changes
+no behavioral requirement, interface, acceptance criterion, or rollout
+boundary. The additional files remain within the original
+`tools/agents/lib/` runtime and `tests/tools/agent_comms/` test ownership map.
+
+Runtime support files introduced to keep each module below 300 lines while
+isolating accepted race-safety, integrity, recovery, and lifecycle fixes:
+
+- Create: `tools/agents/lib/claim-records.mjs` — strict claim record loading,
+  digest binding, and duplicate-scope validation extracted from claims.
+- Create: `tools/agents/lib/doctor-protocol.mjs` — protocol-version diagnosis
+  separated from repair orchestration.
+- Create: `tools/agents/lib/doctor-storage.mjs` — exhaustive storage inventory
+  and corrupt-record classification separated from status presentation.
+- Create: `tools/agents/lib/repair-mutex.mjs` — crash-recoverable, audited
+  repair mutex ownership and stale-generation handling.
+- Create: `tools/agents/lib/safe-file.mjs` — no-follow regular-file reads used
+  by accepted symlink and swap-race fixes.
+- Create: `tools/agents/lib/signal-stop.mjs` — latched SIGINT/SIGTERM watcher
+  shutdown separated from CLI dispatch.
+- Create: `tools/agents/lib/status-locks.mjs` — watcher/doctor lock
+  classification separated from the status aggregate.
+- Create: `tools/agents/lib/watcher-ownership.mjs` — atomic lifetime watcher
+  ownership and generation-safe release separated from presence delivery.
+
+Regression files added for the accepted TDD review findings and kept separate
+by concern rather than growing the original suites past the structure ceiling:
+
+- Create: `tests/tools/agent_comms/claims-integrity.test.mjs`
+- Create: `tests/tools/agent_comms/cli-round1.test.mjs`
+- Create: `tests/tools/agent_comms/doctor-race.test.mjs`
+- Create: `tests/tools/agent_comms/repair-mutex.test.mjs`
+- Create: `tests/tools/agent_comms/status-review.test.mjs`
+- Create: `tests/tools/agent_comms/status-round2.test.mjs`
+- Create: `tests/tools/agent_comms/status-round3.test.mjs`
+- Create: `tests/tools/agent_comms/status-round4.test.mjs`

--- a/prototype/integrated/docs/superpowers/specs/2026-08-14-agent-communication-protocol-design.md
+++ b/prototype/integrated/docs/superpowers/specs/2026-08-14-agent-communication-protocol-design.md
@@ -1,0 +1,338 @@
+# Локальний протокол комунікації агентів
+
+**Дата:** 2026-08-14
+**Статус:** design approved; implementation pending
+**Скоуп:** локальні LLM-агенти, які працюють у різних сесіях і worktree одного checkout Papercut Warzone 2
+
+## Проблема
+
+Субагенти одного оркестратора можуть обмінюватися повідомленнями через вбудований канал своєї сесії. Незалежні Codex, Claude Code та інші LLM-сесії такого спільного каналу не мають, хоча працюють з одним репозиторієм. Через це агент графіки може не знати, що агент моделей змінив pivots або material slots, а агент фізики — що презентації потрібне нове поле стану.
+
+Один спільний Markdown-файл у main checkout проблему не розв'язує:
+
+- два агенти можуть одночасно перезаписати файл;
+- untracked-файл не з'являється автоматично в кожному worktree;
+- немає адресації, підтвердження доставки, presence або видимого конфлікту ownership;
+- main checkout стає прихованою змінною стану без формального протоколу.
+
+Потрібен локальний transport, доступний з усіх worktree, але відсутній у Git. Він не замінює committed-документи: прийняті рішення, схеми та контракти однаково мають потрапляти в репозиторій.
+
+## Цілі
+
+1. Дати незалежним агентам одного локального checkout адресовані inbox-повідомлення.
+2. Не втрачати й не перезаписувати повідомлення при паралельному записі.
+3. Показувати, які агенти зареєстровані, online, stale або мають непрочитані дії.
+4. Вимагати явний acknowledgement для повідомлень, що потребують дії.
+5. Попереджати про перетин ownership/claims до редагування файлів.
+6. Давати стандартний handoff: task, branch, commit, перевірки, контракти та артефакти.
+7. Працювати без мережі та сторонніх npm-залежностей на пінованому Node 22+.
+8. Дати користувачу один copy-paste промт для підключення вже запущених агентів.
+
+## Не-цілі та чесна межа push
+
+- Протокол не замінює Git, PR, `PROGRESS.md`, schema-файли або права ownership з `TRACKS.md`.
+- Claim є попередженням і локальною координацією, а не дозволом змінювати чужий трек.
+- Локальний watcher не може універсально перервати reasoning-turn або розбудити LLM у сторонньому застосунку. Він може тримати heartbeat і негайно надрукувати подію у своєму terminal/session output.
+- Тому гарантія доставки складається з двох частин: довгоживучий watcher для presence і швидкого сигналу плюс обов'язковий `inbox` на контрольних точках із промта.
+- Справжній push без polling лишається можливістю host-specific adapter або вбудованого каналу субагентів одного оркестратора; v1 такого adapter не містить.
+- Протокол v1 локальний для одного checkout на одній машині. Міжмашинна доставка через GitHub або сервер не входить у цю задачу.
+
+## Розглянуті підходи
+
+### Один спільний Markdown-файл
+
+Найменше коду, але немає безпечної конкурентності, адресації та acknowledgements. Відкинуто.
+
+### SQLite або локальний daemon
+
+Дає транзакції та складні запити, але додає lifecycle сервера, блокування бази і складнішу діагностику для різних агентських клієнтів. Для десятків локальних повідомлень це зайва система. Відкладено до появи виміряної потреби.
+
+### Файлова mailbox-система — обрано
+
+Одне повідомлення є одним immutable JSON-файлом. Запис відбувається у тимчасовий файл і завершується атомарним rename в inbox. Кожен агент є єдиним writer власних mutable presence/registry-файлів. Це мінімальна архітектура з видимим станом і без зовнішніх залежностей.
+
+## Розміщення і discovery
+
+Tracked-частина:
+
+```text
+tools/agents/comms.mjs
+tools/agents/lib/*.mjs
+tests/tools/agent_comms/*.test.mjs
+docs/AGENT_COMMS.md
+docs/AGENT_COMMS_PROMPT.md
+AGENTS.md
+.gitignore
+```
+
+Локальна частина:
+
+```text
+.agents/
+├── protocol.json
+├── registry/
+├── presence/
+├── inbox/<agent-id>/
+├── seen/
+├── acknowledgements/
+├── claims/
+├── handoffs/
+├── archive/<agent-id>/
+├── artifacts/
+├── locks/
+├── quarantine/
+└── tmp/
+```
+
+CLI знаходить shared bus однаково з main checkout і linked worktree:
+
+1. якщо задано `PW2_AGENT_BUS_DIR`, використовує цей абсолютний шлях; тестовий набір завжди задає override на тимчасову директорію;
+2. інакше виконує `git rev-parse --path-format=absolute --git-common-dir`;
+3. коренем checkout вважає parent отриманої `.git` директорії;
+4. bus живе у `<checkout-root>/.agents`;
+5. якщо common dir не має basename `.git` або checkout root неможливо визначити однозначно, CLI відмовляється і просить явний `PW2_AGENT_BUS_DIR`.
+
+`init` створює `protocol.json` з protocol version, checkout identity та часом ініціалізації. Повторний `init` ідемпотентний лише для сумісної версії; невідома новіша версія не перезаписується. `.agents/` додається в `.gitignore`. Жоден файл runtime-state не стажується і не потрапляє в PR.
+
+## Ідентичність та реєстрація
+
+Agent id стабільний у межах task і відповідає regex `[a-z0-9][a-z0-9_-]{1,31}`. Рекомендовані ролі: `orchestrator`, `visual`, `models`, `physics`; для паралельних задач додається короткий suffix, наприклад `visual-m2-1b`.
+
+`register` записує:
+
+- `schema_version`;
+- `agent_id`, `role`, `task`;
+- абсолютний worktree path;
+- branch і HEAD SHA;
+- declared ownership scopes;
+- `registered_at` і `updated_at` у UTC;
+- optional client label (`codex`, `claude-code`, `cursor`, `other`).
+
+Активним є registry-record зі статусом `open` і живим heartbeat. Активний дубль agent id відхиляється. `--resume` дозволений лише для того самого worktree і task; інша сесія мусить обрати новий id або спершу закрити стару реєстрацію. Реєстрація без watcher стає stale за тим самим 45-секундним правилом і видима orchestrator-у. `close` відмовляється, доки watcher цього id живий; після зупинки watcher команда помічає agent offline, звільняє його claims і не видаляє історію.
+
+## Формат повідомлення
+
+Кожне повідомлення має schema version 1 і поля:
+
+```json
+{
+  "schema_version": 1,
+  "id": "20260814T183012.123Z-visual-550e8400",
+  "from": "visual",
+  "to": "models",
+  "type": "contract_request",
+  "severity": "action",
+  "subject": "Потрібні material slots танка",
+  "body": "Надай стабільні surface names для hull і turret.",
+  "task": "M2.7",
+  "reply_to": null,
+  "requires_ack": true,
+  "created_at": "2026-08-14T18:30:12.123Z",
+  "sender_head": "a7c46f9...",
+  "attachments": []
+}
+```
+
+Допустимі `type`: `status`, `question`, `contract_request`, `contract_response`, `blocker`, `handoff`, `broadcast`. Допустимі `severity`: `info`, `action`, `blocker`. Невідомі enum values, відсутні required fields, неправильні типи або невідома schema version є гучною помилкою, а не best-effort parsing.
+
+Body передається через `--body`, `--body-file` або stdin. Для складного тексту промт вимагає `--body-file` або stdin, щоб не ризикувати shell quoting.
+
+Attachment містить repo-relative path або шлях усередині `.agents/artifacts`, SHA-256, розмір і ознаку `ephemeral`. Тимчасовий файл поза цими коренями не приймається. Handoff committed-артефакту додатково містить commit SHA.
+
+`broadcast` робить окрему адресовану копію в inbox кожного активного одержувача, щоб acknowledgement рахувався per recipient.
+
+## Атомарність і конкурентність
+
+- Message id містить UTC timestamp, sender id і `crypto.randomUUID()`; файл створюється з exclusive-create.
+- Sender повністю записує й fsync-ить JSON у `.agents/tmp`, після чого робить rename у `inbox/<recipient>/` на тому самому filesystem.
+- Inbox та watcher ніколи не читають `.agents/tmp`.
+- Повідомлення immutable. Reply є новим повідомленням із `reply_to`.
+- Після успішного parse+print `watch` або `inbox` створює immutable seen-receipt `seen/<message-id>--<recipient>.json`. Це означає «доставлено у terminal output», а не «виконано».
+- Ack є окремим immutable файлом `acknowledgements/<message-id>--<recipient>.json`; початкове повідомлення не мутується.
+- `ack` ідемпотентний: спершу атомарно створює ack-record, потім переносить повідомлення в `archive/<recipient>/`. Якщо process упав між діями, повторний `ack` або `doctor --repair` завершує перенос; acked message, що лишився в inbox, не вважається pending.
+- Mutable registry/presence пишеться лише відповідним agent id через temp+rename.
+- Claims перевіряються під коротким global critical section, захопленим atomic `mkdir` у `.agents/locks/claims.lock`. Crash-stale lock не знімається мовчки: `doctor --repair` може прибрати його лише коли записаний PID не існує і вік lock перевищує 60 секунд.
+
+## Presence, watcher і polling
+
+`watch --id <agent>`:
+
+- відхиляє другий живий watcher того самого id;
+- оновлює heartbeat кожні 15 секунд;
+- вважається stale після 45 секунд без heartbeat;
+- стежить за inbox через `fs.watch`, але має fallback scan кожні 2 секунди, бо файлові events можуть coalesce;
+- для нового повідомлення друкує один JSONL event і terminal bell;
+- створює seen-receipt лише після успішного виводу повного event;
+- повторно не друкує message id у межах одного watcher process; після restart unseen повідомлення друкуються, а seen-but-unacked доступні через `inbox`;
+- на `SIGINT`/`SIGTERM` помічає presence offline;
+- не робить ack автоматично.
+
+`wait --id <agent> --timeout <seconds>` є одноразовою альтернативою: повертається при появі unseen message або після timeout. Timeout не є помилкою bus і має окремий exit code. `inbox` за замовчуванням показує всі unacked повідомлення, включно з уже seen, тому background watcher не може приховати дію від наступного checkpoint poll.
+
+Оскільки terminal output не гарантує, що сторонній LLM-клієнт інжектить його в активний reasoning-turn, agent prompt зобов'язує виконувати `inbox`:
+
+1. одразу після `register`;
+2. перед першою зміною файлів;
+3. після кожної довгої команди або повернення до задачі;
+4. перед зміною shared contract;
+5. перед commit;
+6. перед push/PR;
+7. перед переходом до нового етапу;
+8. через `wait`, коли агент не має іншої роботи.
+
+Кожне повідомлення архівується лише явним `ack`. Поле `requires_ack` визначає enforcement: unacked `action`/`blocker` із цим прапорцем робить відповідний status/doctor check червоним; інформаційне повідомлення лишається у списку, але не валить гейт. Агент або ack-ає дію після виконання, або відповідає з `reply_to`, чому вона ще pending. Seen-receipt не є ack.
+
+## Claims та ownership
+
+Scope буває path (`game/presentation`) або named contract (`contract:tank-registration-v1`). Path overlap визначається по сегментах: `game/presentation` конфліктує з `game/presentation/camera`, але не з `game/presentations`.
+
+Claim містить agent, task, scope, reason, created/updated timestamps і expiry. Default lease — 30 хвилин; живий watcher подовжує claims свого agent. Stale claim лишається видимим, але `claim` не краде його автоматично. Зняття чужого stale claim робить лише orchestrator явною командою з audit-записом.
+
+`claim` не дозволяє працювати поза ownership із `TRACKS.md`. Він лише ловить випадковий паралельний дотик усередині дозволеного скоупу або до shared contract.
+
+## Handoff
+
+`handoff` створює typed-повідомлення й immutable record з такими required-полями:
+
+- task і короткий результат;
+- branch, commit SHA, base SHA;
+- changed paths;
+- verification commands і exit/result summary;
+- contracts added/changed/consumed;
+- follow-up для конкретних agent ids;
+- artifact paths + checksums;
+- known limitations/blockers.
+
+Handoff без commit дозволений лише з `--uncommitted` і гучною позначкою; він не може називатися ready-to-merge.
+
+## CLI v1
+
+```text
+init
+register --id --role --task [--ownership ...] [--client ...] [--resume]
+close --id
+send --from --to --type --severity --subject (--body | --body-file | stdin)
+broadcast --from ...
+inbox --id [--json] [--type ...] [--severity ...]
+ack --id --message
+reply --from --message ...
+watch --id [--heartbeat 15] [--scan-interval 2]
+wait --id [--timeout 60]
+claim --id --scope --reason [--lease 1800]
+release --id --scope
+handoff --id --to --commit ...
+status [--json] [--fail-on-stale] [--fail-on-pending]
+doctor [--require-live id,id,...] [--repair]
+prompt --id --role --task [--ownership ...]
+```
+
+Exit codes v1:
+
+- `0`: command succeeded;
+- `2`: usage error;
+- `3`: `wait` timeout/no event;
+- `4`: invalid/corrupt protocol data;
+- `5`: identity, claim or lock conflict;
+- `6`: required agent stale/offline or required acknowledgement pending.
+
+Human output і JSON output не змішуються. `--json` друкує один machine-readable JSON value; watcher завжди друкує JSONL. Status окремо рахує unseen, seen-but-unacked, required-unacked, blockers, live/stale/offline agents, active/stale claims і handoffs.
+
+## Оркестратор
+
+Оркестратор реєструється як `orchestrator`, тримає watcher і використовує `status --fail-on-stale` на checkpoints. Він не ретранслює кожне peer-to-peer повідомлення, але втручається коли:
+
+- claim перетнувся;
+- required agent stale;
+- blocker не ack-нуто;
+- дві сторони не погодили contract;
+- handoff не має доказів або consumer не підтвердив його.
+
+Комунікаційний transport не змінює правило: merge PR робить користувач.
+
+## Помилки та відновлення
+
+- Corrupt JSON переноситься лише командою `doctor --repair` у `.agents/quarantine/`; звичайний inbox/doctor завершується exit 4 і називає файл.
+- Unknown recipient, unregistered sender або duplicate live identity відхиляються до запису повідомлення.
+- Відсутній bus пропонує `init`; destructive auto-reset не існує.
+- Невідома version у `protocol.json` або message schema не мігрується мовчки й дає exit 4.
+- Stale watcher/claim не видаляється автоматично.
+- Cleanup є явною командою майбутнього implementation plan: archive можна чистити за milestone лише після перевірки, що handoff/рішення закомічені. Registry history зберігається до ручного cleanup.
+- У bus заборонені secrets, токени й credentials; це локальний plaintext.
+
+## Структура реалізації
+
+Щоб не створити ще один файл понад 300 рядків, `comms.mjs` є тонким dispatcher. Окремі модулі мають одну причину змінюватись:
+
+- `paths.mjs`: discovery та directory layout;
+- `atomic-json.mjs`: exclusive write, fsync, rename, strict read;
+- `schema.mjs`: validation/versioning;
+- `identity.mjs`: register/close;
+- `messages.mjs`: send/inbox/ack/reply/broadcast;
+- `presence.mjs`: watch/wait/heartbeat;
+- `claims.mjs`: lease/overlap/lock;
+- `handoff.mjs`: handoff validation;
+- `status.mjs`: status/doctor;
+- `prompt.mjs`: canonical bootstrap prompt.
+
+Жодної runtime npm-залежності; лише Node standard library.
+
+## Документація і промт
+
+`docs/AGENT_COMMS.md` містить команди, lifecycle, message/claim/handoff semantics і troubleshooting. `AGENTS.md` отримує коротке обов'язкове правило: агент у локальному worktree виконує canonical bootstrap, перевіряє inbox на визначених checkpoints і закриває presence перед завершенням.
+
+`docs/AGENT_COMMS_PROMPT.md` є copy-paste промтом із плейсхолдерами `<AGENT_ID>`, `<ROLE>`, `<TASK>`, `<OWNERSHIP>`. Команда `prompt` читає цей committed template і лише підставляє передані значення; окремої вбудованої копії тексту в коді немає. Test перевіряє byte-for-byte output для фіксованих значень і наявність усіх обов'язкових checkpoints.
+
+Промт прямо каже агенту:
+
+- спочатку прочитати `AGENTS.md` і `docs/AGENT_COMMS.md`;
+- не продовжувати, якщо `register` або watcher не стартували;
+- повідомити orchestrator про свій id/task/ownership;
+- не редагувати claimed scope іншого агента;
+- poll inbox на кожній контрольній точці;
+- відповідати/ack-ати action і blocker;
+- перед зміною контракту отримати acknowledgement споживача;
+- завершити handoff і `close` навіть при blocker.
+
+## Верифікація і liveness
+
+Тести використовують Node built-in `node:test` і окремий `PW2_AGENT_BUS_DIR` у temp. Обов'язкові кейси:
+
+1. main checkout і linked-worktree fixture резолвлять один bus root;
+2. паралельні sender processes створюють 100 унікальних повідомлень без втрат;
+3. reader ніколи не бачить частковий JSON;
+4. invalid schema, unknown version і corrupt JSON дають exit 4;
+5. unknown recipient і duplicate live identity відхиляються;
+6. unseen → seen → ack → archive, ack видимий sender; crash між ack і archive відновлюється ідемпотентно;
+7. broadcast потребує незалежний ack кожного recipient;
+8. watcher heartbeat переходить online → stale → offline за контрольованим clock;
+9. `wait` розрізняє delivery та timeout;
+10. path-prefix і named-contract claims ловлять справжні перетини й не ловлять схожі назви;
+11. stale claim не крадеться автоматично;
+12. handoff без required evidence відхиляється;
+13. status/doctor повертають ненульовий код на stale required agent, pending blocker, corrupt message і stale lock;
+14. generated prompt читається з committed template, містить усі checkpoints і коректно підставляє значення.
+
+За правилом живого гейта перед GREEN показуються навмисні відмови щонайменше для corrupt message, duplicate claim, stale required watcher і handoff без evidence. CI-виклик Node tests оформлюється окремим micro-PR, бо `.github/workflows/` є shared ownership.
+
+## Критерії приймання
+
+1. Два агенти з різних worktree реєструються і бачать один одного online.
+2. `visual` надсилає `models` contract request; watcher друкує його, `models` відповідає й ack-ає, `visual` бачить acknowledgement.
+3. Паралельні повідомлення не втрачаються і не перезаписуються.
+4. Конфлікт claims відхиляється до зміни файлів.
+5. Orchestrator бачить online/stale, unseen, seen-but-unacked, pending blockers, unacked actions і handoffs однією командою.
+6. Dormant agent може чекати через `wait`; active agent має heartbeat через `watch`.
+7. Corrupt або невідомий protocol state не ігнорується.
+8. `.agents/` не з'являється у `git status` з жодного worktree.
+9. Готовий copy-paste промт підключає нову сесію без знання внутрішньої реалізації CLI.
+10. Повний наявний Godot test suite лишається зеленим; Node protocol tests зелені й мають продемонстрований RED.
+
+## Rollout
+
+1. Primary PR: CLI, Node tests, `.gitignore`, документація, prompt і bootstrap-правило в `AGENTS.md`.
+2. User merges primary PR.
+3. Окремий shared CI micro-PR додає canonical Node test command.
+4. Orchestrator виконує `init`, реєструє себе й перевіряє `doctor`.
+5. Користувач передає committed prompt чинним агентам; кожен реєструється з унікальним id та запускає watcher.
+6. Orchestrator виконує live acceptance між щонайменше `visual`, `models` і `physics`, включно з ack та conflict claim.
+7. Після live acceptance протокол стає обов'язковим для нових локальних multi-agent задач.

--- a/prototype/integrated/docs/superpowers/specs/2026-08-14-agent-communication-protocol-design.md
+++ b/prototype/integrated/docs/superpowers/specs/2026-08-14-agent-communication-protocol-design.md
@@ -1,7 +1,7 @@
 # Локальний протокол комунікації агентів
 
 **Дата:** 2026-08-14
-**Статус:** design approved; implementation pending
+**Статус:** design approved; implementation complete; primary integration pending
 **Скоуп:** локальні LLM-агенти, які працюють у різних сесіях і worktree одного checkout Papercut Warzone 2
 
 ## Проблема

--- a/prototype/integrated/tests/tools/agent_comms/args.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/args.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseArgs } from "../../../tools/agents/lib/args.mjs";
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+
+test("register preserves repeated ownership scopes", () => {
+  const parsed = parseArgs(["register", "--id", "visual", "--role", "artist", "--task",
+    "M2.7", "--ownership", "game/presentation", "--ownership", "contract:paint-v1"]);
+  assert.deepEqual(parsed, { command: "register", options: { id: "visual", role: "artist",
+    task: "M2.7", ownership: ["game/presentation", "contract:paint-v1"] } });
+});
+
+test("message body sources are exclusive", () => {
+  assert.throws(() => parseArgs(["send", "--from", "visual", "--to", "models", "--type",
+    "status", "--severity", "info", "--subject", "update", "--body", "one", "--body-file",
+    "two.txt"]), error => error.exitCode === EXIT.USAGE);
+});
+
+test("handoff accepts its fixed repeated and structured grammar", () => {
+  const parsed = parseArgs(["handoff", "--id", "visual", "--to", "orchestrator", "--task",
+    "M2.7", "--result", "ready", "--branch", "feature/visual", "--commit", "a".repeat(40),
+    "--base", "b".repeat(40), "--changed", "game/view.gd", "--follow-up", "models",
+    "--artifact", "build/proof.txt", "--verification-file", "verify.json", "--contracts-file",
+    "contracts.json", "--limitations-file", "limits.json"]);
+  assert.deepEqual(parsed.options.changed, ["game/view.gd"]);
+  assert.deepEqual(parsed.options.followUp, ["models"]);
+  assert.deepEqual(parsed.options.artifact, ["build/proof.txt"]);
+});
+
+test("unknown options, values and commands are usage errors", () => {
+  for (const argv of [["status", "--mystery"], ["register", "--id"], ["invent"]]) {
+    assert.throws(() => parseArgs(argv), error => error.exitCode === EXIT.USAGE);
+  }
+});
+
+test("force stale release requires an explicit owner", () => {
+  assert.throws(() => parseArgs(["release", "--id", "visual", "--scope", "game/view",
+    "--force-stale"]), error => error.exitCode === EXIT.USAGE);
+});
+
+test("prompt requires every ownership scope to contain non-whitespace content", () => {
+  for (const argv of [
+    ["prompt", "--id", "visual", "--role", "visual", "--task", "M2.7"],
+    ["prompt", "--id", "visual", "--role", "visual", "--task", "M2.7", "--ownership", ""],
+    ["prompt", "--id", "visual", "--role", "visual", "--task", "M2.7", "--ownership", "",
+      "--ownership", "game/presentation"],
+    ["prompt", "--id", "visual", "--role", "visual", "--task", "M2.7", "--ownership",
+      "game/presentation", "--ownership", ""],
+    ["prompt", "--id", "visual", "--role", "visual", "--task", "M2.7", "--ownership", " \t "],
+  ]) assert.throws(() => parseArgs(argv), error => error.exitCode === EXIT.USAGE);
+});

--- a/prototype/integrated/tests/tools/agent_comms/atomic-json-process-storage.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/atomic-json-process-storage.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+import {
+  listJsonFiles,
+  readJsonStrict,
+  writeJsonAtomic,
+} from "../../../tools/agents/lib/atomic-json.mjs";
+import { createBusFixture } from "./helpers.mjs";
+
+const execFileAsync = promisify(execFile);
+
+test("independent reader and writer processes never observe partial JSON",
+  { timeout: 60_000 }, async t => {
+    const fixture = await createBusFixture();
+    t.after(fixture.cleanup);
+    const target = fixture.paths.presenceFile("models");
+    await writeJsonAtomic(target, { sequence: 0, lane: "A", payload: "A".repeat(65_536) }, {
+      tmpDir: fixture.paths.tmp,
+      exclusive: false,
+    });
+    const modulePath = path.resolve(path.dirname(fileURLToPath(import.meta.url)),
+      "../../../tools/agents/lib/atomic-json.mjs");
+    const moduleUrl = pathToFileURL(modulePath).href;
+    const common = `
+      const atomic = await import(${JSON.stringify(moduleUrl)});
+      const target = ${JSON.stringify(target)};
+      const tmpDir = ${JSON.stringify(fixture.paths.tmp)};
+      const root = ${JSON.stringify(fixture.paths.root)};
+    `;
+    const writer = `${common}
+      for (let sequence = 1; sequence <= 150; sequence += 1) {
+        const lane = sequence % 2 === 0 ? "A" : "B";
+        await atomic.writeJsonAtomic(target,
+          { sequence, lane, payload: lane.repeat(65536) }, { tmpDir, exclusive: false });
+      }
+    `;
+    const reader = `${common}
+      for (let attempt = 0; attempt < 1200; attempt += 1) {
+        await atomic.readJsonStrict(target, value => {
+          if (!Number.isSafeInteger(value.sequence) || !["A", "B"].includes(value.lane)
+            || value.payload !== value.lane.repeat(65536)) throw new Error("partial record");
+          return value;
+        }, root);
+      }
+    `;
+
+    await Promise.all([
+      execFileAsync(process.execPath, ["--input-type=module", "--eval", writer]),
+      ...Array.from({ length: 4 }, () =>
+        execFileAsync(process.execPath, ["--input-type=module", "--eval", reader])),
+    ]);
+
+    const final = await readJsonStrict(target, value => value, fixture.paths.root);
+    assert.equal(final.sequence, 150);
+    assert.equal(final.payload, "A".repeat(65_536));
+    assert.deepEqual(await listJsonFiles(fixture.paths.tmp, { root: fixture.paths.root }), []);
+  });

--- a/prototype/integrated/tests/tools/agent_comms/atomic-json-storage.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/atomic-json-storage.test.mjs
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import {
+  mkdtemp,
+  mkdir,
+  open,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  archiveFileNoReplace,
+  listJsonFiles,
+  moveFileAtomic,
+  readJsonStrict,
+  writeJsonAtomic,
+} from "../../../tools/agents/lib/atomic-json.mjs";
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import { createBusFixture, pathExists } from "./helpers.mjs";
+
+test("strict JSON reads reject a symlink instead of following it", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const source = path.join(fixture.root, "outside.json");
+  const linked = fixture.paths.protocol;
+  await writeFile(source, '{"schema_version":1}\n');
+  await symlink(source, linked);
+
+  await assert.rejects(
+    readJsonStrict(linked, value => value, fixture.paths.root),
+    error => error.exitCode === EXIT.DATA,
+  );
+});
+
+test("managed read APIs require an explicit absolute bus root", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  await writeFile(fixture.paths.protocol, '{}\n');
+
+  await assert.rejects(
+    readJsonStrict(fixture.paths.protocol, value => value),
+    error => error.exitCode === EXIT.DATA,
+  );
+  await assert.rejects(
+    listJsonFiles(fixture.paths.registry),
+    error => error.exitCode === EXIT.DATA,
+  );
+});
+
+test("strict JSON reads validate bytes from the no-follow handle they opened", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const target = fixture.paths.protocol;
+  const replacement = path.join(fixture.root, "replacement.json");
+  await writeFile(target, '{"value":1}\n');
+  await writeFile(replacement, '{"value":2}\n');
+  let swapped = false;
+
+  const value = await readJsonStrict(target, record => record, fixture.paths.root,
+    async (...args) => {
+      const handle = await open(...args);
+      await rename(replacement, target);
+      swapped = true;
+      return handle;
+    });
+
+  assert.equal(swapped, true);
+  assert.deepEqual(value, { value: 1 });
+  assert.deepEqual(JSON.parse(await readFile(target, "utf8")), { value: 2 });
+});
+
+test("strict reads reject a parent directory replaced while opening", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const target = fixture.paths.registryFile("visual");
+  const retired = path.join(fixture.root, "retired-registry");
+  const external = path.join(fixture.root, "external-registry-race");
+  await writeFile(target, '{"source":"internal"}\n');
+  await mkdir(external);
+  await writeFile(path.join(external, "visual.json"), '{"source":"external"}\n');
+
+  await assert.rejects(
+    readJsonStrict(target, value => value, fixture.paths.root, async (...args) => {
+      await rename(fixture.paths.registry, retired);
+      await symlink(external, fixture.paths.registry);
+      return open(...args);
+    }),
+    error => error.exitCode === EXIT.DATA,
+  );
+  assert.deepEqual(JSON.parse(await readFile(path.join(external, "visual.json"), "utf8")),
+    { source: "external" });
+});
+
+test("JSON listing rejects a directory replaced during enumeration", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const retired = path.join(fixture.root, "retired-inbox");
+  const external = path.join(fixture.root, "external-inbox-race");
+  await writeFile(path.join(fixture.paths.inbox, "internal.json"), '{}\n');
+  await mkdir(external);
+  const externalFile = path.join(external, "external.json");
+  await writeFile(externalFile, '{"source":"external"}\n');
+
+  await assert.rejects(
+    listJsonFiles(fixture.paths.inbox, {
+      root: fixture.paths.root,
+      readDirectory: async (...args) => {
+        await rename(fixture.paths.inbox, retired);
+        await symlink(external, fixture.paths.inbox);
+        return readdir(...args);
+      },
+    }),
+    error => error.exitCode === EXIT.DATA,
+  );
+  assert.deepEqual(JSON.parse(await readFile(externalFile, "utf8")),
+    { source: "external" });
+});
+
+test("atomic publication rejects a symlinked destination directory", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const outside = await mkdtemp(path.join(os.tmpdir(), "pw2-agent-outside-"));
+  t.after(() => rm(outside, { recursive: true, force: true }));
+  await rm(fixture.paths.inbox, { recursive: true });
+  await symlink(outside, fixture.paths.inbox);
+  const target = fixture.paths.inboxFile("models", "message-id");
+
+  await assert.rejects(
+    writeJsonAtomic(target, { value: 1 }, { tmpDir: fixture.paths.tmp, exclusive: true }),
+    error => error.exitCode === EXIT.DATA,
+  );
+  assert.equal(await pathExists(path.join(outside, "models", "message-id.json")), false);
+});
+
+test("atomic publication rejects destinations outside its managed bus", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const outside = path.join(fixture.root, "outside", "record.json");
+  await mkdir(path.dirname(outside));
+
+  await assert.rejects(
+    writeJsonAtomic(outside, { value: 1 }, { tmpDir: fixture.paths.tmp, exclusive: true }),
+    error => error.exitCode === EXIT.DATA,
+  );
+  assert.equal(await pathExists(outside), false);
+});
+
+test("atomic moves reject a symlinked publication directory", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const outside = await mkdtemp(path.join(os.tmpdir(), "pw2-agent-move-outside-"));
+  t.after(() => rm(outside, { recursive: true, force: true }));
+  const source = path.join(fixture.paths.inbox, "message.json");
+  await writeFile(source, '{"value":1}\n');
+  await rm(fixture.paths.archive, { recursive: true });
+  await symlink(outside, fixture.paths.archive);
+  const destination = fixture.paths.archiveFile("models", "message-id");
+
+  await assert.rejects(
+    moveFileAtomic(source, destination, { root: fixture.paths.root }),
+    error => error.exitCode === EXIT.DATA,
+  );
+  assert.equal(await pathExists(source), true);
+  assert.equal(await pathExists(path.join(outside, "models", "message-id.json")), false);
+});
+
+test("archive completion tolerates a disappeared source only with identical evidence", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const source = fixture.paths.inboxFile("models", "message-id");
+  const destination = fixture.paths.archiveFile("models", "message-id");
+  const expected = Buffer.from('{"value":1}\n');
+  await mkdir(path.dirname(destination));
+  await writeFile(destination, expected);
+
+  await archiveFileNoReplace(source, destination, {
+    root: fixture.paths.root,
+    expectedBytes: expected,
+  });
+
+  assert.deepEqual(await readFile(destination), expected);
+});
+
+test("archive completion preserves a conflicting destination after source disappearance", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const source = fixture.paths.inboxFile("models", "message-id");
+  const destination = fixture.paths.archiveFile("models", "message-id");
+  const conflicting = Buffer.from('{"value":2}\n');
+  await mkdir(path.dirname(destination));
+  await writeFile(destination, conflicting);
+
+  await assert.rejects(
+    archiveFileNoReplace(source, destination, {
+      root: fixture.paths.root,
+      expectedBytes: Buffer.from('{"value":1}\n'),
+    }),
+    error => error.exitCode === EXIT.DATA,
+  );
+  assert.deepEqual(await readFile(destination), conflicting);
+});

--- a/prototype/integrated/tests/tools/agent_comms/atomic-json.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/atomic-json.test.mjs
@@ -29,7 +29,7 @@ test("exclusive writes never replace an immutable record", async t => {
     error => error.exitCode === EXIT.CONFLICT,
   );
   assert.deepEqual(JSON.parse(await readFile(target, "utf8")), { value: 1 });
-  assert.deepEqual(await listJsonFiles(fixture.paths.tmp), []);
+  assert.deepEqual(await listJsonFiles(fixture.paths.tmp, { root: fixture.paths.root }), []);
 });
 
 test("mutable writes atomically replace the published value", async t => {
@@ -77,7 +77,7 @@ test("malformed JSON fails the corrupt-data gate", async t => {
   await writeFile(target, "{not-json", "utf8");
 
   await assert.rejects(
-    readJsonStrict(target, value => value),
+    readJsonStrict(target, value => value, fixture.paths.root),
     error => error.exitCode === EXIT.DATA && error.details.filePath === target,
   );
 });
@@ -92,7 +92,7 @@ test("strict reads return the original validated value", async t => {
   const result = await readJsonStrict(target, value => {
     parsed = value;
     return value;
-  });
+  }, fixture.paths.root);
 
   assert.equal(result, parsed);
 });
@@ -106,11 +106,13 @@ test("JSON listings include only regular JSON files in lexical order", async t =
   await writeFile(path.join(directory, "a.json"), "{}", "utf8");
   await mkdir(path.join(directory, "directory.json"));
 
-  assert.deepEqual(await listJsonFiles(directory), [
+  assert.deepEqual(await listJsonFiles(directory, { root: fixture.paths.root }), [
     path.join(directory, "a.json"),
     path.join(directory, "b.json"),
   ]);
-  assert.deepEqual(await listJsonFiles(path.join(fixture.root, "missing")), []);
+  assert.deepEqual(await listJsonFiles(fixture.paths.inboxDir("missing"), {
+    root: fixture.paths.root,
+  }), []);
 });
 
 test("atomic moves create the destination directory and remove the source", async t => {
@@ -120,7 +122,7 @@ test("atomic moves create the destination directory and remove the source", asyn
   const destination = fixture.paths.archiveFile("models", "message");
   await writeFile(source, '{"value":1}\n', "utf8");
 
-  await moveFileAtomic(source, destination);
+  await moveFileAtomic(source, destination, { root: fixture.paths.root });
 
   assert.equal(await pathExists(source), false);
   assert.deepEqual(JSON.parse(await readFile(destination, "utf8")), { value: 1 });

--- a/prototype/integrated/tests/tools/agent_comms/atomic-json.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/atomic-json.test.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  listJsonFiles,
+  moveFileAtomic,
+  readJsonStrict,
+  writeJsonAtomic,
+} from "../../../tools/agents/lib/atomic-json.mjs";
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import { createBusFixture, pathExists } from "./helpers.mjs";
+
+test("exclusive writes never replace an immutable record", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const target = path.join(fixture.paths.inbox, "models", "message.json");
+  await writeJsonAtomic(target, { value: 1 }, {
+    tmpDir: fixture.paths.tmp,
+    exclusive: true,
+  });
+
+  await assert.rejects(
+    writeJsonAtomic(target, { value: 2 }, {
+      tmpDir: fixture.paths.tmp,
+      exclusive: true,
+    }),
+    error => error.exitCode === EXIT.CONFLICT,
+  );
+  assert.deepEqual(JSON.parse(await readFile(target, "utf8")), { value: 1 });
+  assert.deepEqual(await listJsonFiles(fixture.paths.tmp), []);
+});
+
+test("mutable writes atomically replace the published value", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const target = fixture.paths.presenceFile("visual");
+  await writeJsonAtomic(target, { heartbeat: 1 }, {
+    tmpDir: fixture.paths.tmp,
+    exclusive: false,
+  });
+  await writeJsonAtomic(target, { heartbeat: 2 }, {
+    tmpDir: fixture.paths.tmp,
+    exclusive: false,
+  });
+
+  assert.deepEqual(JSON.parse(await readFile(target, "utf8")), { heartbeat: 2 });
+});
+
+test("values are serialized exactly once before publication", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  let serializations = 0;
+  const value = {
+    toJSON() {
+      serializations += 1;
+      return { serializations };
+    },
+  };
+
+  await writeJsonAtomic(fixture.paths.protocol, value, {
+    tmpDir: fixture.paths.tmp,
+    exclusive: true,
+  });
+
+  assert.equal(serializations, 1);
+  assert.deepEqual(JSON.parse(await readFile(fixture.paths.protocol, "utf8")), {
+    serializations: 1,
+  });
+});
+
+test("malformed JSON fails the corrupt-data gate", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const target = path.join(fixture.paths.inbox, "broken.json");
+  await writeFile(target, "{not-json", "utf8");
+
+  await assert.rejects(
+    readJsonStrict(target, value => value),
+    error => error.exitCode === EXIT.DATA && error.details.filePath === target,
+  );
+});
+
+test("strict reads return the original validated value", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const target = fixture.paths.protocol;
+  await writeFile(target, '{"schema_version":1}\n', "utf8");
+  let parsed;
+
+  const result = await readJsonStrict(target, value => {
+    parsed = value;
+    return value;
+  });
+
+  assert.equal(result, parsed);
+});
+
+test("JSON listings include only regular JSON files in lexical order", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const directory = fixture.paths.handoffs;
+  await writeFile(path.join(directory, "b.json"), "{}", "utf8");
+  await writeFile(path.join(directory, "ignore.txt"), "{}", "utf8");
+  await writeFile(path.join(directory, "a.json"), "{}", "utf8");
+  await mkdir(path.join(directory, "directory.json"));
+
+  assert.deepEqual(await listJsonFiles(directory), [
+    path.join(directory, "a.json"),
+    path.join(directory, "b.json"),
+  ]);
+  assert.deepEqual(await listJsonFiles(path.join(fixture.root, "missing")), []);
+});
+
+test("atomic moves create the destination directory and remove the source", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const source = path.join(fixture.paths.inbox, "message.json");
+  const destination = fixture.paths.archiveFile("models", "message");
+  await writeFile(source, '{"value":1}\n', "utf8");
+
+  await moveFileAtomic(source, destination);
+
+  assert.equal(await pathExists(source), false);
+  assert.deepEqual(JSON.parse(await readFile(destination, "utf8")), { value: 1 });
+});

--- a/prototype/integrated/tests/tools/agent_comms/attachments.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/attachments.test.mjs
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import { mkdir, symlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import {
+  describeAttachment,
+  verifyAttachment,
+} from "../../../tools/agents/lib/attachments.mjs";
+import { createBusFixture } from "./helpers.mjs";
+
+const COMMIT = "b".repeat(40);
+
+function attachmentContext(fixture) {
+  return {
+    paths: fixture.paths,
+    repoRoot: fixture.repo,
+  };
+}
+
+test("committed repository attachment records actual digest and size", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  await mkdir(path.join(fixture.repo, "docs"));
+  await writeFile(path.join(fixture.repo, "docs/evidence.txt"), "evidence\n");
+
+  assert.deepEqual(
+    await describeAttachment(attachmentContext(fixture), {
+      path: "docs/evidence.txt",
+      ephemeral: false,
+      commit: COMMIT,
+    }),
+    {
+      path: "docs/evidence.txt",
+      sha256: "bdcf4c994585af6dd6cb1cfbff78bcc73ab27dc30a299db5bb83766ca05b5de4",
+      size: 9,
+      ephemeral: false,
+      commit: COMMIT,
+    },
+  );
+});
+
+test("ephemeral artifact records actual digest and size", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  await writeFile(path.join(fixture.paths.artifacts, "render.txt"), "artifact bytes\n");
+
+  assert.deepEqual(
+    await describeAttachment(attachmentContext(fixture), {
+      path: ".agents/artifacts/render.txt",
+      ephemeral: true,
+    }),
+    {
+      path: ".agents/artifacts/render.txt",
+      sha256: "59bd16dfc39e768f82bb8ec74467e571e80ed284683b586f077dbf1aa2483ecd",
+      size: 15,
+      ephemeral: true,
+    },
+  );
+});
+
+test("attachment paths cannot be absolute or escape their allowed root", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const external = path.join(fixture.root, "external.txt");
+  await writeFile(external, "outside\n");
+  const context = attachmentContext(fixture);
+
+  await assert.rejects(
+    describeAttachment(context, { path: external, ephemeral: false }),
+    error => error.exitCode === EXIT.DATA,
+  );
+  await assert.rejects(
+    describeAttachment(context, { path: "../external.txt", ephemeral: false }),
+    error => error.exitCode === EXIT.DATA,
+  );
+});
+
+test("attachment checks the real path before allowing a symlink", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const external = path.join(fixture.root, "external.txt");
+  await writeFile(external, "outside\n");
+  await symlink(external, path.join(fixture.repo, "linked.txt"));
+
+  await assert.rejects(
+    describeAttachment(attachmentContext(fixture), {
+      path: "linked.txt",
+      ephemeral: false,
+    }),
+    error => error.exitCode === EXIT.DATA,
+  );
+});
+
+test("missing attachment is rejected as invalid data", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+
+  await assert.rejects(
+    describeAttachment(attachmentContext(fixture), {
+      path: "docs/missing.txt",
+      ephemeral: false,
+    }),
+    error => error.exitCode === EXIT.DATA,
+  );
+});
+
+test("verification recomputes checksum and byte size", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  await writeFile(path.join(fixture.repo, "evidence.txt"), "evidence\n");
+  const context = attachmentContext(fixture);
+  const valid = await describeAttachment(context, {
+    path: "evidence.txt",
+    ephemeral: false,
+    commit: COMMIT,
+  });
+
+  await verifyAttachment(context, valid);
+  await assert.rejects(
+    verifyAttachment(context, { ...valid, sha256: "0".repeat(64) }),
+    error => error.exitCode === EXIT.DATA,
+  );
+  await assert.rejects(
+    verifyAttachment(context, { ...valid, size: 8 }),
+    error => error.exitCode === EXIT.DATA,
+  );
+});
+
+test("ephemeral attachment cannot claim a commit", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  await writeFile(path.join(fixture.paths.artifacts, "render.txt"), "artifact bytes\n");
+
+  await assert.rejects(
+    describeAttachment(attachmentContext(fixture), {
+      path: ".agents/artifacts/render.txt",
+      ephemeral: true,
+      commit: COMMIT,
+    }),
+    error => error.exitCode === EXIT.DATA,
+  );
+});
+
+test("canonical artifact cannot be described as a committed repository file", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  await writeFile(path.join(fixture.paths.artifacts, "render.txt"), "artifact bytes\n");
+  const context = {
+    paths: fixture.paths,
+    repoRoot: fixture.root,
+  };
+
+  await assert.rejects(
+    describeAttachment(context, {
+      path: ".agents/artifacts/render.txt",
+      ephemeral: false,
+      commit: COMMIT,
+    }),
+    error => error.exitCode === EXIT.DATA,
+  );
+});
+
+test("repository symlink into artifacts remains ephemeral", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const artifact = path.join(fixture.paths.artifacts, "render.txt");
+  await writeFile(artifact, "artifact bytes\n");
+  await symlink(artifact, path.join(fixture.root, "linked-artifact.txt"));
+  const context = {
+    paths: fixture.paths,
+    repoRoot: fixture.root,
+  };
+
+  await assert.rejects(
+    describeAttachment(context, {
+      path: "linked-artifact.txt",
+      ephemeral: false,
+      commit: COMMIT,
+    }),
+    error => error.exitCode === EXIT.DATA,
+  );
+});

--- a/prototype/integrated/tests/tools/agent_comms/claims-integrity.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/claims-integrity.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { claimScope, extendClaims, releaseScope }
+  from "../../../tools/agents/lib/claims.mjs";
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import { validateClaim } from "../../../tools/agents/lib/schema.mjs";
+import { createBusFixture, seedOpenAgent } from "./helpers.mjs";
+
+async function setup(t) {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const context = { ...fixture.context, pid: 4242, pidIsAlive: () => false,
+    randomUUID: () => "00000000-0000-4000-8000-000000000001" };
+  await seedOpenAgent(context, { agentId: "visual", task: "M2.7" });
+  const claim = validateClaim({ schema_version: 1, agent_id: "visual", task: "M2.7",
+    scope: "game/presentation", reason: "camera", created_at: context.now().toISOString(),
+    updated_at: context.now().toISOString(),
+    expires_at: new Date(context.now().getTime() + 60_000).toISOString() });
+  const canonical = path.join(context.paths.claims,
+    `${createHash("sha256").update(claim.scope).digest("hex")}.json`);
+  const wrong = path.join(context.paths.claims, "wrong-name.json");
+  const bytes = `${JSON.stringify(claim)}\n`;
+  await Promise.all([writeFile(canonical, bytes), writeFile(wrong, bytes)]);
+  return { context, canonical, wrong, bytes };
+}
+
+for (const [name, mutate] of [
+  ["claim", context => claimScope(context,
+    { agentId: "visual", scope: "game/presentation", reason: "renew" })],
+  ["release", context => releaseScope(context,
+    { agentId: "visual", scope: "game/presentation" })],
+  ["extend", context => extendClaims(context, "visual")],
+]) test(`${name} rejects duplicate scope and wrong digest before mutation`, async t => {
+  const { context, canonical, wrong, bytes } = await setup(t);
+  await assert.rejects(mutate(context), error => error.exitCode === EXIT.DATA);
+  assert.equal(await readFile(canonical, "utf8"), bytes);
+  assert.equal(await readFile(wrong, "utf8"), bytes);
+});

--- a/prototype/integrated/tests/tools/agent_comms/claims-recovery-replay.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/claims-recovery-replay.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { writeJsonAtomic } from "../../../tools/agents/lib/atomic-json.mjs";
+import { claimScope, forceReleaseStaleScope, repairStaleClaimLock }
+  from "../../../tools/agents/lib/claims.mjs";
+import { validateProtocol } from "../../../tools/agents/lib/schema.mjs";
+import { runDoctor } from "../../../tools/agents/lib/status.mjs";
+import { createBusFixture, pathExists, seedOpenAgent } from "./helpers.mjs";
+
+async function setup(t) {
+  const fixture = await createBusFixture(); t.after(fixture.cleanup);
+  const context = { ...fixture.context, pid: 4242, pidIsAlive: pid => pid === 4242,
+    randomUUID: (() => { let value = 1; return () =>
+      `11111111-1111-4111-8111-${String(value++).padStart(12, "0")}`; })(),
+    randomMutexUUID: () => "22222222-2222-4222-8222-222222222222" };
+  await Promise.all([
+    seedOpenAgent(context, { agentId: "visual", task: "M2.7" }),
+    seedOpenAgent(context, { agentId: "models", task: "M2.7" }),
+    seedOpenAgent(context, { agentId: "ops", role: "orchestrator", task: "M2.7" }),
+  ]);
+  await writeJsonAtomic(context.paths.protocol, validateProtocol({ schema_version: 1,
+    protocol_version: 1, checkout_id: "c".repeat(64), checkout_root: fixture.root,
+    initialized_at: context.now().toISOString() }),
+  { tmpDir: context.paths.tmp, exclusive: true });
+  return { ...fixture, context };
+}
+function lockOwner(context, overrides = {}) {
+  return { schema_version: 1, owner_agent: "visual", pid: 9999,
+    acquired_at: new Date(context.now().getTime() - 60_001).toISOString(), ...overrides };
+}
+async function seedClaimLock(context, owner = lockOwner(context)) {
+  const directory = path.join(context.paths.locks, "claims.lock");
+  await mkdir(directory);
+  await writeJsonAtomic(path.join(directory, "owner.json"), owner,
+    { tmpDir: context.paths.tmp, exclusive: true });
+  return directory;
+}
+async function seedStaleClaim(context) {
+  await claimScope(context, { agentId: "visual", scope: "game/presentation",
+    reason: "camera", leaseSeconds: 60 });
+  const claimPath = path.join(context.paths.claims, (await readdir(context.paths.claims))[0]);
+  const claim = JSON.parse(await readFile(claimPath));
+  const stale = { ...claim, expires_at: new Date(context.now().getTime() - 1).toISOString() };
+  await writeJsonAtomic(claimPath, stale, { tmpDir: context.paths.tmp, exclusive: false });
+  return { claimPath, stale };
+}
+function crash(message) { return Object.assign(new Error(message), { code: "SYNTHETIC_CRASH" }); }
+
+test("doctor replays stale claim-lock rename after immutable audit publication", async t => {
+  const { context } = await setup(t); const active = await seedClaimLock(context);
+  const killed = crash("kill after claim-lock audit publication");
+  await assert.rejects(repairStaleClaimLock({ ...context,
+    renameClaimLock: async () => { throw killed; } }), killed);
+  assert.equal((await readdir(context.paths.quarantine))
+    .filter(name => name.startsWith("claims-audit-")).length, 1);
+
+  const report = await runDoctor(context, { repair: true });
+
+  assert.equal(report.repairs.some(item => item.action === "repair_stale_claim_lock"), true);
+  assert.equal(await pathExists(active), false);
+  assert.equal(report.ok, true);
+});
+
+test("pending claim-lock audit never moves a replacement owner generation", async t => {
+  const { context } = await setup(t); const active = await seedClaimLock(context);
+  const killed = crash("kill after claim-lock audit publication");
+  await assert.rejects(repairStaleClaimLock({ ...context,
+    renameClaimLock: async () => { throw killed; } }), killed);
+  const replacement = lockOwner(context, { owner_agent: "models", pid: 4242,
+    acquired_at: context.now().toISOString() });
+  await writeJsonAtomic(path.join(active, "owner.json"), replacement,
+    { tmpDir: context.paths.tmp, exclusive: false });
+
+  const report = await runDoctor(context, { repair: true });
+
+  assert.equal(report.ok, false); assert.equal(report.repairs.length, 0);
+  assert.deepEqual(JSON.parse(await readFile(path.join(active, "owner.json"))), replacement);
+});
+
+test("doctor replays force-release unlink after immutable audit publication", async t => {
+  const { context } = await setup(t); const { claimPath } = await seedStaleClaim(context);
+  const killed = crash("kill after force-release audit publication");
+  await assert.rejects(forceReleaseStaleScope({ ...context,
+    unlinkClaimRecord: async () => { throw killed; } }, { agentId: "ops",
+    ownerAgent: "visual", scope: "game/presentation" }), killed);
+  const pending = await runDoctor(context, {});
+  assert.equal(pending.ok, false);
+  assert.equal(pending.issues.some(item => item.code === "PENDING_FORCE_RELEASE"), true);
+
+  const report = await runDoctor(context, { repair: true });
+
+  assert.equal(report.repairs.some(item => item.action === "complete_pending_force_release"), true);
+  assert.equal(await pathExists(claimPath), false);
+  assert.equal(report.ok, true);
+});
+
+test("pending force-release audit never unlinks a replacement claim generation", async t => {
+  const { context } = await setup(t); const { claimPath, stale } = await seedStaleClaim(context);
+  const killed = crash("kill after force-release audit publication");
+  await assert.rejects(forceReleaseStaleScope({ ...context,
+    unlinkClaimRecord: async () => { throw killed; } }, { agentId: "ops",
+    ownerAgent: "visual", scope: "game/presentation" }), killed);
+  const replacement = { ...stale, agent_id: "models", task: "M2.7", reason: "replacement",
+    created_at: context.now().toISOString(), updated_at: context.now().toISOString(),
+    expires_at: new Date(context.now().getTime() + 60_000).toISOString() };
+  await writeJsonAtomic(claimPath, replacement, { tmpDir: context.paths.tmp, exclusive: false });
+
+  const report = await runDoctor(context, { repair: true });
+
+  assert.equal(report.ok, false); assert.equal(report.repairs.length, 0);
+  assert.deepEqual(JSON.parse(await readFile(claimPath)), replacement);
+});

--- a/prototype/integrated/tests/tools/agent_comms/claims.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/claims.test.mjs
@@ -1,0 +1,299 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { claimScope, extendClaims, forceReleaseStaleScope, normalizeScope,
+  releaseOwnedClaims, releaseScope, repairStaleClaimLock, scopesOverlap,
+} from "../../../tools/agents/lib/claims.mjs";
+import { writeJsonAtomic } from "../../../tools/agents/lib/atomic-json.mjs";
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import { createBusFixture, pathExists, seedOpenAgent } from "./helpers.mjs";
+const lockDir = context => path.join(context.paths.locks, "claims.lock");
+const lockOwnerFile = context => path.join(lockDir(context), "owner.json");
+async function fixtureFor(t, agents = [{ agentId: "visual" }, { agentId: "models" }]) {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const context = {
+    ...fixture.context, pid: 4242, pidIsAlive: () => false,
+    randomUUID: (() => {
+      let index = 0;
+      return () => `00000000-0000-4000-8000-${String(++index).padStart(12, "0")}`;
+    })(),
+  };
+  await Promise.all(agents.map(agent => seedOpenAgent(context, { task: "M2.7", ...agent })));
+  return { ...fixture, context };
+}
+async function claimFiles(context) {
+  return (await readdir(context.paths.claims)).filter(name => name.endsWith(".json"));
+}
+async function claims(context) {
+  return Promise.all((await claimFiles(context)).map(async name => JSON.parse(
+    await readFile(path.join(context.paths.claims, name), "utf8"),
+  )));
+}
+async function auditFiles(context) {
+  return (await readdir(context.paths.quarantine))
+    .filter(name => name.startsWith("claims-audit-")).sort();
+}
+async function seedLock(context, { agent = "visual", pid = 1234, acquiredAt } = {}) {
+  await mkdir(lockDir(context));
+  const record = {
+    schema_version: 1, owner_agent: agent, pid,
+    acquired_at: acquiredAt ?? context.now().toISOString(),
+  };
+  await writeFile(lockOwnerFile(context), `${JSON.stringify(record, null, 2)}\n`);
+  return record;
+}
+function deferred() {
+  let resolve; const promise = new Promise(done => { resolve = done; });
+  return { promise, resolve };
+}
+test("path overlap uses segments rather than string prefixes", () => {
+  assert.equal(scopesOverlap("game/presentation", "game/presentation/camera"), true);
+  assert.equal(scopesOverlap("game/presentation", "game/presentations"), false);
+  assert.deepEqual(normalizeScope("game/presentation"), {
+    kind: "path", value: "game/presentation",
+  });
+});
+test("named contracts overlap only on exact normalized name", () => {
+  assert.equal(scopesOverlap(
+    "contract:tank-registration-v1", "contract:tank-registration-v1",
+  ), true);
+  assert.equal(scopesOverlap(
+    "contract:tank-registration-v1", "contract:tank-registration-v2",
+  ), false);
+  assert.deepEqual(normalizeScope("contract:tank-registration-v1"), {
+    kind: "contract", value: "tank-registration-v1",
+  });
+});
+test("trailing slash normalizes and same-agent renewal stays one claim", async t => {
+  const fixture = await fixtureFor(t);
+  const first = await claimScope(fixture.context, {
+    agentId: "visual", scope: "game/presentation/", reason: "camera", leaseSeconds: 10,
+  });
+  fixture.clock.advance(2_000);
+  const renewed = await claimScope(fixture.context, {
+    agentId: "visual", scope: "game/presentation", reason: "camera", leaseSeconds: 20,
+  });
+  assert.equal((await claimFiles(fixture.context)).length, 1);
+  assert.equal(first.scope, "game/presentation");
+  assert.equal(renewed.created_at, first.created_at);
+  assert.equal(renewed.updated_at, "2026-08-14T18:00:02.000Z");
+  assert.equal(renewed.expires_at, "2026-08-14T18:00:22.000Z");
+});
+test("overlapping claim by another agent is a conflict with exit code five", async t => {
+  const fixture = await fixtureFor(t);
+  await claimScope(fixture.context, {
+    agentId: "visual", scope: "game/presentation", reason: "camera",
+  });
+  await assert.rejects(claimScope(fixture.context, {
+    agentId: "models", scope: "game/presentation/camera", reason: "rig",
+  }), error => error.exitCode === EXIT.CONFLICT && error.details.owner === "visual");
+  assert.deepEqual((await claims(fixture.context)).map(record => record.agent_id), ["visual"]);
+});
+test("an expired claim remains unavailable until explicitly released", async t => {
+  const fixture = await fixtureFor(t);
+  await claimScope(fixture.context, {
+    agentId: "visual", scope: "game/presentation", reason: "camera", leaseSeconds: 1,
+  });
+  fixture.clock.advance(1_001);
+  await assert.rejects(claimScope(fixture.context, {
+    agentId: "models", scope: "game/presentation", reason: "rig",
+  }), error => error.exitCode === EXIT.CONFLICT);
+  assert.equal((await claims(fixture.context))[0].agent_id, "visual");
+});
+test("watcher extension renews every claim owned by its agent", async t => {
+  const fixture = await fixtureFor(t);
+  await claimScope(fixture.context, {
+    agentId: "visual", scope: "game/presentation", reason: "camera", leaseSeconds: 1,
+  });
+  await claimScope(fixture.context, {
+    agentId: "visual", scope: "contract:tank-registration-v1", reason: "contract",
+  });
+  fixture.clock.advance(2_000);
+  const extended = await extendClaims(fixture.context, "visual");
+  assert.equal(extended.length, 2);
+  assert.deepEqual(extended.map(record => record.updated_at), [
+    "2026-08-14T18:00:02.000Z", "2026-08-14T18:00:02.000Z",
+  ]);
+  assert.deepEqual(extended.map(record => record.expires_at), [
+    "2026-08-14T18:30:02.000Z", "2026-08-14T18:30:02.000Z",
+  ]);
+});
+test("ordinary release is owner-only", async t => {
+  const fixture = await fixtureFor(t);
+  await claimScope(fixture.context, {
+    agentId: "visual", scope: "game/presentation", reason: "camera",
+  });
+  await assert.rejects(releaseScope(fixture.context, {
+    agentId: "models", scope: "game/presentation",
+  }), error => error.exitCode === EXIT.CONFLICT);
+  assert.equal((await claimFiles(fixture.context)).length, 1);
+  assert.equal((await releaseScope(fixture.context, {
+    agentId: "visual", scope: "game/presentation",
+  })).agent_id, "visual");
+  assert.equal((await claimFiles(fixture.context)).length, 0);
+});
+test("owner-scoped close release cannot remove another agent claims", async t => {
+  const fixture = await fixtureFor(t);
+  for (const scope of ["game/presentation", "contract:tank-registration-v1"]) {
+    await claimScope(fixture.context, { agentId: "visual", scope, reason: "work" });
+  }
+  await claimScope(fixture.context, {
+    agentId: "models", scope: "game/models", reason: "mesh",
+  });
+  const released = await releaseOwnedClaims(fixture.context, "visual");
+  assert.equal(released.length, 2);
+  assert.deepEqual((await claims(fixture.context)).map(record => record.agent_id), ["models"]);
+});
+test("orchestrator force-releases only a stale foreign claim and audits first", async t => {
+  const fixture = await fixtureFor(t, [
+    { agentId: "visual" }, { agentId: "ops", role: "orchestrator" },
+  ]);
+  await claimScope(fixture.context, {
+    agentId: "visual", scope: "game/presentation", reason: "camera", leaseSeconds: 1,
+  });
+  fixture.clock.advance(1_001);
+  const released = await forceReleaseStaleScope(fixture.context, {
+    agentId: "ops", ownerAgent: "visual", scope: "game/presentation",
+  });
+  assert.equal(released.agent_id, "visual");
+  assert.equal((await claimFiles(fixture.context)).length, 0);
+  const audits = await auditFiles(fixture.context);
+  assert.equal(audits.length, 1);
+  const auditPath = path.join(fixture.context.paths.quarantine, audits[0]);
+  const before = await readFile(auditPath, "utf8");
+  assert.equal(JSON.parse(before).action, "force_release_stale_claim");
+  await assert.rejects(forceReleaseStaleScope(fixture.context, {
+    agentId: "ops", ownerAgent: "visual", scope: "game/presentation",
+  }), error => error.exitCode === EXIT.CONFLICT);
+  assert.equal(await readFile(auditPath, "utf8"), before);
+});
+test("force release rejects non-orchestrators and active claims without audit", async t => {
+  const fixture = await fixtureFor(t, [
+    { agentId: "visual" }, { agentId: "models" },
+    { agentId: "ops", role: "orchestrator" },
+  ]);
+  await claimScope(fixture.context, {
+    agentId: "visual", scope: "game/presentation", reason: "camera",
+  });
+  for (const agentId of ["models", "ops"]) {
+    await assert.rejects(forceReleaseStaleScope(fixture.context, {
+      agentId, ownerAgent: "visual", scope: "game/presentation",
+    }), error => error.exitCode === EXIT.CONFLICT);
+  }
+  assert.equal((await claimFiles(fixture.context)).length, 1);
+  assert.deepEqual(await auditFiles(fixture.context), []);
+});
+test("a pre-existing atomic mkdir lock rejects contention without changing owner", async t => {
+  const fixture = await fixtureFor(t);
+  await seedLock(fixture.context);
+  const before = await readFile(lockOwnerFile(fixture.context), "utf8");
+  await assert.rejects(claimScope(fixture.context, {
+    agentId: "visual", scope: "game/presentation", reason: "camera",
+  }), error => error.exitCode === EXIT.CONFLICT);
+  assert.equal(await readFile(lockOwnerFile(fixture.context), "utf8"), before);
+});
+test("published owner cleanup preserves the original acquisition error", async t => {
+  const fixture = await fixtureFor(t);
+  const failure = new Error("fsync cleanup failed after publish");
+  const context = {
+    ...fixture.context,
+    writeClaimLockOwner: async (...args) => {
+      await writeJsonAtomic(...args);
+      throw failure;
+    },
+  };
+  await assert.rejects(claimScope(context, {
+    agentId: "visual", scope: "game/presentation", reason: "camera",
+  }), error => error === failure);
+  assert.equal(await pathExists(lockDir(context)), false);
+  assert.deepEqual(await claimFiles(context), []);
+});
+test("repair never removes a live lock or a dead lock at most sixty seconds old", async t => {
+  for (const item of [
+    { live: true, age: 60_001 },
+    { live: false, age: 60_000 },
+  ]) {
+    const fixture = await fixtureFor(t);
+    const acquiredAt = new Date(fixture.context.now().getTime() - item.age).toISOString();
+    await seedLock(fixture.context, { acquiredAt });
+    const context = { ...fixture.context, pidIsAlive: () => item.live };
+    assert.equal(await repairStaleClaimLock(context), false);
+    assert.equal(await pathExists(lockDir(context)), true);
+    assert.deepEqual(await auditFiles(context), []);
+  }
+});
+test("repair audits a dead lock older than sixty seconds before removing it", async t => {
+  const fixture = await fixtureFor(t);
+  await seedLock(fixture.context, {
+    acquiredAt: new Date(fixture.context.now().getTime() - 60_001).toISOString(),
+  });
+  assert.equal(await repairStaleClaimLock(fixture.context), true);
+  assert.equal(await pathExists(lockDir(fixture.context)), false);
+  const audits = await auditFiles(fixture.context);
+  assert.equal(audits.length, 1);
+  assert.equal(JSON.parse(await readFile(
+    path.join(fixture.context.paths.quarantine, audits[0]), "utf8",
+  )).action, "repair_stale_claim_lock");
+});
+test("delayed second repair cannot quarantine a replacement live lock", {
+  timeout: 1_000,
+}, async t => {
+  const fixture = await fixtureFor(t);
+  await seedLock(fixture.context, {
+    acquiredAt: new Date(fixture.context.now().getTime() - 60_001).toISOString(),
+  });
+  const secondAtRename = deferred(), firstRenamed = deferred(), releaseSecond = deferred();
+  let renameCount = 0;
+  const context = { ...fixture.context, renameClaimLock: async (source, destination) => {
+    renameCount += 1;
+    if (renameCount === 1) {
+      await secondAtRename.promise;
+      await rename(source, destination);
+      firstRenamed.resolve();
+      return;
+    }
+    secondAtRename.resolve();
+    await releaseSecond.promise;
+    await rename(source, destination);
+  } };
+  const repairs = [repairStaleClaimLock(context), repairStaleClaimLock(context)];
+  await firstRenamed.promise;
+  const replacement = await seedLock(context, { agent: "models", pid: 9999 });
+  releaseSecond.resolve();
+  assert.deepEqual((await Promise.all(repairs)).sort(), [false, true]);
+  assert.deepEqual(JSON.parse(await readFile(lockOwnerFile(context), "utf8")), replacement);
+  const staleDirs = (await readdir(context.paths.quarantine, { withFileTypes: true }))
+    .filter(entry => entry.isDirectory() && entry.name.startsWith("claims-lock-stale-"));
+  assert.equal(staleDirs.length, 1);
+  assert.equal(JSON.parse(await readFile(path.join(
+    context.paths.quarantine, staleDirs[0].name, "owner.json",
+  ), "utf8")).owner_agent, "visual");
+});
+test("failed repair audit leaves the stale lock in place", async t => {
+  const fixture = await fixtureFor(t);
+  await seedLock(fixture.context, {
+    acquiredAt: new Date(fixture.context.now().getTime() - 60_001).toISOString(),
+  });
+  await rm(fixture.context.paths.quarantine, { recursive: true });
+  await writeFile(fixture.context.paths.quarantine, "not a directory");
+  await assert.rejects(repairStaleClaimLock(fixture.context));
+  assert.equal(await pathExists(lockDir(fixture.context)), true);
+  assert.equal(await pathExists(lockOwnerFile(fixture.context)), true);
+});
+test("failed immutable audit leaves the stale claim in place", async t => {
+  const fixture = await fixtureFor(t, [
+    { agentId: "visual" }, { agentId: "ops", role: "orchestrator" },
+  ]);
+  await claimScope(fixture.context, {
+    agentId: "visual", scope: "game/presentation", reason: "camera", leaseSeconds: 1,
+  });
+  fixture.clock.advance(1_001);
+  await rm(fixture.context.paths.quarantine, { recursive: true });
+  await writeFile(fixture.context.paths.quarantine, "not a directory");
+  await assert.rejects(forceReleaseStaleScope(fixture.context, {
+    agentId: "ops", ownerAgent: "visual", scope: "game/presentation",
+  }));
+  assert.equal((await claimFiles(fixture.context)).length, 1);
+});

--- a/prototype/integrated/tests/tools/agent_comms/cli-round1.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/cli-round1.test.mjs
@@ -12,6 +12,7 @@ import { createGitWorktreeFixture, pathExists, runCli, startCli } from "./helper
 const delay = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds));
 const WATCHER_READY_TIMEOUT_MS = 10_000;
 const WATCHER_POLL_MS = 5;
+const STDIN_LIVENESS_TIMEOUT_MS = 30_000;
 
 function describeChild(child, prefix) {
   return `${prefix}; stdout=${JSON.stringify(child.collected.stdout)}`
@@ -33,7 +34,7 @@ async function waitForWatcherOnline(fixture, child, agentId) {
       assert.fail(describeChild(child, `watcher exited before publishing ownership: ${JSON.stringify(exit)}`));
     }
     if (await pathExists(ownership)) {
-      const record = await readJsonStrict(presence, validatePresence)
+      const record = await readJsonStrict(presence, validatePresence, fixture.bus)
         .catch(error => { if (error.code === "ENOENT") return null; throw error; });
       if (record?.status === "online" && record.pid === child.pid) return record;
     }
@@ -50,16 +51,28 @@ async function bootstrap(fixture) {
   }
 }
 
-async function openStdinResult(child) {
+// The property under test is liveness -- the command must not read stdin -- not
+// latency. A command that truly waits on an unclosed stdin blocks forever, so a
+// generous ceiling still catches it, while a short race deadline only converts
+// ordinary scheduling delay under parallel load into a false failure.
+async function openStdinResult(child, argv) {
   const exited = new Promise((resolve, reject) => {
     child.once("error", reject);
     child.once("close", (code, signal) => resolve({ code, signal }));
   });
-  const result = await Promise.race([exited, delay(300).then(() => null)]);
+  // Promise.race does not cancel the loser: an uncleared ceiling timer would
+  // keep the runner alive for its full duration after the child already exited.
+  let ceiling;
+  const expired = new Promise(resolve => {
+    ceiling = setTimeout(resolve, STDIN_LIVENESS_TIMEOUT_MS, null);
+  });
+  const result = await Promise.race([exited, expired]);
+  clearTimeout(ceiling);
   if (result !== null) return result;
   child.kill("SIGKILL");
   await exited;
-  assert.fail("command waited for stdin despite an explicit body source");
+  assert.fail(describeChild(child, `${argv[0]} waited for stdin for `
+    + `${STDIN_LIVENESS_TIMEOUT_MS}ms despite an explicit body source`));
 }
 
 test("explicit body sources let send broadcast and reply exit with stdin left open", async t => {
@@ -83,7 +96,7 @@ test("explicit body sources let send broadcast and reply exit with stdin left op
       "--subject", "reply", "--body-file", "body.txt"],
   ];
   for (const argv of commands) {
-    const result = await openStdinResult(startCli(fixture, argv, { cwd: fixture.worktree }));
+    const result = await openStdinResult(startCli(fixture, argv, { cwd: fixture.worktree }), argv);
     assert.equal(result.code, 0, `${argv[0]} did not exit cleanly`);
   }
 });
@@ -132,7 +145,8 @@ test("a latched startup signal stops the watcher after publication", async t => 
   assert.equal(await runWithSignals(["register", "--id", "visual", "--role", "artist", "--task", "M2.7"],
     runtime, signals), 0);
   assert.equal(await runWithSignals(["watch", "--id", "visual"], runtime, signals), 0);
-  const presence = await readJsonStrict(`${fixture.bus}/presence/visual.json`, validatePresence);
+  const presence = await readJsonStrict(`${fixture.bus}/presence/visual.json`, validatePresence,
+    fixture.bus);
   assert.equal(presence.status, "offline");
 });
 

--- a/prototype/integrated/tests/tools/agent_comms/cli-round1.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/cli-round1.test.mjs
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { readFile, readdir, writeFile } from "node:fs/promises";
+import { PassThrough, Readable } from "node:stream";
+import test from "node:test";
+
+import { runWithSignals } from "../../../tools/agents/comms.mjs";
+import { readJsonStrict } from "../../../tools/agents/lib/atomic-json.mjs";
+import { validatePresence } from "../../../tools/agents/lib/schema.mjs";
+import { createGitWorktreeFixture, pathExists, runCli, startCli } from "./helpers.mjs";
+
+const delay = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds));
+const WATCHER_READY_TIMEOUT_MS = 10_000;
+const WATCHER_POLL_MS = 5;
+
+function describeChild(child, prefix) {
+  return `${prefix}; stdout=${JSON.stringify(child.collected.stdout)}`
+    + `; stderr=${JSON.stringify(child.collected.stderr)}`;
+}
+
+// The watcher installs its signal handlers before it publishes ownership, so an
+// online presence record owned by this exact child proves the handler is armed.
+// A fixed startup sleep does not: the child dies from the default SIGTERM
+// disposition whenever the machine is slower than the guessed delay.
+async function waitForWatcherOnline(fixture, child, agentId) {
+  const ownership = `${fixture.bus}/locks/watcher-${agentId}.json`;
+  const presence = `${fixture.bus}/presence/${agentId}.json`;
+  let exit = null;
+  child.once("close", (code, signal) => { exit = { code, signal }; });
+  const deadline = Date.now() + WATCHER_READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (exit !== null) {
+      assert.fail(describeChild(child, `watcher exited before publishing ownership: ${JSON.stringify(exit)}`));
+    }
+    if (await pathExists(ownership)) {
+      const record = await readJsonStrict(presence, validatePresence)
+        .catch(error => { if (error.code === "ENOENT") return null; throw error; });
+      if (record?.status === "online" && record.pid === child.pid) return record;
+    }
+    await delay(WATCHER_POLL_MS);
+  }
+  assert.fail(describeChild(child, `watcher did not come online within ${WATCHER_READY_TIMEOUT_MS}ms`));
+}
+
+async function bootstrap(fixture) {
+  for (const argv of [["init"], ["register", "--id", "visual", "--role", "orchestrator", "--task", "M2.7"],
+    ["register", "--id", "models", "--role", "artist", "--task", "M2.7"]]) {
+    const result = await runCli(fixture, argv, { cwd: fixture.worktree });
+    assert.equal(result.code, 0, result.stderr);
+  }
+}
+
+async function openStdinResult(child) {
+  const exited = new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code, signal) => resolve({ code, signal }));
+  });
+  const result = await Promise.race([exited, delay(300).then(() => null)]);
+  if (result !== null) return result;
+  child.kill("SIGKILL");
+  await exited;
+  assert.fail("command waited for stdin despite an explicit body source");
+}
+
+test("explicit body sources let send broadcast and reply exit with stdin left open", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  await bootstrap(fixture);
+  await writeFile(`${fixture.worktree}/body.txt`, "from file");
+  const original = await runCli(fixture, ["send", "--from", "visual", "--to", "models", "--type",
+    "question", "--severity", "info", "--subject", "original", "--body", "source", "--json"],
+  { cwd: fixture.worktree });
+  const message = JSON.parse(original.stdout);
+  const base = ["--from", "visual", "--to", "models", "--type", "status", "--severity", "info",
+    "--subject", "open-stdin"];
+  const commands = [
+    ["send", ...base, "--body", "inline"], ["send", ...base, "--body-file", "body.txt"],
+    ["broadcast", "--from", "visual", "--severity", "info", "--subject", "broadcast", "--body", "inline"],
+    ["broadcast", "--from", "visual", "--severity", "info", "--subject", "broadcast", "--body-file", "body.txt"],
+    ["reply", "--from", "models", "--message", message.id, "--type", "status", "--severity", "info",
+      "--subject", "reply", "--body", "inline"],
+    ["reply", "--from", "models", "--message", message.id, "--type", "status", "--severity", "info",
+      "--subject", "reply", "--body-file", "body.txt"],
+  ];
+  for (const argv of commands) {
+    const result = await openStdinResult(startCli(fixture, argv, { cwd: fixture.worktree }));
+    assert.equal(result.code, 0, `${argv[0]} did not exit cleanly`);
+  }
+});
+
+test("successful human output is human text rather than JSON", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  const result = await runCli(fixture, ["init"], { cwd: fixture.worktree });
+  assert.equal(result.code, 0);
+  assert.equal(result.stdout, "agent bus initialized\n");
+  assert.equal(result.stderr, "");
+  assert.equal(result.stdout.includes("{"), false);
+});
+
+test("force-stale release requires an orchestrator and releases the named stale owner", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  await bootstrap(fixture);
+  const claimed = await runCli(fixture, ["claim", "--id", "models", "--scope", "game/models",
+    "--reason", "mesh"], { cwd: fixture.worktree });
+  assert.equal(claimed.code, 0, claimed.stderr);
+  const claimFile = `${fixture.bus}/claims/${(await readdir(`${fixture.bus}/claims`))[0]}`;
+  const stale = JSON.parse(await readFile(claimFile, "utf8"));
+  stale.expires_at = "2020-01-01T00:00:00.000Z";
+  await writeFile(claimFile, `${JSON.stringify(stale)}\n`);
+  const denied = await runCli(fixture, ["release", "--id", "models", "--scope", "game/models",
+    "--force-stale", "--owner", "models"], { cwd: fixture.worktree });
+  assert.equal(denied.code, 5);
+  const released = await runCli(fixture, ["release", "--id", "visual", "--scope", "game/models",
+    "--force-stale", "--owner", "models"], { cwd: fixture.worktree });
+  assert.equal(released.code, 0, released.stderr);
+  assert.equal(released.stdout, "released game/models\n");
+});
+
+test("a latched startup signal stops the watcher after publication", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  const signals = new EventEmitter();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const runtime = { cwd: fixture.worktree, env: { PW2_AGENT_BUS_DIR: fixture.bus }, stdin: Readable.from([]), stdout,
+    stderr, pid: 1234, pidIsAlive: () => true,
+    watchDirectory: () => ({ close() {}, once() {} }),
+    beforeWatcherPublish: async () => { signals.emit("SIGTERM"); } };
+  assert.equal(await runWithSignals(["init"], runtime, signals), 0);
+  assert.equal(await runWithSignals(["register", "--id", "visual", "--role", "artist", "--task", "M2.7"],
+    runtime, signals), 0);
+  assert.equal(await runWithSignals(["watch", "--id", "visual"], runtime, signals), 0);
+  const presence = await readJsonStrict(`${fixture.bus}/presence/visual.json`, validatePresence);
+  assert.equal(presence.status, "offline");
+});
+
+test("SIGTERM is accepted by the executable watcher lifecycle", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  await bootstrap(fixture);
+  const watch = startCli(fixture, ["watch", "--id", "models", "--scan-interval", "0.01"],
+    { cwd: fixture.worktree });
+  watch.stdin.end();
+  await waitForWatcherOnline(fixture, watch, "models");
+  watch.kill("SIGTERM");
+  const outcome = await new Promise(resolve =>
+    watch.once("close", (code, signal) => resolve({ code, signal })));
+  assert.deepEqual(outcome, { code: 0, signal: null },
+    describeChild(watch, `watcher did not stop gracefully: ${JSON.stringify(outcome)}`));
+  assert.equal(watch.collected.stdout, "");
+});

--- a/prototype/integrated/tests/tools/agent_comms/combined-hardening-doctor.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/combined-hardening-doctor.test.mjs
@@ -1,0 +1,179 @@
+// Combined regressions 9-11 from docs/MIGRATION.md. The 0004 recovery audits
+// are exercised on top of the 0003 managed-root storage, which is where the
+// reconciliation risk lives: the archived scanners were written against the
+// pre-storage read signatures.
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { link, mkdir, readFile, readdir, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { writeJsonAtomic } from "../../../tools/agents/lib/atomic-json.mjs";
+import { repairStaleClaimLock } from "../../../tools/agents/lib/claims.mjs";
+import { markSeen, sendMessage } from "../../../tools/agents/lib/messages.mjs";
+import { repairStaleRepairMutex } from "../../../tools/agents/lib/repair-mutex.mjs";
+import { validateProtocol } from "../../../tools/agents/lib/schema.mjs";
+import { runDoctor } from "../../../tools/agents/lib/status.mjs";
+import { createBusFixture, messageRequest, pathExists, seedOpenAgent } from "./helpers.mjs";
+
+const STALE_MS = 60_001;
+
+async function setup(t) {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const context = { ...fixture.context, pid: 4242, pidIsAlive: pid => pid === 4242,
+    randomUUID: (() => { let value = 1; return () =>
+      `11111111-1111-4111-8111-${String(value++).padStart(12, "0")}`; })(),
+    randomMutexUUID: () => "22222222-2222-4222-8222-222222222222" };
+  await Promise.all(["visual", "models"].map(agentId =>
+    seedOpenAgent(context, { agentId, task: "M2.7" })));
+  await writeJsonAtomic(context.paths.protocol, validateProtocol({ schema_version: 1,
+    protocol_version: 1, checkout_id: "c".repeat(64), checkout_root: fixture.root,
+    initialized_at: context.now().toISOString() }),
+  { tmpDir: context.paths.tmp, exclusive: true });
+  return { ...fixture, context };
+}
+
+function crash(message) { return Object.assign(new Error(message), { code: "SYNTHETIC_CRASH" }); }
+
+async function seedClaimLock(context) {
+  const directory = path.join(context.paths.locks, "claims.lock");
+  await mkdir(directory);
+  await writeJsonAtomic(path.join(directory, "owner.json"), { schema_version: 1,
+    owner_agent: "visual", pid: 9999,
+    acquired_at: new Date(context.now().getTime() - STALE_MS).toISOString() },
+  { tmpDir: context.paths.tmp, exclusive: true });
+  return directory;
+}
+
+async function seedMutex(context) {
+  const directory = path.join(context.paths.locks, "watcher-models.lock");
+  await mkdir(directory);
+  await writeJsonAtomic(path.join(directory, "owner.json"), { schema_version: 1,
+    kind: "watcher", agent_id: "models", pid: 9999,
+    token: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    acquired_at: new Date(context.now().getTime() - STALE_MS).toISOString() },
+  { tmpDir: context.paths.tmp, exclusive: true });
+  return directory;
+}
+
+// A record doctor would otherwise quarantine, used to prove that one corrupt
+// recovery artifact blocks repairs that have nothing to do with it.
+async function unrelatedCorruptRecord(context) {
+  const file = context.paths.inboxFile("models", "00000000-0000-4000-8000-000000000009");
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFile(file, "{not-json");
+  return file;
+}
+
+test("10: a crash after claim-lock audit publication replays exactly once", async t => {
+  const { context } = await setup(t);
+  const active = await seedClaimLock(context);
+  const killed = crash("kill after claim-lock audit publication");
+  await assert.rejects(repairStaleClaimLock({ ...context,
+    renameClaimLock: async () => { throw killed; } }), killed);
+
+  const first = await runDoctor(context, { repair: true });
+
+  assert.equal(first.repairs.some(item => item.action === "repair_stale_claim_lock"), true);
+  assert.equal(await pathExists(active), false);
+  assert.equal(first.ok, true);
+
+  const quarantine = (await readdir(context.paths.quarantine)).sort();
+  const second = await runDoctor(context, { repair: true });
+
+  assert.equal(second.ok, true);
+  assert.deepEqual(second.repairs, [], "replay was not idempotent");
+  assert.deepEqual((await readdir(context.paths.quarantine)).sort(), quarantine);
+});
+
+test("10: a crash after mutex audit publication replays exactly once", async t => {
+  const { context } = await setup(t);
+  const active = await seedMutex(context);
+  const killed = crash("kill after mutex audit publication");
+  await assert.rejects(repairStaleRepairMutex({ ...context,
+    renameRepairMutex: async () => { throw killed; } }, "watcher", "models"), killed);
+
+  const first = await runDoctor(context, { repair: true });
+
+  assert.equal(first.repairs.some(item => item.action === "repair_stale_watcher_mutex"), true);
+  assert.equal(await pathExists(active), false);
+  assert.equal(first.ok, true);
+
+  const quarantine = (await readdir(context.paths.quarantine)).sort();
+  const second = await runDoctor(context, { repair: true });
+
+  assert.equal(second.ok, true);
+  assert.deepEqual(second.repairs, [], "replay was not idempotent");
+  assert.deepEqual((await readdir(context.paths.quarantine)).sort(), quarantine);
+});
+
+test("11: every recovery artifact family is inventoried and blocks unrelated repair", async t => {
+  const digest = createHash("sha256").update("unmatched").digest("hex");
+  const artifacts = [
+    ["claims-audit-not-a-uuid.json", async file => writeFile(file, "{}\n")],
+    [`claims-lock-stale-${digest}`, async file => mkdir(file)],
+    ["mutex-audit-not-a-digest.json", async file => writeFile(file, "{}\n")],
+    [`mutex-stale-${digest}`, async file => mkdir(file)],
+    ["watcher-owner-stale-33333333-3333-4333-8333-333333333333.json",
+      async file => writeFile(file, "{}\n")],
+  ];
+
+  for (const [name, create] of artifacts) {
+    const { context } = await setup(t);
+    const corrupt = await unrelatedCorruptRecord(context);
+    await create(path.join(context.paths.quarantine, name));
+
+    const report = await runDoctor(context, { repair: true });
+
+    assert.equal(report.ok, false, `${name} was not inventoried`);
+    assert.deepEqual(report.repairs, [], `${name} did not block unrelated repair`);
+    assert.equal(await pathExists(corrupt), true,
+      `${name} left an unrelated record repaired despite ambiguous recovery state`);
+  }
+});
+
+test("9: two doctors and a publisher cannot delete the publisher's new generation", async t => {
+  const { context } = await setup(t);
+  const base = { ...context, randomUUID: () => "44444444-4444-4444-8444-444444444444" };
+  const message = await sendMessage(base, messageRequest());
+  const seen = base.paths.seenFile(message.id, "models");
+  await mkdir(base.paths.seen, { recursive: true });
+  await writeFile(seen, "{broken");
+
+  let links = 0;
+  const held = Promise.withResolvers();
+  const linked = Promise.withResolvers();
+  const removed = Promise.withResolvers();
+  const published = Promise.withResolvers();
+  const racing = { ...base,
+    linkCorruptRecord: async (from, destination) => {
+      links += 1;
+      const result = await link(from, destination);
+      if (links === 1) { linked.resolve(); await held.promise; }
+      return result;
+    },
+    unlinkCorruptRecord: async from => {
+      await unlink(from);
+      if (from === seen) { removed.resolve(); await published.promise; }
+    } };
+
+  const first = runDoctor(racing, { repair: true });
+  await linked.promise;
+  const second = runDoctor(racing, { repair: true });
+  for (let index = 0; index < 8; index += 1) await new Promise(setImmediate);
+
+  // The repair mutex admits exactly one quarantine attempt at a time.
+  assert.equal(links, 1, "two doctors quarantined the same record concurrently");
+  held.resolve();
+  await removed.promise;
+  const replacement = await markSeen(base, message, "models");
+  published.resolve();
+  await Promise.all([first, second]);
+
+  assert.deepEqual(JSON.parse(await readFile(seen, "utf8")), replacement,
+    "a doctor deleted the publisher's replacement generation");
+  const after = await runDoctor(base, {});
+  assert.deepEqual(after.issues.filter(item => item.code.includes("CORRUPT")), [],
+    "the workspace was left with corrupt recovery state after the race");
+});

--- a/prototype/integrated/tests/tools/agent_comms/combined-hardening-lifecycle.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/combined-hardening-lifecycle.test.mjs
@@ -1,0 +1,212 @@
+// Combined regressions 1-5 and 12 from docs/MIGRATION.md. These exercise the
+// reconciled tree end to end: the lifecycle guard from 0002 standing on the
+// managed-root storage from 0003, reached through real CLI processes so that
+// workspace identity, stdout purity, and exit codes are all observed together.
+import assert from "node:assert/strict";
+import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import { closeAgent, registerAgent } from "../../../tools/agents/lib/identity.mjs";
+import { acquireWatcherOwnership } from "../../../tools/agents/lib/watcher-ownership.mjs";
+import { createBusFixture, createGitWorktreeFixture, runCli, startCli } from "./helpers.mjs";
+
+const MESSAGE_ID = "00000000-0000-4000-8000-000000000001";
+const SHA = "a".repeat(40);
+const GATE_TIMEOUT_MS = 30_000;
+
+// Every command the CLI accepts apart from init and prompt, each with the
+// minimum valid argv so that argument parsing succeeds and the protocol gate,
+// not the parser, is what decides the outcome.
+const GATED_COMMANDS = [
+  ["register", "--id", "visual", "--role", "artist", "--task", "M2.7"],
+  ["close", "--id", "visual"],
+  ["send", "--from", "visual", "--to", "models", "--type", "status", "--severity", "info",
+    "--subject", "s", "--body", "b"],
+  ["broadcast", "--from", "visual", "--severity", "info", "--subject", "s", "--body", "b"],
+  ["inbox", "--id", "visual"],
+  ["ack", "--id", "visual", "--message", MESSAGE_ID],
+  ["reply", "--from", "visual", "--message", MESSAGE_ID, "--type", "status",
+    "--severity", "info", "--subject", "s", "--body", "b"],
+  ["watch", "--id", "visual"],
+  ["wait", "--id", "visual", "--timeout", "0"],
+  ["claim", "--id", "visual", "--scope", "game/models", "--reason", "r"],
+  ["release", "--id", "visual", "--scope", "game/models"],
+  ["handoff", "--id", "visual", "--to", "models", "--task", "M2.7", "--result", "done",
+    "--branch", "topic", "--base", SHA, "--commit", SHA, "--verification-file", "v.json",
+    "--contracts-file", "c.json", "--limitations-file", "l.json"],
+  ["status"],
+  ["doctor"],
+  ["doctor", "--repair"],
+];
+
+async function snapshotTree(root, relative = "") {
+  const entries = (await readdir(path.join(root, relative), { withFileTypes: true }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+  const snapshot = [];
+  for (const entry of entries) {
+    const item = path.join(relative, entry.name);
+    if (entry.isDirectory()) {
+      snapshot.push(["directory", item], ...await snapshotTree(root, item));
+    } else {
+      snapshot.push(["file", item, (await readFile(path.join(root, item))).toString("base64")]);
+    }
+  }
+  return snapshot;
+}
+
+// watch is the only gated command with no --json option, so machine mode is
+// requested per command rather than assumed.
+const supportsJson = argv => argv[0] !== "watch";
+
+// watch never terminates on its own, so a blocked gate must not hang the suite.
+async function runGated(fixture, argv, cwd) {
+  const child = startCli(fixture, supportsJson(argv) ? [...argv, "--json"] : argv, { cwd });
+  child.stdin.end();
+  const exited = new Promise(resolve => child.once("close", code => resolve({
+    code, stdout: child.collected.stdout, stderr: child.collected.stderr })));
+  let ceiling;
+  const expired = new Promise(resolve => { ceiling = setTimeout(resolve, GATE_TIMEOUT_MS, null); });
+  const result = await Promise.race([exited, expired]);
+  clearTimeout(ceiling);
+  if (result !== null) return result;
+  child.kill("SIGKILL");
+  await exited;
+  return assert.fail(`${argv[0]} never exited: the protocol gate did not block it`);
+}
+
+async function foreignFixture(t) {
+  const owner = await createGitWorktreeFixture();
+  const foreign = await createGitWorktreeFixture();
+  t.after(async () => { await Promise.all([owner.cleanup(), foreign.cleanup()]); });
+  const initialized = await runCli(owner, ["init", "--json"], { cwd: owner.worktree });
+  assert.equal(initialized.code, 0, initialized.stderr);
+  return { owner, foreign };
+}
+
+async function writeProtocol(fixture, mutate) {
+  const file = path.join(fixture.owner.bus, "protocol.json");
+  const record = JSON.parse(await readFile(file, "utf8"));
+  await writeFile(file, `${JSON.stringify(mutate(record))}\n`);
+}
+
+test("1: a foreign workspace protocol blocks every non-init command before mutation", async t => {
+  const fixture = await foreignFixture(t);
+  const before = await snapshotTree(fixture.owner.bus);
+
+  for (const argv of GATED_COMMANDS) {
+    const result = await runGated(fixture.owner, argv, fixture.foreign.worktree);
+    assert.equal(result.code, EXIT.DATA, `${argv.join(" ")}: ${result.stderr || result.stdout}`);
+    if (supportsJson(argv)) {
+      assert.equal(result.stderr, "", `${argv[0]} polluted stderr in JSON mode`);
+      assert.equal(JSON.parse(result.stdout).error.exit_code, EXIT.DATA);
+    } else {
+      assert.equal(result.stdout, "", `${argv[0]} wrote a human error to stdout`);
+      assert.notEqual(result.stderr, "", `${argv[0]} reported nothing on stderr`);
+    }
+    assert.deepEqual(await snapshotTree(fixture.owner.bus), before,
+      `${argv.join(" ")} mutated a foreign workspace`);
+  }
+});
+
+test("2: a malformed foreign protocol blocks ordinary commands and doctor --repair", async t => {
+  const fixture = await foreignFixture(t);
+  await writeFile(path.join(fixture.owner.bus, "protocol.json"), "{not-json");
+  const before = await snapshotTree(fixture.owner.bus);
+
+  for (const argv of [["close", "--id", "visual"], ["doctor", "--repair"]]) {
+    const result = await runGated(fixture.owner, argv, fixture.foreign.worktree);
+    assert.equal(result.code, EXIT.DATA, result.stderr || result.stdout);
+    assert.deepEqual(await snapshotTree(fixture.owner.bus), before,
+      `${argv.join(" ")} mutated a foreign workspace with an unreadable protocol`);
+  }
+});
+
+test("12: an unknown protocol version fails closed before any repair", async t => {
+  const fixture = await foreignFixture(t);
+  await writeProtocol(fixture, record => ({ ...record, protocol_version: 99 }));
+  const before = await snapshotTree(fixture.owner.bus);
+
+  for (const argv of [["close", "--id", "visual"], ["doctor", "--repair"], ["status"]]) {
+    const result = await runGated(fixture.owner, argv, fixture.foreign.worktree);
+    assert.equal(result.code, EXIT.DATA, result.stderr || result.stdout);
+    assert.deepEqual(await snapshotTree(fixture.owner.bus), before,
+      `${argv.join(" ")} mutated a workspace with an unknown protocol version`);
+  }
+});
+
+test("12: an unknown schema version fails closed on the owning checkout too", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  assert.equal((await runCli(fixture, ["init"], { cwd: fixture.worktree })).code, 0);
+  const file = path.join(fixture.bus, "protocol.json");
+  const record = JSON.parse(await readFile(file, "utf8"));
+  await writeFile(file, `${JSON.stringify({ ...record, schema_version: 99 })}\n`);
+  const before = await readFile(file);
+
+  const repaired = await runGated(fixture, ["doctor", "--repair"], fixture.worktree);
+
+  assert.equal(repaired.code, EXIT.DATA, repaired.stderr || repaired.stdout);
+  assert.deepEqual(await readFile(file), before, "repair rewrote an unknown schema version");
+});
+
+test("3: init validates an existing protocol identity before changing layout", async t => {
+  const fixture = await foreignFixture(t);
+  await rm(path.join(fixture.owner.bus, "artifacts"), { recursive: true });
+  const before = await snapshotTree(fixture.owner.bus);
+
+  const result = await runGated(fixture.owner, ["init"], fixture.foreign.worktree);
+
+  assert.equal(result.code, EXIT.DATA, result.stderr || result.stdout);
+  assert.deepEqual(await snapshotTree(fixture.owner.bus), before,
+    "init created layout inside a foreign workspace");
+});
+
+test("4: register, close, and watcher start share one ownership critical section", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const context = { ...fixture.context, pid: 4242, pidIsAlive: () => true,
+    gitState: async () => ({ branch: "topic", head: SHA }),
+    releaseOwnedClaims: async () => [] };
+  const registration = { agentId: "visual", role: "artist", task: "M2.7",
+    worktree: "/tmp/worktree-a", ownership: [] };
+  await registerAgent(context, registration);
+  await acquireWatcherOwnership(context, "visual", 4242);
+
+  // One watcher owner excludes every other lifecycle transition for that agent.
+  await assert.rejects(registerAgent(context, { ...registration, resume: true }),
+    error => error.exitCode === EXIT.CONFLICT);
+  await assert.rejects(closeAgent(context, "visual"),
+    error => error.exitCode === EXIT.CONFLICT);
+  await assert.rejects(acquireWatcherOwnership(context, "visual", 4243),
+    error => error.exitCode === EXIT.CONFLICT);
+});
+
+test("5: broadcast reaches live sessions, not merely registered-open ones", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  const run = argv => runCli(fixture, [...argv, "--json"], { cwd: fixture.worktree });
+  assert.equal((await run(["init"])).code, 0);
+  for (const id of ["visual", "models"]) {
+    assert.equal((await run(["register", "--id", id, "--role", "artist", "--task", "M2.7"])).code, 0);
+  }
+  const base = ["broadcast", "--from", "visual", "--severity", "info", "--subject", "s",
+    "--body", "b"];
+
+  const registeredOnly = await run(base);
+
+  assert.equal(registeredOnly.code, 0, registeredOnly.stderr);
+  assert.deepEqual(JSON.parse(registeredOnly.stdout), [],
+    "broadcast published to an agent that is open but not live");
+
+  await mkdir(path.join(fixture.bus, "presence"), { recursive: true });
+  await writeFile(path.join(fixture.bus, "presence", "models.json"), `${JSON.stringify({
+    schema_version: 1, agent_id: "models", pid: process.pid, status: "online",
+    heartbeat_at: new Date().toISOString() })}\n`);
+
+  const live = await run(base);
+
+  assert.equal(live.code, 0, live.stderr);
+  assert.deepEqual(JSON.parse(live.stdout).map(item => item.to), ["models"]);
+});

--- a/prototype/integrated/tests/tools/agent_comms/combined-hardening-storage.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/combined-hardening-storage.test.mjs
@@ -1,0 +1,145 @@
+// Combined regressions 6-8 from docs/MIGRATION.md. The storage rules from 0003
+// are exercised through the real CLI, so they are proven to survive on the code
+// path that the 0002 protocol guard and the 0004 doctor also run through, not
+// only through the direct library calls the archived unit tests use.
+import assert from "node:assert/strict";
+import { mkdir, readFile, readdir, rename, symlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import { createGitWorktreeFixture, pathExists, runCli } from "./helpers.mjs";
+
+async function workspace(t) {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  const run = (argv, options = {}) => runCli(fixture, [...argv, "--json"],
+    { cwd: fixture.worktree, ...options });
+  assert.equal((await run(["init"])).code, 0);
+  for (const id of ["visual", "models"]) {
+    const registered = await run(["register", "--id", id, "--role", "artist", "--task", "M2.7"]);
+    assert.equal(registered.code, 0, registered.stderr);
+  }
+  return { fixture, run };
+}
+
+async function sendMessage({ run }, extra = []) {
+  const sent = await run(["send", "--from", "visual", "--to", "models", "--type", "question",
+    "--severity", "action", "--subject", "contract", "--body", "please confirm", ...extra]);
+  assert.equal(sent.code, 0, sent.stderr);
+  return JSON.parse(sent.stdout);
+}
+
+test("6: a symlinked registry parent is rejected on the command path", async t => {
+  const { fixture, run } = await workspace(t);
+  const registry = path.join(fixture.bus, "registry");
+  const external = path.join(fixture.root, "external-registry");
+  await rename(registry, external);
+  await symlink(external, registry);
+  const before = await readdir(external);
+
+  const status = await run(["status"]);
+
+  assert.equal(status.code, EXIT.DATA, status.stderr || status.stdout);
+  assert.equal(status.stderr, "", "machine mode polluted stderr");
+  assert.equal(JSON.parse(status.stdout).error.exit_code, EXIT.DATA);
+  assert.deepEqual(await readdir(external), before,
+    "a symlinked registry parent was read and rewritten");
+});
+
+test("6: a symlinked inbox parent is rejected on the command path", async t => {
+  const context = await workspace(t);
+  await sendMessage(context);
+  const { fixture, run } = context;
+  const inbox = path.join(fixture.bus, "inbox", "models");
+  const external = path.join(fixture.root, "external-inbox");
+  await rename(inbox, external);
+  await symlink(external, inbox);
+  const before = await readdir(external);
+
+  const listed = await run(["inbox", "--id", "models"]);
+
+  assert.equal(listed.code, EXIT.DATA, listed.stderr || listed.stdout);
+  assert.deepEqual(await readdir(external), before,
+    "a symlinked inbox parent was read and marked seen");
+});
+
+test("7: an inbox filename that does not match its record id is data corruption", async t => {
+  const context = await workspace(t);
+  const message = await sendMessage(context);
+  const { fixture, run } = context;
+  const canonical = path.join(fixture.bus, "inbox", "models", `${message.id}.json`);
+  const alias = path.join(fixture.bus, "inbox", "models", `${message.id}-alias.json`);
+  await rename(canonical, alias);
+
+  const listed = await run(["inbox", "--id", "models"]);
+
+  assert.equal(listed.code, EXIT.DATA, listed.stderr || listed.stdout);
+  assert.equal(JSON.parse(listed.stdout).error.exit_code, EXIT.DATA);
+});
+
+test("7: an archive filename cannot claim another recipient directory", async t => {
+  const context = await workspace(t);
+  const message = await sendMessage(context, ["--requires-ack"]);
+  const { fixture, run } = context;
+  const misplaced = path.join(fixture.bus, "archive", "visual", `${message.id}.json`);
+  await mkdir(path.dirname(misplaced), { recursive: true });
+  await rename(path.join(fixture.bus, "inbox", "models", `${message.id}.json`), misplaced);
+
+  const acked = await run(["ack", "--id", "visual", "--message", message.id]);
+
+  assert.equal(acked.code, EXIT.DATA, acked.stderr || acked.stdout);
+  assert.deepEqual(JSON.parse(await readFile(misplaced, "utf8")).to, "models",
+    "a misfiled archive record was rewritten to match its directory");
+});
+
+test("8: acknowledgement never overwrites conflicting archive evidence", async t => {
+  const context = await workspace(t);
+  const message = await sendMessage(context, ["--requires-ack"]);
+  const { fixture, run } = context;
+  assert.equal((await run(["inbox", "--id", "models"])).code, 0);
+  const archived = path.join(fixture.bus, "archive", "models", `${message.id}.json`);
+  await mkdir(path.dirname(archived), { recursive: true });
+  const conflicting = `${JSON.stringify({ ...message, subject: "someone else's evidence" })}\n`;
+  await writeFile(archived, conflicting);
+
+  const acked = await run(["ack", "--id", "models", "--message", message.id]);
+
+  assert.equal(acked.code, EXIT.DATA, acked.stderr || acked.stdout);
+  assert.equal(await readFile(archived, "utf8"), conflicting,
+    "acknowledgement replaced immutable archive evidence");
+
+  // The receipt is written before the archive move on purpose: it is the
+  // evidence doctor requires to finish an interrupted move. So the incomplete
+  // state must be durable AND visible, and repair must still refuse to
+  // overwrite the conflicting archive.
+  assert.equal(await pathExists(path.join(fixture.bus, "acknowledgements",
+    `${message.id}--models.json`)), true, "the acknowledgement receipt was lost");
+  const diagnosed = await run(["doctor"]);
+  assert.equal(JSON.parse(diagnosed.stdout).issues
+    .some(item => item.code === "ACKED_MESSAGE_NOT_ARCHIVED"), true,
+  "an unfinished archive move was not reported");
+
+  const repaired = await run(["doctor", "--repair"]);
+
+  assert.notEqual(repaired.code, 0, "repair claimed success over conflicting archive evidence");
+  assert.equal(await readFile(archived, "utf8"), conflicting,
+    "repair replaced immutable archive evidence");
+});
+
+test("8: acknowledging an already published identical archive stays idempotent", async t => {
+  const context = await workspace(t);
+  const message = await sendMessage(context, ["--requires-ack"]);
+  const { fixture, run } = context;
+  assert.equal((await run(["inbox", "--id", "models"])).code, 0);
+  const first = await run(["ack", "--id", "models", "--message", message.id]);
+  assert.equal(first.code, 0, first.stderr);
+  const archived = path.join(fixture.bus, "archive", "models", `${message.id}.json`);
+  const bytes = await readFile(archived);
+
+  const second = await run(["ack", "--id", "models", "--message", message.id]);
+
+  assert.notEqual(second.code, EXIT.DATA,
+    "a republished identical archive was reported as corruption");
+  assert.deepEqual(await readFile(archived), bytes, "a repeated ack rewrote the archive");
+});

--- a/prototype/integrated/tests/tools/agent_comms/doctor-race.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/doctor-race.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { link, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import test from "node:test";
+
+import { initBus } from "../../../tools/agents/lib/identity.mjs";
+import { markSeen, sendMessage } from "../../../tools/agents/lib/messages.mjs";
+import { createBusPaths, ensureBusLayout } from "../../../tools/agents/lib/paths.mjs";
+import { validateProtocol } from "../../../tools/agents/lib/schema.mjs";
+import { runDoctor } from "../../../tools/agents/lib/status.mjs";
+import { createBusFixture, createFakeClock, createGitWorktreeFixture, messageRequest,
+  seedOpenAgent } from "./helpers.mjs";
+
+function deferred() { let resolve;
+  const promise = new Promise(done => { resolve = done; }); return { promise, resolve }; }
+async function ticks(count = 8) {
+  for (let index = 0; index < count; index += 1)
+    await new Promise(resolve => setImmediate(resolve));
+}
+function signalled(value) {
+  return Promise.race([value, new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("repair hook was not reached")), 250);
+    timer.unref();
+  })]);
+}
+function racingContext(base, source) {
+  const linked = deferred(), releaseLink = deferred(), removed = deferred(), published = deferred();
+  let linkCount = 0;
+  const context = { ...base,
+    linkCorruptRecord: async (from, destination) => {
+      linkCount += 1; const result = await link(from, destination);
+      if (linkCount === 1) { linked.resolve(); await releaseLink.promise; }
+      return result;
+    },
+    unlinkCorruptRecord: async from => {
+      await unlink(from);
+      if (from === source) { removed.resolve(); await published.promise; }
+    },
+  };
+  return { context, linked, releaseLink, removed, published, links: () => linkCount };
+}
+async function seedAgents(context) {
+  await Promise.all(["visual", "models"].map(agentId => seedOpenAgent(context,
+    { agentId, task: "M2.7" })));
+}
+
+test("two doctors serialize while init publishes replacement protocol B", async t => {
+  const fixture = await createGitWorktreeFixture(); t.after(fixture.cleanup);
+  const paths = createBusPaths(fixture.bus); await ensureBusLayout(paths);
+  const clock = createFakeClock("2026-08-14T18:00:00.000Z");
+  const base = { paths, now: clock.now, pid: 4242, pidIsAlive: pid => pid === 4242 };
+  await writeFile(paths.protocol, "{broken");
+  const race = racingContext(base, paths.protocol);
+  const first = runDoctor(race.context, { repair: true }); await race.linked.promise;
+  const second = runDoctor(race.context, { repair: true }); await ticks();
+  assert.equal(race.links(), 1);
+  race.releaseLink.resolve(); await signalled(race.removed.promise);
+  const replacement = await initBus(base); race.published.resolve();
+  await Promise.all([first, second]);
+  assert.deepEqual(JSON.parse(await readFile(paths.protocol, "utf8")), replacement);
+});
+
+test("two doctors serialize while recipient publishes replacement seen B", async t => {
+  const fixture = await createBusFixture(); t.after(fixture.cleanup);
+  const base = { ...fixture.context, pid: 4242, pidIsAlive: pid => pid === 4242,
+    randomUUID: () => "44444444-4444-4444-8444-444444444444" };
+  await seedAgents(base);
+  const protocol = validateProtocol({ schema_version: 1, protocol_version: 1,
+    checkout_id: "c".repeat(64), checkout_root: fixture.root,
+    initialized_at: base.now().toISOString() });
+  await writeFile(base.paths.protocol, `${JSON.stringify(protocol)}\n`);
+  const message = await sendMessage(base, messageRequest());
+  const seen = base.paths.seenFile(message.id, "models"); await mkdir(base.paths.seen,
+    { recursive: true }); await writeFile(seen, "{broken");
+  const race = racingContext(base, seen);
+  const first = runDoctor(race.context, { repair: true }); await race.linked.promise;
+  const second = runDoctor(race.context, { repair: true }); await ticks();
+  assert.equal(race.links(), 1);
+  race.releaseLink.resolve(); await signalled(race.removed.promise);
+  const replacement = await markSeen(base, message, "models"); race.published.resolve();
+  await Promise.all([first, second]);
+  assert.deepEqual(JSON.parse(await readFile(seen, "utf8")), replacement);
+});

--- a/prototype/integrated/tests/tools/agent_comms/errors.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/errors.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CommsError, EXIT } from "../../../tools/agents/lib/errors.mjs";
+
+test("exit codes are stable", () => {
+  assert.deepEqual(EXIT, {
+    OK: 0,
+    USAGE: 2,
+    TIMEOUT: 3,
+    DATA: 4,
+    CONFLICT: 5,
+    REQUIRED: 6,
+  });
+  assert.equal(new CommsError("bad data", EXIT.DATA).exitCode, 4);
+});
+
+test("protocol errors retain structured details", () => {
+  const details = { path: "inbox/broken.json" };
+  const error = new CommsError("bad data", EXIT.DATA, details);
+
+  assert.equal(error.name, "CommsError");
+  assert.equal(error.message, "bad data");
+  assert.equal(error.exitCode, EXIT.DATA);
+  assert.equal(error.details, details);
+});

--- a/prototype/integrated/tests/tools/agent_comms/final-cli.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/final-cli.test.mjs
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile, readdir, realpath, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { createGitWorktreeFixture, pathExists, runCli } from "./helpers.mjs";
+
+async function succeeds(fixture, argv) {
+  const result = await runCli(fixture, [...argv, "--json"], { cwd: fixture.worktree });
+  assert.equal(result.code, 0, result.stderr || result.stdout);
+  assert.equal(result.stderr, "");
+  return JSON.parse(result.stdout);
+}
+
+async function bootstrap(fixture, agents = []) {
+  await succeeds(fixture, ["init"]);
+  for (const agent of agents) await succeeds(fixture,
+    ["register", "--id", agent, "--role", "artist", "--task", "M2.7"]);
+}
+
+function protocolError(result, exitCode) {
+  assert.equal(result.code, exitCode);
+  assert.equal(result.stderr, "");
+  const parsed = JSON.parse(result.stdout);
+  assert.deepEqual(Object.keys(parsed), ["error"]);
+  assert.deepEqual(Object.keys(parsed.error).sort(), ["details", "exit_code", "message"]);
+  assert.equal(parsed.error.exit_code, exitCode);
+  assert.equal(typeof parsed.error.message, "string");
+  return parsed;
+}
+
+test("normal commands validate protocol before mutating bus state", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  await bootstrap(fixture, ["visual"]);
+  const registryPath = path.join(fixture.bus, "registry", "visual.json");
+  const before = await readFile(registryPath, "utf8");
+  await writeFile(path.join(fixture.bus, "protocol.json"), "{not-json");
+
+  const result = await runCli(fixture, ["close", "--id", "visual", "--json"],
+    { cwd: fixture.worktree });
+  protocolError(result, 4);
+  assert.equal(await readFile(registryPath, "utf8"), before);
+  assert.equal(await pathExists(path.join(fixture.bus, "presence", "visual.json")), false);
+});
+
+test("init identity comes from Git even when the bus has an explicit override", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  const externalBus = path.join(fixture.root, "external-bus");
+  const result = await runCli(fixture, ["init", "--json"], { cwd: fixture.worktree,
+    env: { PW2_AGENT_BUS_DIR: externalBus } });
+  assert.equal(result.code, 0, result.stderr || result.stdout);
+  const protocol = JSON.parse(result.stdout);
+  const commonDir = await realpath(path.join(fixture.main, ".git"));
+  assert.equal(protocol.checkout_root, fixture.main);
+  assert.equal(protocol.checkout_id, createHash("sha256").update(commonDir).digest("hex"));
+});
+
+test("doctor maps unknown schema and protocol versions to data exit four", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  const original = await succeeds(fixture, ["init"]);
+  for (const [field, value, issueCode] of [
+    ["schema_version", 2, "UNKNOWN_SCHEMA_VERSION"],
+    ["protocol_version", 2, "UNKNOWN_PROTOCOL_VERSION"],
+  ]) {
+    await writeFile(path.join(fixture.bus, "protocol.json"),
+      `${JSON.stringify({ ...original, [field]: value })}\n`);
+    const result = await runCli(fixture, ["doctor", "--json"], { cwd: fixture.worktree });
+    assert.equal(result.code, 4);
+    assert.equal(result.stderr, "");
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.issues.some(issue => issue.code === issueCode), true);
+  }
+});
+
+test("json usage and conflict errors are one stable machine value", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  protocolError(await runCli(fixture, ["invent", "--json"]), 2);
+  const human = await runCli(fixture, ["invent"]);
+  assert.equal(human.code, 2);
+  assert.equal(human.stdout, "");
+  assert.match(human.stderr, /unknown command/);
+
+  await bootstrap(fixture, ["visual"]);
+  const duplicate = await runCli(fixture, ["register", "--id", "visual", "--role", "artist",
+    "--task", "M2.7", "--json"], { cwd: fixture.worktree });
+  protocolError(duplicate, 5);
+  assert.equal(duplicate.stdout.trim().split("\n").length, 1);
+});
+
+test("json wait timeout is one stable machine value", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  await bootstrap(fixture, ["visual"]);
+  const result = await runCli(fixture, ["wait", "--id", "visual", "--timeout", "0.01",
+    "--json"], { cwd: fixture.worktree });
+  protocolError(result, 3);
+  assert.equal(JSON.parse(result.stdout).error.message, "wait timed out");
+});
+
+test("broadcast snapshots only open agents with fresh live presence", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  await bootstrap(fixture, ["sender", "active", "heartbeatless", "stale", "offline", "dead"]);
+  const fresh = new Date().toISOString();
+  const old = new Date(Date.now() - 46_000).toISOString();
+  const presence = (agentId, pid, status, heartbeatAt) => ({ schema_version: 1,
+    agent_id: agentId, pid, status, heartbeat_at: heartbeatAt });
+  for (const record of [
+    presence("active", process.pid, "online", fresh),
+    presence("stale", process.pid, "online", old),
+    presence("offline", process.pid, "offline", fresh),
+    presence("dead", 99_999_999, "online", fresh),
+  ]) await writeFile(path.join(fixture.bus, "presence", `${record.agent_id}.json`),
+    `${JSON.stringify(record)}\n`);
+
+  const delivered = await succeeds(fixture, ["broadcast", "--from", "sender", "--severity",
+    "info", "--subject", "live only", "--body", "snapshot"]);
+  assert.deepEqual(delivered.map(message => message.to), ["active"]);
+});
+
+test("handoff accepts committed and ephemeral artifacts through distinct routes", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  await bootstrap(fixture, ["visual", "orchestrator"]);
+  const revision = "a".repeat(40);
+  await writeFile(path.join(fixture.worktree, "proof.txt"), "committed proof");
+  await writeFile(path.join(fixture.bus, "artifacts", "capture.txt"), "ephemeral proof");
+  await writeFile(path.join(fixture.worktree, "verification.json"), JSON.stringify([
+    { command: "node --test", exitCode: 0, summary: "passed" },
+  ]));
+  await writeFile(path.join(fixture.worktree, "contracts.json"), JSON.stringify({
+    added: [], changed: [], consumed: [],
+  }));
+  await writeFile(path.join(fixture.worktree, "limitations.json"), "[]");
+
+  const value = await succeeds(fixture, ["handoff", "--id", "visual", "--to", "orchestrator",
+    "--task", "M2.7", "--result", "ready", "--branch", "feature/visual", "--commit", revision,
+    "--base", revision, "--changed", "proof.txt", "--artifact", "proof.txt",
+    "--ephemeral-artifact", ".agents/artifacts/capture.txt", "--verification-file",
+    "verification.json", "--contracts-file", "contracts.json", "--limitations-file",
+    "limitations.json"]);
+  assert.deepEqual(value.record.artifacts.map(artifact => ({ path: artifact.path,
+    ephemeral: artifact.ephemeral, commit: artifact.commit ?? null })), [
+    { path: "proof.txt", ephemeral: false, commit: revision },
+    { path: ".agents/artifacts/capture.txt", ephemeral: true, commit: null },
+  ]);
+  assert.equal((await readdir(path.join(fixture.bus, "handoffs"))).length, 1);
+});

--- a/prototype/integrated/tests/tools/agent_comms/final-lifecycle.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/final-lifecycle.test.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import { closeAgent, initBus, registerAgent }
+  from "../../../tools/agents/lib/identity.mjs";
+import { createBusPaths } from "../../../tools/agents/lib/paths.mjs";
+import { startWatcher } from "../../../tools/agents/lib/presence.mjs";
+import { withRepairMutex } from "../../../tools/agents/lib/repair-mutex.mjs";
+import { createBusFixture, createGitWorktreeFixture, pathExists, seedPresence }
+  from "./helpers.mjs";
+
+const HEAD = "a".repeat(40);
+
+function registration(overrides = {}) {
+  return { agentId: "visual", role: "artist", task: "M2.7",
+    worktree: "/tmp/visual-worktree", ownership: ["game/presentation"], ...overrides };
+}
+
+function contextFor(fixture, overrides = {}) {
+  return { paths: fixture.paths, now: fixture.clock.now, pid: 4242,
+    pidIsAlive: pid => pid === 4242,
+    gitState: async () => ({ branch: "feature/visual", head: HEAD }),
+    releaseOwnedClaims: async () => {}, extendOwnedClaims: async () => {},
+    watchDirectory: () => ({ close() {}, once() {} }), output: async () => {},
+    ...overrides };
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise(done => { resolve = done; });
+  return { promise, resolve };
+}
+
+async function waitUntil(predicate) {
+  for (let index = 0; index < 100_000; index += 1) {
+    if (predicate()) return;
+    await new Promise(resolve => setImmediate(resolve));
+  }
+  assert.fail("condition did not become true");
+}
+
+test("init rejects a protocol bound to another checkout identity", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  const context = { paths: createBusPaths(fixture.bus),
+    now: () => new Date("2026-08-14T18:00:00.000Z") };
+  const original = await initBus(context);
+
+  for (const mismatch of [
+    { checkout_id: "b".repeat(64) },
+    { checkout_root: path.join(fixture.root, "another-checkout") },
+  ]) {
+    const incompatible = { ...original, ...mismatch };
+    await writeFile(context.paths.protocol, `${JSON.stringify(incompatible)}\n`);
+    await assert.rejects(initBus(context), error => error.exitCode === EXIT.DATA);
+    assert.deepEqual(JSON.parse(await readFile(context.paths.protocol, "utf8")), incompatible);
+  }
+});
+
+test("open registration requires resume while a closed id starts a new lifecycle", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const context = contextFor(fixture, { pidIsAlive: () => false });
+  const first = await registerAgent(context, registration());
+
+  await assert.rejects(registerAgent(context, registration({ worktree: "/tmp/replacement" })),
+    error => error.exitCode === EXIT.CONFLICT);
+  assert.deepEqual(JSON.parse(await readFile(context.paths.registryFile("visual"), "utf8")), first);
+
+  await closeAgent(context, "visual");
+  await assert.rejects(registerAgent(context, { ...registration(), resume: true }),
+    error => error.exitCode === EXIT.CONFLICT);
+  fixture.clock.advance(1_000);
+  const reused = await registerAgent(context, registration({ task: "M2.8",
+    worktree: "/tmp/reused-worktree" }));
+  assert.equal(reused.status, "open");
+  assert.equal(reused.task, "M2.8");
+  assert.equal(reused.registered_at, "2026-08-14T18:00:01.000Z");
+});
+
+test("watcher ownership blocks resume and close even with offline heartbeat", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const context = contextFor(fixture);
+  await registerAgent(context, registration());
+  const watcher = await startWatcher(context, { agentId: "visual" });
+  t.after(() => watcher.stop());
+  await seedPresence(context, { agentId: "visual", pid: 4242, status: "offline" });
+
+  await assert.rejects(registerAgent(context, { ...registration(), resume: true }),
+    error => error.exitCode === EXIT.CONFLICT);
+  await assert.rejects(closeAgent(context, "visual"),
+    error => error.exitCode === EXIT.CONFLICT);
+
+  await watcher.stop();
+  assert.equal((await registerAgent(context, { ...registration(), resume: true })).status, "open");
+});
+
+test("watcher start rechecks registration after a racing close", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const context = contextFor(fixture);
+  await registerAgent(context, registration());
+  const held = deferred();
+  const releaseHolder = deferred();
+  const holding = withRepairMutex(context, "watcher", "visual", async () => {
+    held.resolve();
+    await releaseHolder.promise;
+  });
+  await held.promise;
+
+  let watcherWaiting = false;
+  const allowWatcherRetry = deferred();
+  const watcherContext = { ...context, waitRepairMutex: async () => {
+    watcherWaiting = true;
+    await allowWatcherRetry.promise;
+  } };
+  const starting = startWatcher(watcherContext, { agentId: "visual" });
+  let startupError = null;
+  void starting.catch(error => { startupError = error; });
+  await waitUntil(() => watcherWaiting || startupError !== null);
+  assert.equal(startupError, null, startupError?.stack);
+  const closing = closeAgent(context, "visual");
+  await new Promise(resolve => setImmediate(resolve));
+  releaseHolder.resolve();
+  await holding;
+  await closing;
+  allowWatcherRetry.resolve();
+
+  const result = await starting.then(value => ({ value }), error => ({ error }));
+  if (result.value !== undefined) await result.value.stop();
+  assert.equal(result.error?.exitCode, EXIT.CONFLICT);
+  assert.equal(await pathExists(path.join(context.paths.locks, "watcher-visual.json")), false);
+});

--- a/prototype/integrated/tests/tools/agent_comms/foreign-checkout.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/foreign-checkout.test.mjs
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { createGitWorktreeFixture, pathExists, runCli } from "./helpers.mjs";
+
+async function succeeds(fixture, argv) {
+  const result = await runCli(fixture, [...argv, "--json"], { cwd: fixture.worktree });
+  assert.equal(result.code, 0, result.stderr || result.stdout);
+  return JSON.parse(result.stdout);
+}
+
+async function foreignBusFixture(t, agents) {
+  const owner = await createGitWorktreeFixture();
+  const foreign = await createGitWorktreeFixture();
+  t.after(async () => { await Promise.all([owner.cleanup(), foreign.cleanup()]); });
+  await succeeds(owner, ["init"]);
+  for (const agent of agents) await succeeds(owner,
+    ["register", "--id", agent, "--role", "artist", "--task", "M2.7"]);
+  return { owner, foreign };
+}
+
+async function snapshotTree(root, relative = "") {
+  const directory = path.join(root, relative);
+  const entries = (await readdir(directory, { withFileTypes: true }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+  const snapshot = [];
+  for (const entry of entries) {
+    const item = path.join(relative, entry.name);
+    if (entry.isDirectory()) {
+      snapshot.push(["directory", item]);
+      snapshot.push(...await snapshotTree(root, item));
+    } else {
+      snapshot.push(["file", item,
+        (await readFile(path.join(root, item))).toString("base64")]);
+    }
+  }
+  return snapshot;
+}
+
+async function foreignCommand(fixture, argv, message = /different checkout/) {
+  const before = await snapshotTree(fixture.owner.bus);
+  const result = await runCli(fixture.owner, [...argv, "--json"], {
+    cwd: fixture.foreign.worktree,
+  });
+  const after = await snapshotTree(fixture.owner.bus);
+  assert.deepEqual(after, before, `${argv[0]} mutated a foreign checkout bus`);
+  assert.equal(result.code, 4, result.stderr || result.stdout);
+  const error = JSON.parse(result.stdout).error;
+  assert.equal(error.exit_code, 4);
+  assert.match(error.message, message);
+}
+
+test("close cannot mutate a matching-version bus owned by another checkout", async t => {
+  const fixture = await foreignBusFixture(t, ["visual"]);
+  await foreignCommand(fixture, ["close", "--id", "visual"]);
+});
+
+test("send cannot mutate a matching-version bus owned by another checkout", async t => {
+  const fixture = await foreignBusFixture(t, ["visual", "models"]);
+  await foreignCommand(fixture, ["send", "--from", "visual", "--to", "models", "--type",
+    "status", "--severity", "info", "--subject", "foreign", "--body", "must not publish"]);
+});
+
+test("doctor repair cannot mutate a matching-version foreign bus", async t => {
+  const fixture = await foreignBusFixture(t, []);
+  const corrupt = path.join(fixture.owner.bus, "inbox", "foreign", "broken.json");
+  await mkdir(path.dirname(corrupt));
+  await writeFile(corrupt, "{not-json");
+  await foreignCommand(fixture, ["doctor", "--repair"]);
+});
+
+test("doctor repair cannot mutate a foreign bus whose protocol is corrupt", async t => {
+  const fixture = await foreignBusFixture(t, []);
+  await writeFile(path.join(fixture.owner.bus, "protocol.json"), "{not-json");
+
+  await foreignCommand(fixture, ["doctor", "--repair"], /cannot prove checkout identity/);
+});
+
+test("init validates a foreign protocol before creating missing layout directories", async t => {
+  const fixture = await foreignBusFixture(t, []);
+  await rm(path.join(fixture.owner.bus, "artifacts"), { recursive: true });
+  await rm(path.join(fixture.owner.bus, "archive"), { recursive: true });
+
+  await foreignCommand(fixture, ["init"]);
+});
+
+// A foreign bus whose protocol cannot even be parsed or whose version is
+// unknown must fail closed for ordinary commands too, not only for repair:
+// an unreadable identity is never permission to mutate someone else's bus.
+async function unknownVersionProtocol(fixture) {
+  const file = path.join(fixture.owner.bus, "protocol.json");
+  const record = JSON.parse(await readFile(file, "utf8"));
+  await writeFile(file, `${JSON.stringify({ ...record, protocol_version: 99 })}\n`);
+}
+
+test("normal commands cannot mutate a foreign bus whose protocol is malformed", async t => {
+  const fixture = await foreignBusFixture(t, ["visual"]);
+  await writeFile(path.join(fixture.owner.bus, "protocol.json"), "{not-json");
+
+  await foreignCommand(fixture, ["close", "--id", "visual"], /invalid JSON record/);
+});
+
+test("normal commands cannot mutate a foreign bus whose protocol version is unknown", async t => {
+  const fixture = await foreignBusFixture(t, ["visual"]);
+  await unknownVersionProtocol(fixture);
+
+  await foreignCommand(fixture, ["close", "--id", "visual"], /unknown protocol version/);
+});
+
+test("doctor repair cannot mutate a foreign bus whose protocol version is unknown", async t => {
+  const fixture = await foreignBusFixture(t, []);
+  await unknownVersionProtocol(fixture);
+
+  await foreignCommand(fixture, ["doctor", "--repair"], /cannot prove checkout identity/);
+});
+
+test("init refuses a foreign protocol standing alone without any layout directory", async t => {
+  const fixture = await foreignBusFixture(t, []);
+  const protocolFile = path.join(fixture.owner.bus, "protocol.json");
+  const record = await readFile(protocolFile);
+  for (const entry of await readdir(fixture.owner.bus)) {
+    if (entry !== "protocol.json") await rm(path.join(fixture.owner.bus, entry), { recursive: true });
+  }
+
+  await foreignCommand(fixture, ["init"]);
+
+  assert.deepEqual(await readdir(fixture.owner.bus), ["protocol.json"]);
+  assert.deepEqual(await readFile(protocolFile), record);
+});
+
+test("doctor repair may quarantine a corrupt protocol on the canonical checkout bus", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  await succeeds(fixture, ["init"]);
+  await writeFile(path.join(fixture.bus, "protocol.json"), "{not-json");
+
+  const result = await runCli(fixture, ["doctor", "--repair", "--json"], {
+    cwd: fixture.worktree,
+  });
+
+  assert.equal(result.code, 4, result.stderr || result.stdout);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.repairs.some(item => item.action === "quarantine_corrupt_json"), true);
+  assert.equal(await pathExists(path.join(fixture.bus, "protocol.json")), false);
+});
+
+test("a valid external bus bound to the current checkout remains usable", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  const externalBus = path.join(fixture.root, "external-bus");
+  const options = { cwd: fixture.worktree, env: { PW2_AGENT_BUS_DIR: externalBus } };
+  const initialized = await runCli(fixture, ["init", "--json"], options);
+  assert.equal(initialized.code, 0, initialized.stderr || initialized.stdout);
+
+  const doctor = await runCli(fixture, ["doctor", "--json"], options);
+
+  assert.equal(doctor.code, 0, doctor.stderr || doctor.stdout);
+  assert.equal(JSON.parse(doctor.stdout).ok, true);
+});

--- a/prototype/integrated/tests/tools/agent_comms/handoff.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/handoff.test.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { readFile, readdir, writeFile } from "node:fs/promises";
+import test from "node:test";
+
+import { describeAttachment } from "../../../tools/agents/lib/attachments.mjs";
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import { createHandoff } from "../../../tools/agents/lib/handoff.mjs";
+import { validateHandoff } from "../../../tools/agents/lib/schema.mjs";
+import {
+  createMessagingFixture,
+  messageUuid,
+  pathExists,
+} from "./helpers.mjs";
+
+const COMMIT = "b".repeat(40);
+const BASE = "c".repeat(40);
+
+async function validHandoff(context, overrides = {}) {
+  await writeFile(`${context.repoRoot}/evidence.txt`, "evidence\n");
+  const artifact = await describeAttachment(context, {
+    path: "evidence.txt",
+    ephemeral: false,
+    commit: COMMIT,
+  });
+  return {
+    from: "visual",
+    to: "models",
+    task: "M2.7",
+    result: "Stable material slots added.",
+    branch: "m2/visual",
+    commit: COMMIT,
+    base: BASE,
+    changedPaths: ["game/presentation/tank.gd"],
+    verification: [{ command: "node --test", exitCode: 0, summary: "pass" }],
+    contracts: { added: [], changed: ["tank-registration-v1"], consumed: [] },
+    followUp: ["models"],
+    artifacts: [artifact],
+    limitations: [],
+    uncommitted: false,
+    ...overrides,
+  };
+}
+
+test("committed handoff requires branch, commit, base, paths, and verification", async t => {
+  const { context } = await createMessagingFixture(t);
+  const handoff = await validHandoff(context);
+
+  await assert.rejects(
+    createHandoff(context, { ...handoff, verification: [] }),
+    error => error.exitCode === EXIT.DATA && error.message.includes("verification"),
+  );
+  for (const input of [
+    { ...handoff, branch: "" },
+    { ...handoff, commit: "b".repeat(39) },
+    { ...handoff, base: "C".repeat(40) },
+    { ...handoff, changedPaths: ["../tank.gd"] },
+  ]) {
+    await assert.rejects(createHandoff(context, input), error => error.exitCode === EXIT.DATA);
+  }
+});
+
+test("uncommitted handoff is never ready to merge", async t => {
+  const { context } = await createMessagingFixture(t);
+  const handoff = await validHandoff(context, { commit: null, uncommitted: true });
+
+  const { record, message } = await createHandoff(context, handoff);
+
+  assert.equal(record.ready_to_merge, false);
+  assert.equal(record.state, "UNCOMMITTED");
+  assert.equal(message.type, "handoff");
+  assert.equal(message.requires_ack, true);
+  assert.match(message.body, /UNCOMMITTED/);
+  assert.match(message.body, /never ready to merge/);
+});
+
+test("handoff record and addressed message share immutable evidence", async t => {
+  const { context } = await createMessagingFixture(t, {
+    randomUUID: () => messageUuid(1),
+  });
+  const handoff = await validHandoff(context);
+  const { record, message } = await createHandoff(context, handoff);
+
+  const stored = JSON.parse(await readFile(context.paths.handoffFile(record.id), "utf8"));
+  assert.deepEqual(validateHandoff(stored), record);
+  assert.deepEqual(message.attachments, record.artifacts);
+  assert.match(message.body, new RegExp(record.id));
+  assert.deepEqual(record.changed_paths, ["game/presentation/tank.gd"]);
+  assert.deepEqual(record.follow_up, ["models"]);
+  assert.equal(record.artifacts[0].sha256.length, 64);
+  assert.equal(record.artifacts[0].size, 9);
+  await assert.rejects(createHandoff(context, handoff), error => error.exitCode === EXIT.CONFLICT);
+  assert.deepEqual(JSON.parse(await readFile(context.paths.handoffFile(record.id), "utf8")), record);
+});
+
+test("stale artifact evidence is rejected before handoff publication", async t => {
+  const { context } = await createMessagingFixture(t);
+  const handoff = await validHandoff(context);
+  await writeFile(`${context.repoRoot}/evidence.txt`, "changed evidence\n");
+
+  await assert.rejects(createHandoff(context, handoff), error => error.exitCode === EXIT.DATA);
+  assert.deepEqual(await readdir(context.paths.handoffs), []);
+});
+
+test("failed verification is retained but cannot make a committed handoff ready", async t => {
+  const { context } = await createMessagingFixture(t);
+  const handoff = await validHandoff(context, {
+    verification: [{ command: "node --test", exitCode: 1, summary: "failed" }],
+  });
+
+  const { record, message } = await createHandoff(context, handoff);
+
+  assert.equal(record.ready_to_merge, false);
+  assert.equal(record.state, "NOT_READY");
+  assert.match(message.body, /exit 1/);
+});
+
+test("delivery failure preserves published handoff evidence for diagnosis", async t => {
+  const { context } = await createMessagingFixture(t);
+  const handoff = await validHandoff(context, { to: "missing" });
+
+  await assert.rejects(createHandoff(context, handoff), error => error.exitCode === EXIT.CONFLICT);
+
+  const files = await readdir(context.paths.handoffs);
+  assert.equal(files.length, 1);
+  const stored = validateHandoff(JSON.parse(await readFile(
+    `${context.paths.handoffs}/${files[0]}`,
+    "utf8",
+  )));
+  assert.equal(stored.to, "missing");
+  assert.equal(await pathExists(context.paths.inboxDir("missing")), false);
+});

--- a/prototype/integrated/tests/tools/agent_comms/harness-hermeticity.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/harness-hermeticity.test.mjs
@@ -1,0 +1,53 @@
+// Regression for a real incident: run under a git hook, the suite inherited
+// GIT_DIR and every fixture operated on the ambient repository instead of its
+// own temporary one. That flipped the real repo to bare, created a stray
+// branch, and stacked empty "fixture" commits onto the working branch.
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { createGitWorktreeFixture, hermeticEnv, runCli } from "./helpers.mjs";
+
+function withEnvironment(t, values) {
+  const previous = new Map(Object.keys(values).map(key => [key, process.env[key]]));
+  Object.assign(process.env, values);
+  t.after(() => {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+}
+
+test("hermeticEnv strips every inherited git variable", () => {
+  const environment = hermeticEnv({ PW2_AGENT_BUS_DIR: "/tmp/bus" });
+
+  assert.deepEqual(Object.keys(environment).filter(key => key.startsWith("GIT_")), []);
+  assert.equal(environment.PW2_AGENT_BUS_DIR, "/tmp/bus");
+  assert.equal(environment.PATH, process.env.PATH, "the rest of the environment was dropped");
+});
+
+test("fixtures ignore an ambient GIT_DIR belonging to another repository", async t => {
+  // A git hook exports these. Pointing them somewhere that does not exist means
+  // any leaked variable makes fixture git commands fail loudly instead of
+  // silently mutating whatever repository the suite happens to run inside.
+  withEnvironment(t, {
+    GIT_DIR: path.join(os.tmpdir(), "acc-absent-git-dir"),
+    GIT_WORK_TREE: path.join(os.tmpdir(), "acc-absent-work-tree"),
+    GIT_INDEX_FILE: path.join(os.tmpdir(), "acc-absent-index"),
+  });
+
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+
+  const initialized = await runCli(fixture, ["init"], { cwd: fixture.worktree });
+  assert.equal(initialized.code, 0, initialized.stderr);
+  const registered = await runCli(fixture, ["register", "--id", "visual", "--role", "artist",
+    "--task", "M2.7", "--json"], { cwd: fixture.worktree });
+  assert.equal(registered.code, 0, registered.stderr);
+
+  // The registration records Git state, so a leaked GIT_DIR would surface here
+  // as another repository's branch and HEAD rather than the fixture's own.
+  assert.equal(JSON.parse(registered.stdout).branch, "linked");
+});

--- a/prototype/integrated/tests/tools/agent_comms/helpers.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/helpers.mjs
@@ -1,0 +1,284 @@
+import { execFile, spawn } from "node:child_process";
+import { access, mkdtemp, mkdir, realpath, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import {
+  createBusPaths,
+  ensureBusLayout,
+  resolveBusDir,
+} from "../../../tools/agents/lib/paths.mjs";
+
+const execFileAsync = promisify(execFile);
+
+async function git(cwd, args) {
+  const { stdout } = await execFileAsync("git", args, { cwd });
+  return stdout;
+}
+
+export async function createGitWorktreeFixture() {
+  const root = await mkdtemp(path.join(os.tmpdir(), "pw2-agent-git-"));
+  const main = path.join(root, "main");
+  const worktree = path.join(root, "linked");
+  await mkdir(main);
+  await git(main, ["init", "--quiet", "--initial-branch=main"]);
+  await git(main, ["config", "user.name", "Agent Comms Test"]);
+  await git(main, ["config", "user.email", "agent-comms@example.invalid"]);
+  await git(main, ["commit", "--quiet", "--allow-empty", "-m", "fixture"]);
+  await git(main, ["worktree", "add", "--quiet", "-b", "linked", worktree]);
+
+  const canonicalMain = await realpath(main);
+  const canonicalWorktree = await realpath(worktree);
+  const bus = path.join(canonicalMain, ".agents");
+  return {
+    root,
+    main: canonicalMain,
+    worktree: canonicalWorktree,
+    bus,
+    resolveFrom: async cwd => resolveBusDir({
+      cwd,
+      env: {},
+      runGit: directory => git(directory, [
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-common-dir",
+      ]),
+    }),
+    cleanup: () => rm(root, { recursive: true, force: true }),
+  };
+}
+
+export async function createBusFixture() {
+  const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "pw2-agent-bus-"));
+  const root = await realpath(temporaryRoot);
+  const repo = path.join(root, "repo");
+  const bus = path.join(root, ".agents");
+  await mkdir(repo);
+  const paths = createBusPaths(bus);
+  await ensureBusLayout(paths);
+  const clock = createFakeClock("2026-08-14T18:00:00.000Z");
+
+  return {
+    root,
+    repo,
+    bus,
+    paths,
+    clock,
+    context: {
+      paths,
+      now: clock.now,
+    },
+    cleanup: () => rm(root, { recursive: true, force: true }),
+  };
+}
+
+export function createFakeClock(startIso) {
+  let current = Date.parse(startIso);
+  if (!Number.isFinite(current)) throw new TypeError("invalid fake-clock start time");
+
+  return Object.freeze({
+    now: () => new Date(current),
+    advance: milliseconds => {
+      current += milliseconds;
+      return new Date(current);
+    },
+    set: iso => {
+      const next = Date.parse(iso);
+      if (!Number.isFinite(next)) throw new TypeError("invalid fake-clock time");
+      current = next;
+      return new Date(current);
+    },
+  });
+}
+
+export async function runCli(fixture, argv, options = {}) {
+  const child = startCli(fixture, argv, options);
+  if (options.input === undefined) child.stdin.end();
+  else child.stdin.end(options.input);
+  const code = await new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", resolve);
+  });
+  return { code, stdout: child.collected.stdout, stderr: child.collected.stderr };
+}
+
+export function startCli(fixture, argv, options = {}) {
+  const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+  const executable = path.resolve(testDirectory, "../../../tools/agents/comms.mjs");
+  const child = spawn(process.execPath, [executable, ...argv], {
+    cwd: options.cwd ?? fixture.repo,
+    env: {
+      ...process.env,
+      PW2_AGENT_BUS_DIR: fixture.bus,
+      ...options.env,
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", chunk => { stdout += chunk; });
+  child.stderr.on("data", chunk => { stderr += chunk; });
+  Object.defineProperty(child, "collected", { value: { get stdout() { return stdout; },
+    get stderr() { return stderr; } } });
+  return child;
+}
+
+export async function pathExists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch (error) {
+    if (error.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+export async function seedOpenAgent(context, input) {
+  const { writeJsonAtomic } = await import("../../../tools/agents/lib/atomic-json.mjs");
+  const { validateRegistry } = await import("../../../tools/agents/lib/schema.mjs");
+  const now = context.now().toISOString();
+  const record = validateRegistry({
+    schema_version: 1,
+    agent_id: input.agentId,
+    role: input.role ?? input.agentId,
+    task: input.task ?? "M2.test",
+    worktree: input.worktree ?? "/tmp/test-worktree",
+    branch: input.branch ?? `test/${input.agentId}`,
+    head: input.head ?? "a".repeat(40),
+    ownership: input.ownership ?? [],
+    status: "open",
+    registered_at: input.registeredAt ?? now,
+    updated_at: input.updatedAt ?? now,
+    ...(input.client === undefined ? {} : { client: input.client }),
+  });
+  await writeJsonAtomic(context.paths.registryFile(record.agent_id), record, {
+    tmpDir: context.paths.tmp,
+    exclusive: true,
+  });
+  return record;
+}
+
+export async function seedPresence(context, input) {
+  const { writeJsonAtomic } = await import("../../../tools/agents/lib/atomic-json.mjs");
+  const { validatePresence } = await import("../../../tools/agents/lib/schema.mjs");
+  const record = validatePresence({
+    schema_version: 1,
+    agent_id: input.agentId,
+    pid: input.pid ?? 1234,
+    status: input.status ?? "online",
+    heartbeat_at: input.heartbeatAt ?? context.now().toISOString(),
+  });
+  await writeJsonAtomic(context.paths.presenceFile(record.agent_id), record, {
+    tmpDir: context.paths.tmp,
+    exclusive: false,
+  });
+  return record;
+}
+
+export async function seedMessage(context, input) {
+  const { writeJsonAtomic } = await import("../../../tools/agents/lib/atomic-json.mjs");
+  const { validateMessage } = await import("../../../tools/agents/lib/schema.mjs");
+  const record = validateMessage(input);
+  await writeJsonAtomic(context.paths.inboxFile(record.to, record.id), record, {
+    tmpDir: context.paths.tmp,
+    exclusive: true,
+  });
+  return record;
+}
+
+export function messageUuid(index) {
+  return `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`;
+}
+
+export function messageRequest(overrides = {}) {
+  return {
+    from: "visual",
+    to: "models",
+    type: "contract_request",
+    severity: "action",
+    subject: "Need material slots",
+    body: "Provide stable hull and turret surface names.",
+    task: "M2.7",
+    requiresAck: true,
+    attachments: [],
+    ...overrides,
+  };
+}
+
+export function replyRequest(messageId, overrides = {}) {
+  return {
+    from: "models",
+    messageId,
+    type: "contract_response",
+    severity: "info",
+    subject: "Material slots",
+    body: "Use hull_paper and turret_paper.",
+    task: "M2.7",
+    attachments: [],
+    ...overrides,
+  };
+}
+
+export function broadcastRequest(overrides = {}) {
+  return {
+    from: "visual",
+    severity: "action",
+    subject: "Contract changed",
+    body: "Review contract v2.",
+    task: "M2.7",
+    requiresAck: true,
+    attachments: [],
+    ...overrides,
+  };
+}
+
+export async function createMessagingFixture(t, options = {}) {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  let nextUuid = options.uuidStart ?? 1;
+  const context = {
+    paths: fixture.paths,
+    repoRoot: fixture.repo,
+    now: fixture.clock.now,
+    randomUUID: options.randomUUID ?? (() => messageUuid(nextUuid++)),
+    listActiveAgentIds: options.listActiveAgentIds ?? (async () => []),
+  };
+  const agentIds = options.agentIds ?? ["visual", "models"];
+  await Promise.all(agentIds.map(agentId => seedOpenAgent(context, {
+    agentId,
+    task: "M2.7",
+    head: "a".repeat(40),
+  })));
+  return { ...fixture, context };
+}
+
+async function seedReceipt(context, message, kind, overrides) {
+  const { writeJsonAtomic } = await import("../../../tools/agents/lib/atomic-json.mjs");
+  const schema = await import("../../../tools/agents/lib/schema.mjs");
+  const seen = kind === "seen";
+  const receipt = (seen ? schema.validateSeenReceipt : schema.validateAcknowledgement)({
+    schema_version: 1,
+    message_id: message.id,
+    recipient: message.to,
+    [seen ? "seen_at" : "acknowledged_at"]: context.now().toISOString(),
+    ...overrides,
+  });
+  const filePath = seen
+    ? context.paths.seenFile(message.id, message.to)
+    : context.paths.ackFile(message.id, message.to);
+  await writeJsonAtomic(filePath, receipt, { tmpDir: context.paths.tmp, exclusive: true });
+  return receipt;
+}
+
+export async function seedSeenReceipt(context, message, overrides = {}) {
+  return seedReceipt(context, message, "seen", overrides);
+}
+
+export async function seedAcknowledgement(context, message, overrides = {}) {
+  return seedReceipt(context, message, "acknowledgement", overrides);
+}

--- a/prototype/integrated/tests/tools/agent_comms/helpers.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/helpers.mjs
@@ -13,8 +13,17 @@ import {
 
 const execFileAsync = promisify(execFile);
 
+// Git exports GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE and friends into the
+// environment of anything it runs, hooks included. Inheriting them makes every
+// fixture operate on the ambient repository instead of its own temporary one,
+// so they are stripped unconditionally rather than only when a hook is noticed.
+export function hermeticEnv(overrides = {}) {
+  const inherited = Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_"));
+  return { ...Object.fromEntries(inherited), ...overrides };
+}
+
 async function git(cwd, args) {
-  const { stdout } = await execFileAsync("git", args, { cwd });
+  const { stdout } = await execFileAsync("git", args, { cwd, env: hermeticEnv() });
   return stdout;
 }
 
@@ -109,11 +118,10 @@ export function startCli(fixture, argv, options = {}) {
   const executable = path.resolve(testDirectory, "../../../tools/agents/comms.mjs");
   const child = spawn(process.execPath, [executable, ...argv], {
     cwd: options.cwd ?? fixture.repo,
-    env: {
-      ...process.env,
+    env: hermeticEnv({
       PW2_AGENT_BUS_DIR: fixture.bus,
       ...options.env,
-    },
+    }),
     stdio: ["pipe", "pipe", "pipe"],
   });
 

--- a/prototype/integrated/tests/tools/agent_comms/identity-storage.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/identity-storage.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import { requireOpenAgent } from "../../../tools/agents/lib/identity.mjs";
+import { createBusFixture, seedOpenAgent } from "./helpers.mjs";
+
+test("registry reads reject a parent directory replaced by a symlink", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const record = await seedOpenAgent(fixture.context, { agentId: "visual" });
+  const external = path.join(fixture.root, "external-registry");
+  const externalFile = path.join(external, "visual.json");
+  const bytes = `${JSON.stringify(record, null, 2)}\n`;
+  await mkdir(external);
+  await writeFile(externalFile, bytes);
+  await rm(fixture.paths.registry, { recursive: true });
+  await symlink(external, fixture.paths.registry);
+
+  await assert.rejects(
+    requireOpenAgent(fixture.context, "visual"),
+    error => error.exitCode === EXIT.DATA,
+  );
+  assert.equal(await readFile(externalFile, "utf8"), bytes);
+});

--- a/prototype/integrated/tests/tools/agent_comms/identity.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/identity.test.mjs
@@ -1,0 +1,262 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile, realpath, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import { createBusPaths, ensureBusLayout } from "../../../tools/agents/lib/paths.mjs";
+import { validatePresence } from "../../../tools/agents/lib/schema.mjs";
+import {
+  createBusFixture,
+  createGitWorktreeFixture,
+  seedPresence,
+} from "./helpers.mjs";
+import {
+  closeAgent,
+  initBus,
+  registerAgent,
+  requireOpenAgent,
+} from "../../../tools/agents/lib/identity.mjs";
+
+const HEAD = "a".repeat(40);
+
+function registration(agentId, worktree, overrides = {}) {
+  return {
+    agentId,
+    role: agentId,
+    task: "M2.7",
+    worktree,
+    ownership: ["tools/agents"],
+    client: "codex",
+    ...overrides,
+  };
+}
+
+function contextFor(fixture, options = {}) {
+  return {
+    paths: fixture.paths,
+    now: fixture.clock.now,
+    pidIsAlive: options.pidIsAlive ?? (() => false),
+    gitState: options.gitState ?? (async () => ({ branch: "m2/identity", head: HEAD })),
+    releaseOwnedClaims: options.releaseOwnedClaims ?? (async () => {}),
+  };
+}
+
+async function writeLivePresence(context, agentId, pid) {
+  await seedPresence(context, { agentId, pid, status: "online" });
+}
+
+test("init records the canonical checkout identity exactly once", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  const paths = createBusPaths(fixture.bus);
+  const clock = { now: () => new Date("2026-08-14T18:00:00.000Z") };
+  const context = {
+    paths,
+    now: clock.now,
+    pidIsAlive: () => false,
+    gitState: async () => ({ branch: "main", head: HEAD }),
+    releaseOwnedClaims: async () => {},
+  };
+  const commonDir = await realpath(path.join(fixture.main, ".git"));
+  const expected = {
+    schema_version: 1,
+    protocol_version: 1,
+    checkout_id: createHash("sha256").update(commonDir).digest("hex"),
+    checkout_root: fixture.main,
+    initialized_at: "2026-08-14T18:00:00.000Z",
+  };
+
+  assert.deepEqual(await initBus(context), expected);
+  assert.deepEqual(JSON.parse(await readFile(paths.protocol, "utf8")), expected);
+});
+
+test("compatible init is idempotent", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  const paths = createBusPaths(fixture.bus);
+  let timestamp = "2026-08-14T18:00:00.000Z";
+  const context = {
+    paths,
+    now: () => new Date(timestamp),
+    pidIsAlive: () => false,
+    gitState: async () => ({ branch: "main", head: HEAD }),
+    releaseOwnedClaims: async () => {},
+  };
+
+  const first = await initBus(context);
+  timestamp = "2026-08-14T18:01:00.000Z";
+  assert.deepEqual(await initBus(context), first);
+});
+
+test("init refuses to replace an unknown protocol version", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  const paths = createBusPaths(fixture.bus);
+  await ensureBusLayout(paths);
+  const incompatible = {
+    schema_version: 1,
+    protocol_version: 2,
+    checkout_id: "b".repeat(64),
+    checkout_root: fixture.main,
+    initialized_at: "2026-08-14T18:00:00.000Z",
+  };
+  await writeFile(paths.protocol, `${JSON.stringify(incompatible)}\n`, "utf8");
+  const context = {
+    paths,
+    now: () => new Date("2026-08-14T18:01:00.000Z"),
+    pidIsAlive: () => false,
+    gitState: async () => ({ branch: "main", head: HEAD }),
+    releaseOwnedClaims: async () => {},
+  };
+
+  await assert.rejects(initBus(context), error => error.exitCode === EXIT.DATA);
+  assert.deepEqual(JSON.parse(await readFile(paths.protocol, "utf8")), incompatible);
+});
+
+test("registration captures the Git branch and HEAD", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const context = contextFor(fixture, {
+    gitState: async cwd => ({ branch: `branch-for-${path.basename(cwd)}`, head: HEAD }),
+  });
+
+  const record = await registerAgent(context, registration("visual", "/tmp/visual-worktree"));
+
+  assert.deepEqual(record, {
+    schema_version: 1,
+    agent_id: "visual",
+    role: "visual",
+    task: "M2.7",
+    worktree: "/tmp/visual-worktree",
+    branch: "branch-for-visual-worktree",
+    head: HEAD,
+    ownership: ["tools/agents"],
+    client: "codex",
+    status: "open",
+    registered_at: "2026-08-14T18:00:00.000Z",
+    updated_at: "2026-08-14T18:00:00.000Z",
+  });
+});
+
+test("a live duplicate id is rejected", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const context = contextFor(fixture, { pidIsAlive: pid => pid === 1234 });
+  await registerAgent(context, registration("visual", "/tmp/worktree-a"));
+  await writeLivePresence(context, "visual", 1234);
+
+  await assert.rejects(
+    registerAgent(context, registration("visual", "/tmp/worktree-b")),
+    error => error.exitCode === EXIT.CONFLICT,
+  );
+});
+
+test("registration becomes stale without a live heartbeat", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const context = contextFor(fixture, { pidIsAlive: () => true });
+  await registerAgent(context, registration("visual", "/tmp/worktree-a"));
+  await writeLivePresence(context, "visual", 1234);
+  fixture.clock.advance(45_001);
+
+  const replacement = await registerAgent(context, registration("visual", "/tmp/worktree-b"));
+  assert.equal(replacement.worktree, "/tmp/worktree-b");
+});
+
+test("resume requires the same worktree and task", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const context = contextFor(fixture);
+  const first = await registerAgent(context, registration("models", "/tmp/worktree-a"));
+  const resumed = await registerAgent(context, { ...first, resume: true });
+
+  assert.equal(resumed.agent_id, "models");
+  await assert.rejects(
+    registerAgent(context, { ...first, task: "M2.8", resume: true }),
+    error => error.exitCode === EXIT.CONFLICT,
+  );
+  await assert.rejects(
+    registerAgent(context, { ...first, worktree: "/tmp/worktree-b", resume: true }),
+    error => error.exitCode === EXIT.CONFLICT,
+  );
+});
+
+test("requireOpenAgent rejects missing and closed registrations", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const context = contextFor(fixture);
+
+  await assert.rejects(
+    requireOpenAgent(context, "missing"),
+    error => error.exitCode === EXIT.CONFLICT,
+  );
+  await registerAgent(context, registration("visual", "/tmp/worktree-a"));
+  await closeAgent(context, "visual");
+  await assert.rejects(
+    requireOpenAgent(context, "visual"),
+    error => error.exitCode === EXIT.CONFLICT,
+  );
+});
+
+test("requireOpenAgent returns a strict open registry record", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const context = contextFor(fixture);
+  const registered = await registerAgent(context, registration("visual", "/tmp/worktree-a"));
+
+  assert.deepEqual(await requireOpenAgent(context, "visual"), registered);
+});
+
+test("requireOpenAgent accepts stale and offline open registrations", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const context = contextFor(fixture, { pidIsAlive: () => true });
+  const cases = [
+    {
+      agentId: "visual",
+      presence: { status: "online", heartbeatAt: "2026-08-14T17:59:14.999Z" },
+    },
+    {
+      agentId: "models",
+      presence: { status: "offline", heartbeatAt: "2026-08-14T18:00:00.000Z" },
+    },
+  ];
+
+  for (const item of cases) {
+    const registered = await registerAgent(
+      context,
+      registration(item.agentId, `/tmp/${item.agentId}-worktree`),
+    );
+    await seedPresence(context, { agentId: item.agentId, pid: 1234, ...item.presence });
+    assert.deepEqual(await requireOpenAgent(context, item.agentId), registered);
+  }
+});
+
+test("close refuses a live watcher and releases only the closed agent claims", async t => {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const released = [];
+  const context = contextFor(fixture, {
+    pidIsAlive: pid => pid === 1234,
+    releaseOwnedClaims: async agentId => { released.push(agentId); },
+  });
+  await registerAgent(context, registration("visual", "/tmp/worktree-a"));
+  await registerAgent(context, registration("models", "/tmp/worktree-b"));
+  await writeLivePresence(context, "visual", 1234);
+
+  await assert.rejects(closeAgent(context, "visual"), error => error.exitCode === EXIT.CONFLICT);
+  await seedPresence(context, { agentId: "visual", pid: 1234, status: "offline" });
+  const closed = await closeAgent(context, "visual");
+  const presence = await readPresence(context, "visual");
+
+  assert.equal(closed.status, "closed");
+  assert.equal(closed.closed_at, "2026-08-14T18:00:00.000Z");
+  assert.equal(presence.status, "offline");
+  assert.deepEqual(released, ["visual"]);
+});
+
+async function readPresence(context, agentId) {
+  return validatePresence(JSON.parse(await readFile(context.paths.presenceFile(agentId), "utf8")));
+}

--- a/prototype/integrated/tests/tools/agent_comms/identity.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/identity.test.mjs
@@ -18,6 +18,8 @@ import {
   registerAgent,
   requireOpenAgent,
 } from "../../../tools/agents/lib/identity.mjs";
+import { acquireWatcherOwnership, writePresenceIfWatcherOwner }
+  from "../../../tools/agents/lib/watcher-ownership.mjs";
 
 const HEAD = "a".repeat(40);
 
@@ -153,7 +155,7 @@ test("a live duplicate id is rejected", async t => {
   );
 });
 
-test("registration becomes stale without a live heartbeat", async t => {
+test("stale open registration still requires an explicit resume", async t => {
   const fixture = await createBusFixture();
   t.after(fixture.cleanup);
   const context = contextFor(fixture, { pidIsAlive: () => true });
@@ -161,8 +163,8 @@ test("registration becomes stale without a live heartbeat", async t => {
   await writeLivePresence(context, "visual", 1234);
   fixture.clock.advance(45_001);
 
-  const replacement = await registerAgent(context, registration("visual", "/tmp/worktree-b"));
-  assert.equal(replacement.worktree, "/tmp/worktree-b");
+  await assert.rejects(registerAgent(context, registration("visual", "/tmp/worktree-b")),
+    error => error.exitCode === EXIT.CONFLICT);
 });
 
 test("resume requires the same worktree and task", async t => {
@@ -244,10 +246,10 @@ test("close refuses a live watcher and releases only the closed agent claims", a
   });
   await registerAgent(context, registration("visual", "/tmp/worktree-a"));
   await registerAgent(context, registration("models", "/tmp/worktree-b"));
-  await writeLivePresence(context, "visual", 1234);
+  const owner = await acquireWatcherOwnership(context, "visual", 1234);
 
   await assert.rejects(closeAgent(context, "visual"), error => error.exitCode === EXIT.CONFLICT);
-  await seedPresence(context, { agentId: "visual", pid: 1234, status: "offline" });
+  await writePresenceIfWatcherOwner(context, owner, "offline", true);
   const closed = await closeAgent(context, "visual");
   const presence = await readPresence(context, "visual");
 

--- a/prototype/integrated/tests/tools/agent_comms/integration.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/integration.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import test from "node:test";
+
+import { createGitWorktreeFixture, runCli, startCli } from "./helpers.mjs";
+
+const execFileAsync = promisify(execFile);
+const delay = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds));
+
+async function jsonCli(fixture, argv, options) {
+  const result = await runCli(fixture, [...argv, "--json"], options);
+  assert.equal(result.code, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+test("the executable covers every command and stable process exit", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  const executable = path.resolve(path.dirname(fileURLToPath(import.meta.url)),
+    "../../../tools/agents/comms.mjs");
+  const [firstLine, details] = await Promise.all([
+    readFile(executable, "utf8").then(text => text.split("\n")[0]), stat(executable),
+  ]);
+  assert.equal(firstLine, "#!/usr/bin/env node");
+  assert.notEqual(details.mode & 0o111, 0);
+
+  const beforeInit = await runCli(fixture, ["status"], { cwd: fixture.worktree });
+  assert.equal(beforeInit.code, 4);
+  assert.match(beforeInit.stderr, /protocol/i);
+  assert.equal((await runCli(fixture, ["unknown"])).code, 2);
+  assert.equal((await runCli(fixture, ["wait", "--id", "visual", "--timeout"])).code, 2);
+
+  const initialized = await jsonCli(fixture, ["init"], { cwd: fixture.worktree });
+  assert.equal(initialized.schema_version, 1);
+  await jsonCli(fixture, ["register", "--id", "visual", "--role", "orchestrator", "--task",
+    "M2.7", "--ownership", "game/presentation"], { cwd: fixture.worktree });
+  await jsonCli(fixture, ["register", "--id", "models", "--role", "artist", "--task", "M2.7"],
+    { cwd: fixture.worktree });
+
+  const sent = await jsonCli(fixture, ["send", "--from", "visual", "--to", "models", "--type",
+    "question", "--severity", "action", "--subject", "first", "--body", "inline",
+    "--requires-ack"], { cwd: fixture.worktree });
+  const bodyFile = path.join(fixture.worktree, "body.txt");
+  await writeFile(bodyFile, "from file");
+  await jsonCli(fixture, ["send", "--from", "visual", "--to", "models", "--type", "status",
+    "--severity", "info", "--subject", "second", "--body-file", "body.txt"],
+  { cwd: fixture.worktree });
+  await jsonCli(fixture, ["send", "--from", "visual", "--to", "models", "--type", "status",
+    "--severity", "info", "--subject", "third"], { cwd: fixture.worktree, input: "stdin" });
+  const broadcast = await jsonCli(fixture, ["broadcast", "--from", "visual", "--severity", "info",
+    "--subject", "notice", "--body", "all"], { cwd: fixture.worktree });
+  assert.equal(broadcast.length, 1);
+
+  const inbox = await jsonCli(fixture, ["inbox", "--id", "models"], { cwd: fixture.worktree });
+  assert.equal(inbox.length, 4);
+  await jsonCli(fixture, ["ack", "--id", "models", "--message", sent.id], { cwd: fixture.worktree });
+  await jsonCli(fixture, ["reply", "--from", "models", "--message", sent.id, "--type",
+    "contract_response", "--severity", "info", "--subject", "answer", "--body", "done"],
+  { cwd: fixture.worktree });
+  await jsonCli(fixture, ["inbox", "--id", "visual"], { cwd: fixture.worktree });
+
+  const timeout = await runCli(fixture, ["wait", "--id", "visual", "--timeout", "0.01"],
+    { cwd: fixture.worktree });
+  assert.equal(timeout.code, 3, timeout.stderr);
+  assert.equal(timeout.stderr, "");
+
+  const watch = startCli(fixture, ["watch", "--id", "models", "--scan-interval", "0.01"],
+    { cwd: fixture.worktree });
+  watch.stdin.end();
+  await delay(80);
+  await jsonCli(fixture, ["send", "--from", "visual", "--to", "models", "--type", "status",
+    "--severity", "info", "--subject", "watch", "--body", "event"], { cwd: fixture.worktree });
+  await delay(120);
+  watch.kill("SIGINT");
+  const watchCode = await new Promise(resolve => watch.once("close", resolve));
+  assert.equal(watchCode, 0);
+  assert.ok(watch.collected.stdout.trim().split("\n").every(line => JSON.parse(line).event === "message"));
+
+  await jsonCli(fixture, ["claim", "--id", "models", "--scope", "game/models", "--reason", "mesh"],
+    { cwd: fixture.worktree });
+  assert.equal((await runCli(fixture, ["claim", "--id", "visual", "--scope", "game/models",
+    "--reason", "overlap"], { cwd: fixture.worktree })).code, 5);
+  await jsonCli(fixture, ["release", "--id", "models", "--scope", "game/models"],
+    { cwd: fixture.worktree });
+
+  const revision = (await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: fixture.worktree })).stdout.trim();
+  await writeFile(path.join(fixture.worktree, "proof.txt"), "proof");
+  await writeFile(path.join(fixture.worktree, "verification.json"), JSON.stringify([
+    { command: "node --test", exitCode: 0, summary: "passed" },
+  ]));
+  await writeFile(path.join(fixture.worktree, "contracts.json"), JSON.stringify({
+    added: [], changed: [], consumed: [],
+  }));
+  await writeFile(path.join(fixture.worktree, "limitations.json"), "[]");
+  await jsonCli(fixture, ["handoff", "--id", "models", "--to", "visual", "--task", "M2.7",
+    "--result", "ready", "--branch", "linked", "--commit", revision, "--base", revision,
+    "--changed", "proof.txt", "--artifact", "proof.txt", "--verification-file", "verification.json",
+    "--contracts-file", "contracts.json", "--limitations-file", "limitations.json"],
+  { cwd: fixture.worktree });
+
+  const status = await jsonCli(fixture, ["status"], { cwd: fixture.worktree });
+  assert.equal(status.protocol.schema_version, 1);
+  const required = await runCli(fixture, ["doctor", "--require-live", "visual"],
+    { cwd: fixture.worktree });
+  assert.equal(required.code, 6);
+  await jsonCli(fixture, ["close", "--id", "models"], { cwd: fixture.worktree });
+
+  await writeFile(path.join(fixture.bus, "inbox", "visual", "broken.json"), "{");
+  const corrupt = await runCli(fixture, ["inbox", "--id", "visual"], { cwd: fixture.worktree });
+  assert.equal(corrupt.code, 4);
+  assert.equal((await runCli(fixture, ["doctor"], { cwd: fixture.worktree })).code, 4);
+  assert.equal((await runCli(fixture, ["doctor", "--repair"], { cwd: fixture.worktree })).code, 0);
+});

--- a/prototype/integrated/tests/tools/agent_comms/integration.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/integration.test.mjs
@@ -51,6 +51,10 @@ test("the executable covers every command and stable process exit", async t => {
   { cwd: fixture.worktree });
   await jsonCli(fixture, ["send", "--from", "visual", "--to", "models", "--type", "status",
     "--severity", "info", "--subject", "third"], { cwd: fixture.worktree, input: "stdin" });
+  await writeFile(path.join(fixture.bus, "presence", "models.json"), `${JSON.stringify({
+    schema_version: 1, agent_id: "models", pid: process.pid, status: "online",
+    heartbeat_at: new Date().toISOString(),
+  })}\n`);
   const broadcast = await jsonCli(fixture, ["broadcast", "--from", "visual", "--severity", "info",
     "--subject", "notice", "--body", "all"], { cwd: fixture.worktree });
   assert.equal(broadcast.length, 1);

--- a/prototype/integrated/tests/tools/agent_comms/integration.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/integration.test.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import test from "node:test";
 
-import { createGitWorktreeFixture, runCli, startCli } from "./helpers.mjs";
+import { createGitWorktreeFixture, hermeticEnv, runCli, startCli } from "./helpers.mjs";
 
 const execFileAsync = promisify(execFile);
 const delay = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds));
@@ -91,7 +91,8 @@ test("the executable covers every command and stable process exit", async t => {
   await jsonCli(fixture, ["release", "--id", "models", "--scope", "game/models"],
     { cwd: fixture.worktree });
 
-  const revision = (await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: fixture.worktree })).stdout.trim();
+  const revision = (await execFileAsync("git", ["rev-parse", "HEAD"],
+    { cwd: fixture.worktree, env: hermeticEnv() })).stdout.trim();
   await writeFile(path.join(fixture.worktree, "proof.txt"), "proof");
   await writeFile(path.join(fixture.worktree, "verification.json"), JSON.stringify([
     { command: "node --test", exitCode: 0, summary: "passed" },

--- a/prototype/integrated/tests/tools/agent_comms/messages-process-storage.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/messages-process-storage.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  listJsonFiles,
+  readJsonStrict,
+  writeJsonAtomic,
+} from "../../../tools/agents/lib/atomic-json.mjs";
+import { createBusPaths } from "../../../tools/agents/lib/paths.mjs";
+import { validateMessage, validateRegistry } from "../../../tools/agents/lib/schema.mjs";
+import { createGitWorktreeFixture, runCli, startCli } from "./helpers.mjs";
+
+function waitForChild(child) {
+  child.stdin.end();
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", code => resolve({
+      code,
+      stdout: child.collected.stdout,
+      stderr: child.collected.stderr,
+    }));
+  });
+}
+
+test("one hundred independent sender processes across worktrees lose no messages",
+  { timeout: 60_000 }, async t => {
+    const fixture = await createGitWorktreeFixture();
+    t.after(fixture.cleanup);
+    const initialized = await runCli(fixture, ["init", "--json"], { cwd: fixture.main });
+    assert.equal(initialized.code, 0, initialized.stderr);
+    const paths = createBusPaths(fixture.bus);
+    const timestamp = "2026-08-14T18:00:00.000Z";
+    const senderIds = Array.from({ length: 100 }, (_, index) =>
+      `sender${String(index).padStart(3, "0")}`);
+    const registrations = ["models", ...senderIds].map((agentId, index) =>
+      validateRegistry({
+        schema_version: 1,
+        agent_id: agentId,
+        role: agentId === "models" ? "recipient" : "sender",
+        task: "M2.process-stress",
+        worktree: index % 2 === 0 ? fixture.main : fixture.worktree,
+        branch: index % 2 === 0 ? "main" : "linked",
+        head: "a".repeat(40),
+        ownership: [],
+        status: "open",
+        registered_at: timestamp,
+        updated_at: timestamp,
+      }));
+    await Promise.all(registrations.map(record => writeJsonAtomic(
+      paths.registryFile(record.agent_id),
+      record,
+      { tmpDir: paths.tmp, exclusive: true },
+    )));
+
+    const children = senderIds.map((sender, index) => startCli(fixture, [
+      "send",
+      "--from", sender,
+      "--to", "models",
+      "--type", "status",
+      "--severity", "info",
+      "--subject", `process ${index}`,
+      "--body", `body ${index}`,
+      "--json",
+    ], { cwd: index % 2 === 0 ? fixture.main : fixture.worktree }));
+    const results = await Promise.all(children.map(waitForChild));
+    assert.ok(results.every(result => result.code === 0),
+      results.filter(result => result.code !== 0).map(result => result.stderr).join("\n"));
+
+    const files = await listJsonFiles(paths.inboxDir("models"), { root: paths.root });
+    const messages = await Promise.all(files.map(file =>
+      readJsonStrict(file, validateMessage, paths.root)));
+    assert.equal(messages.length, 100);
+    assert.equal(new Set(messages.map(message => message.id)).size, 100);
+    assert.deepEqual(new Set(messages.map(message => message.from)), new Set(senderIds));
+  });

--- a/prototype/integrated/tests/tools/agent_comms/messages-storage.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/messages-storage.test.mjs
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, rename, rm, symlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import {
+  ackMessage,
+  listInbox,
+  replyToMessage,
+  sendMessage,
+} from "../../../tools/agents/lib/messages.mjs";
+import {
+  createMessagingFixture,
+  messageRequest,
+  pathExists,
+  replyRequest,
+} from "./helpers.mjs";
+
+test("inbox records are bound to their filename", async t => {
+  const { context } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  const canonical = context.paths.inboxFile("models", message.id);
+  const alias = context.paths.inboxFile("models", `${message.id}-alias`);
+  await rename(canonical, alias);
+
+  await assert.rejects(
+    listInbox(context, { agentId: "models" }),
+    error => error.exitCode === EXIT.DATA,
+  );
+});
+
+test("archived records are bound to recipient directory and filename", async t => {
+  const { context } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  const aliasId = `${message.id}-alias`;
+  const alias = context.paths.archiveFile("models", aliasId);
+  await mkdir(context.paths.archiveDir("models"), { recursive: true });
+  await rename(context.paths.inboxFile("models", message.id), alias);
+
+  await assert.rejects(
+    ackMessage(context, { agentId: "models", messageId: aliasId }),
+    error => error.exitCode === EXIT.DATA,
+  );
+});
+
+test("archived records cannot claim a different recipient directory", async t => {
+  const { context } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  const misplaced = context.paths.archiveFile("visual", message.id);
+  await mkdir(context.paths.archiveDir("visual"), { recursive: true });
+  await rename(context.paths.inboxFile("models", message.id), misplaced);
+
+  await assert.rejects(
+    ackMessage(context, { agentId: "visual", messageId: message.id }),
+    error => error.exitCode === EXIT.DATA,
+  );
+});
+
+test("acknowledgement rejects a symlinked inbox record without publishing a receipt", async t => {
+  const { context, root } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  const inboxPath = context.paths.inboxFile("models", message.id);
+  const backing = path.join(root, "backing-message.json");
+  await rename(inboxPath, backing);
+  await symlink(backing, inboxPath);
+
+  await assert.rejects(
+    ackMessage(context, { agentId: "models", messageId: message.id }),
+    error => error.exitCode === EXIT.DATA,
+  );
+  assert.equal(await pathExists(context.paths.ackFile(message.id, "models")), false);
+  assert.equal(await pathExists(context.paths.archiveFile("models", message.id)), false);
+});
+
+async function replaceRecipientDirectory(directory, external) {
+  await mkdir(external);
+  await rm(directory, { recursive: true });
+  await symlink(external, directory);
+}
+
+test("inbox listing rejects a recipient directory replaced by a symlink", async t => {
+  const { context, root } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  const inboxPath = context.paths.inboxFile("models", message.id);
+  const bytes = await readFile(inboxPath);
+  const external = path.join(root, "external-inbox-list");
+  await replaceRecipientDirectory(context.paths.inboxDir("models"), external);
+  const externalFile = path.join(external, `${message.id}.json`);
+  await writeFile(externalFile, bytes);
+
+  await assert.rejects(
+    listInbox(context, { agentId: "models" }),
+    error => error.exitCode === EXIT.DATA,
+  );
+  assert.deepEqual(await readFile(externalFile), bytes);
+});
+
+test("ack rejects a symlinked inbox parent without mutating external state", async t => {
+  const { context, root } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  const inboxPath = context.paths.inboxFile("models", message.id);
+  const bytes = await readFile(inboxPath);
+  const external = path.join(root, "external-inbox-ack");
+  await replaceRecipientDirectory(context.paths.inboxDir("models"), external);
+  const externalFile = path.join(external, `${message.id}.json`);
+  await writeFile(externalFile, bytes);
+
+  await assert.rejects(
+    ackMessage(context, { agentId: "models", messageId: message.id }),
+    error => error.exitCode === EXIT.DATA,
+  );
+  assert.deepEqual(await readFile(externalFile), bytes);
+  assert.equal(await pathExists(context.paths.ackFile(message.id, "models")), false);
+  assert.equal(await pathExists(context.paths.archiveFile("models", message.id)), false);
+});
+
+test("ack rejects a symlinked archive parent without publishing a receipt", async t => {
+  const { context, root } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  const inboxPath = context.paths.inboxFile("models", message.id);
+  const bytes = await readFile(inboxPath);
+  const external = path.join(root, "external-archive-ack");
+  await mkdir(external);
+  const externalFile = path.join(external, `${message.id}.json`);
+  await rename(inboxPath, externalFile);
+  await symlink(external, context.paths.archiveDir("models"));
+
+  await assert.rejects(
+    ackMessage(context, { agentId: "models", messageId: message.id }),
+    error => error.exitCode === EXIT.DATA,
+  );
+  assert.deepEqual(await readFile(externalFile), bytes);
+  assert.equal(await pathExists(context.paths.ackFile(message.id, "models")), false);
+});
+
+test("acknowledgement never overwrites conflicting archive evidence", async t => {
+  const { context } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  const inboxPath = context.paths.inboxFile("models", message.id);
+  const archivePath = context.paths.archiveFile("models", message.id);
+  const conflicting = `${JSON.stringify({ ...message, body: "conflicting evidence" }, null, 2)}\n`;
+  await mkdir(context.paths.archiveDir("models"), { recursive: true });
+  await writeFile(archivePath, conflicting);
+
+  await assert.rejects(
+    ackMessage(context, { agentId: "models", messageId: message.id }),
+    error => error.exitCode === EXIT.DATA,
+  );
+  assert.equal(await pathExists(inboxPath), true);
+  assert.equal(await readFile(archivePath, "utf8"), conflicting);
+});
+
+test("acknowledgement accepts only a byte-identical existing archive", async t => {
+  const { context } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  const inboxPath = context.paths.inboxFile("models", message.id);
+  const archivePath = context.paths.archiveFile("models", message.id);
+  const original = await readFile(inboxPath);
+  await mkdir(context.paths.archiveDir("models"), { recursive: true });
+  await writeFile(archivePath, original);
+
+  await ackMessage(context, { agentId: "models", messageId: message.id });
+
+  assert.equal(await pathExists(inboxPath), false);
+  assert.deepEqual(await readFile(archivePath), original);
+});
+
+test("concurrent acknowledgements finish one immutable archive", async t => {
+  const { context } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  const inboxPath = context.paths.inboxFile("models", message.id);
+  const archivePath = context.paths.archiveFile("models", message.id);
+  const original = await readFile(inboxPath);
+
+  const acknowledgements = await Promise.all(Array.from({ length: 12 }, () =>
+    ackMessage(context, { agentId: "models", messageId: message.id })));
+
+  assert.ok(acknowledgements.every(value => value.message_id === message.id));
+  assert.equal(await pathExists(inboxPath), false);
+  assert.deepEqual(await readFile(archivePath), original);
+});
+
+test("message commands reject control and path-hostile ids as data", async t => {
+  const { context } = await createMessagingFixture(t);
+  for (const messageId of ["bad\0id", "bad\nid", "colon:id", "..", "trailing."]) {
+    await assert.rejects(
+      ackMessage(context, { agentId: "models", messageId }),
+      error => error.exitCode === EXIT.DATA,
+    );
+    await assert.rejects(
+      replyToMessage(context, replyRequest(messageId)),
+      error => error.exitCode === EXIT.DATA,
+    );
+  }
+});

--- a/prototype/integrated/tests/tools/agent_comms/messages.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/messages.test.mjs
@@ -1,0 +1,267 @@
+import assert from "node:assert/strict";
+import { readFile, symlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { describeAttachment } from "../../../tools/agents/lib/attachments.mjs";
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import {
+  ackMessage, broadcastMessage, listInbox, markSeen, replyToMessage, sendMessage,
+} from "../../../tools/agents/lib/messages.mjs";
+import {
+  validateAcknowledgement,
+  validateSeenReceipt,
+} from "../../../tools/agents/lib/schema.mjs";
+import {
+  broadcastRequest,
+  createMessagingFixture,
+  messageRequest,
+  messageUuid,
+  pathExists,
+  replyRequest,
+  seedAcknowledgement,
+  seedSeenReceipt,
+} from "./helpers.mjs";
+
+test("sent message has compact timestamp, sender head, and full UUID", async t => {
+  const { context } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  assert.equal(message.id, `20260814T180000.000Z-visual-${messageUuid(1)}`);
+  assert.equal(message.sender_head, "a".repeat(40));
+  assert.equal(message.reply_to, null);
+  assert.equal(await pathExists(context.paths.inboxFile("models", message.id)), true);
+});
+
+test("unregistered sender and unknown recipient are rejected before delivery", async t => {
+  const { context } = await createMessagingFixture(t);
+  await assert.rejects(sendMessage(context, messageRequest({ from: "unknown" })),
+    error => error.exitCode === EXIT.CONFLICT);
+  await assert.rejects(sendMessage(context, messageRequest({ to: "unknown" })),
+    error => error.exitCode === EXIT.CONFLICT);
+  assert.deepEqual(await listInbox(context, { agentId: "models" }), []);
+});
+
+test("body text, body file, and stdin produce equivalent message bodies", async t => {
+  const { context, root } = await createMessagingFixture(t);
+  const body = "Line one\nLine two — shell-safe.\n";
+  const bodyFile = path.join(root, "message.txt");
+  await writeFile(bodyFile, body);
+  const direct = await sendMessage(context, messageRequest({ body }));
+  const fromFile = await sendMessage(context, messageRequest({ body: undefined, bodyFile }));
+  const fromStdin = await sendMessage(context, messageRequest({ body: undefined, stdin: body }));
+  assert.deepEqual([direct.body, fromFile.body, fromStdin.body], [body, body, body]);
+});
+
+test("inbox filters by type and severity without changing stored messages", async t => {
+  const { context } = await createMessagingFixture(t);
+  await sendMessage(context, messageRequest({ type: "question", severity: "info" }));
+  await sendMessage(context, messageRequest({ type: "blocker", severity: "blocker" }));
+  await sendMessage(context, messageRequest({ type: "status", severity: "info" }));
+  const questions = await listInbox(context, { agentId: "models", types: ["question"] });
+  const blockers = await listInbox(context, { agentId: "models", severities: ["blocker"] });
+  assert.deepEqual(questions.map(item => item.message.type), ["question"]);
+  assert.deepEqual(blockers.map(item => item.message.type), ["blocker"]);
+  assert.equal((await listInbox(context, { agentId: "models" })).length, 3);
+});
+
+test("seen is delivery while acknowledgement is completion", async t => {
+  const { context } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  await markSeen(context, message, "models");
+  assert.equal((await listInbox(context, { agentId: "models" }))[0].state, "seen");
+  const ack = await ackMessage(context, { agentId: "models", messageId: message.id });
+  assert.deepEqual(await listInbox(context, { agentId: "models" }), []);
+  assert.equal(await pathExists(context.paths.archiveFile("models", message.id)), true);
+  const stored = JSON.parse(await readFile(context.paths.ackFile(message.id, "models"), "utf8"));
+  assert.deepEqual(validateAcknowledgement(stored), ack);
+});
+
+test("reply is a new message linked to the original", async t => {
+  const { context } = await createMessagingFixture(t);
+  const original = await sendMessage(context, messageRequest());
+  const reply = await replyToMessage(context, replyRequest(original.id));
+  assert.equal(reply.to, "visual");
+  assert.equal(reply.reply_to, original.id);
+  assert.equal((await listInbox(context, { agentId: "visual" }))[0].message.id, reply.id);
+});
+
+test("one hundred parallel sends lose no messages", async t => {
+  const { context } = await createMessagingFixture(t);
+  await Promise.all(Array.from({ length: 100 }, (_, index) => sendMessage(
+    { ...context, randomUUID: () => messageUuid(index + 1) },
+    messageRequest({ subject: `Message ${index}` }),
+  )));
+  const inbox = await listInbox(context, { agentId: "models" });
+  assert.equal(inbox.length, 100);
+  assert.equal(new Set(inbox.map(item => item.message.id)).size, 100);
+});
+
+test("message files are immutable exclusive records", async t => {
+  const { context } = await createMessagingFixture(t, { randomUUID: () => messageUuid(1) });
+  await sendMessage(context, messageRequest());
+  await assert.rejects(sendMessage(context, messageRequest({ body: "replacement" })),
+    error => error.exitCode === EXIT.CONFLICT);
+  assert.equal((await listInbox(context, { agentId: "models" }))[0].message.body,
+    messageRequest().body);
+});
+
+test("broadcast snapshots active peers into separate addressed copies", async t => {
+  const { context } = await createMessagingFixture(t, {
+    agentIds: ["visual", "models", "physics", "inactive"],
+    listActiveAgentIds: async () => ["visual", "models", "physics"],
+  });
+  const copies = await broadcastMessage(context, broadcastRequest());
+  assert.deepEqual(copies.map(message => message.to), ["models", "physics"]);
+  assert.equal(new Set(copies.map(message => message.id)).size, 2);
+  assert.equal((await listInbox(context, { agentId: "models" })).length, 1);
+  assert.equal((await listInbox(context, { agentId: "physics" })).length, 1);
+  assert.equal((await listInbox(context, { agentId: "inactive" })).length, 0);
+  assert.equal((await listInbox(context, { agentId: "visual" })).length, 0);
+});
+
+test("broadcast acknowledgement is independent for each recipient", async t => {
+  const { context } = await createMessagingFixture(t, {
+    agentIds: ["visual", "models", "physics"],
+    listActiveAgentIds: async () => ["models", "physics"],
+  });
+  const copies = await broadcastMessage(context, broadcastRequest());
+  const modelsCopy = copies.find(message => message.to === "models");
+  await ackMessage(context, { agentId: "models", messageId: modelsCopy.id });
+  assert.equal((await listInbox(context, { agentId: "models" })).length, 0);
+  assert.equal((await listInbox(context, { agentId: "physics" })).length, 1);
+});
+
+test("acknowledgement written before a crash hides work and resumes archive", async t => {
+  const { context } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  const ack = await seedAcknowledgement(context, message);
+  assert.deepEqual(await listInbox(context, { agentId: "models" }), []);
+  assert.equal(await pathExists(context.paths.inboxFile("models", message.id)), true);
+  assert.deepEqual(await ackMessage(context, { agentId: "models", messageId: message.id }), ack);
+  assert.equal(await pathExists(context.paths.inboxFile("models", message.id)), false);
+  assert.equal(await pathExists(context.paths.archiveFile("models", message.id)), true);
+});
+
+test("send rejects a structurally valid attachment whose file is missing", async t => {
+  const { context } = await createMessagingFixture(t);
+  const missing = { path: "docs/missing.txt", sha256: "0".repeat(64), size: 10,
+    ephemeral: false };
+  await assert.rejects(sendMessage(context, messageRequest({ attachments: [missing] })),
+    error => error.exitCode === EXIT.DATA);
+  assert.deepEqual(await listInbox(context, { agentId: "models" }), []);
+});
+
+test("reply rejects an attachment symlink outside the repository", async t => {
+  const { context, repo, root } = await createMessagingFixture(t);
+  const original = await sendMessage(context, messageRequest());
+  const external = path.join(root, "external.txt");
+  await writeFile(external, "outside\n");
+  await symlink(external, path.join(repo, "linked.txt"));
+  const linked = { path: "linked.txt", sha256: "0".repeat(64), size: 8, ephemeral: false };
+  await assert.rejects(replyToMessage(context, replyRequest(original.id,
+    { attachments: [linked] })), error => error.exitCode === EXIT.DATA);
+  assert.deepEqual(await listInbox(context, { agentId: "visual" }), []);
+});
+
+test("broadcast rejects stale attachment evidence before delivery", async t => {
+  const { context, repo } = await createMessagingFixture(t, {
+    agentIds: ["visual", "models", "physics"],
+    listActiveAgentIds: async () => ["models", "physics"],
+  });
+  const evidencePath = path.join(repo, "evidence.txt");
+  await writeFile(evidencePath, "evidence\n");
+  const stale = await describeAttachment(context, { path: "evidence.txt", ephemeral: false });
+  await writeFile(evidencePath, "changed evidence\n");
+  await assert.rejects(broadcastMessage(context, broadcastRequest({ attachments: [stale] })),
+    error => error.exitCode === EXIT.DATA);
+  assert.deepEqual(await listInbox(context, { agentId: "models" }), []);
+  assert.deepEqual(await listInbox(context, { agentId: "physics" }), []);
+});
+
+test("markSeen rejects a fabricated or altered message", async t => {
+  const { context } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  const fabricated = { ...message, id: `${message.id}-fabricated` };
+  await assert.rejects(markSeen(context, { ...message, body: "altered" }, "models"),
+    error => error.exitCode === EXIT.DATA);
+  await assert.rejects(markSeen(context, fabricated, "models"),
+    error => error.exitCode === EXIT.DATA);
+  assert.equal(await pathExists(context.paths.seenFile(message.id, "models")), false);
+  assert.equal(await pathExists(context.paths.seenFile(fabricated.id, "models")), false);
+});
+
+test("markSeen is idempotent for concurrent delivery of one persisted message", async t => {
+  const { context } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  const receipts = await Promise.all([
+    markSeen(context, message, "models"),
+    markSeen(context, message, "models"),
+  ]);
+  const stored = JSON.parse(
+    await readFile(context.paths.seenFile(message.id, "models"), "utf8"),
+  );
+  assert.deepEqual(receipts[0], receipts[1]);
+  assert.deepEqual(validateSeenReceipt(stored), receipts[0]);
+});
+
+test("markSeen rejects an existing receipt for another recipient", async t => {
+  const { context } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  await seedSeenReceipt(context, message, { recipient: "visual" });
+  await assert.rejects(markSeen(context, message, "models"),
+    error => error.exitCode === EXIT.DATA);
+});
+
+test("markSeen rejects a corrupt existing receipt", async t => {
+  const { context } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  await writeFile(context.paths.seenFile(message.id, "models"), "not-json\n");
+  await assert.rejects(markSeen(context, message, "models"),
+    error => error.exitCode === EXIT.DATA);
+});
+
+test("inbox rejects a seen receipt bound to another message", async t => {
+  const { context } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  await seedSeenReceipt(context, message, { message_id: `${message.id}-other` });
+  await assert.rejects(listInbox(context, { agentId: "models" }),
+    error => error.exitCode === EXIT.DATA);
+});
+
+test("inbox rejects corrupt acknowledgement instead of hiding work", async t => {
+  const { context } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  await writeFile(context.paths.ackFile(message.id, "models"), "not-json\n");
+  await assert.rejects(listInbox(context, { agentId: "models" }),
+    error => error.exitCode === EXIT.DATA);
+});
+
+test("inbox and ack reject acknowledgement bound to another message", async t => {
+  const { context } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  await seedAcknowledgement(context, message, { message_id: `${message.id}-other` });
+  await assert.rejects(listInbox(context, { agentId: "models" }),
+    error => error.exitCode === EXIT.DATA);
+  await assert.rejects(ackMessage(context, { agentId: "models", messageId: message.id }),
+    error => error.exitCode === EXIT.DATA);
+  assert.equal(await pathExists(context.paths.inboxFile("models", message.id)), true);
+});
+
+test("inbox rejects a seen receipt addressed to the wrong recipient", async t => {
+  const { context } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  await seedSeenReceipt(context, message, { recipient: "visual" });
+  await assert.rejects(listInbox(context, { agentId: "models" }),
+    error => error.exitCode === EXIT.DATA);
+});
+
+test("inbox and ack reject acknowledgement addressed to the wrong recipient", async t => {
+  const { context } = await createMessagingFixture(t);
+  const message = await sendMessage(context, messageRequest());
+  await seedAcknowledgement(context, message, { recipient: "visual" });
+  await assert.rejects(listInbox(context, { agentId: "models" }),
+    error => error.exitCode === EXIT.DATA);
+  await assert.rejects(ackMessage(context, { agentId: "models", messageId: message.id }),
+    error => error.exitCode === EXIT.DATA);
+  assert.equal(await pathExists(context.paths.inboxFile("models", message.id)), true);
+});

--- a/prototype/integrated/tests/tools/agent_comms/paths-storage.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/paths-storage.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readdir, rm, symlink } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import {
+  createBusPaths,
+  ensureBusLayout,
+  resolveBusDir,
+} from "../../../tools/agents/lib/paths.mjs";
+
+async function temporaryDirectory(t) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "pw2-agent-paths-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  return root;
+}
+
+test("relative bus overrides are rejected as invalid data", async () => {
+  await assert.rejects(
+    resolveBusDir({
+      cwd: "/checkout",
+      env: { PW2_AGENT_BUS_DIR: "relative/.agents" },
+      runGit: () => assert.fail("Git discovery must not run for an override"),
+    }),
+    error => error.exitCode === EXIT.DATA,
+  );
+});
+
+test("layout creation rejects a symlinked bus root", async t => {
+  const root = await temporaryDirectory(t);
+  const outside = path.join(root, "outside");
+  const bus = path.join(root, ".agents");
+  await mkdir(outside);
+  await symlink(outside, bus);
+
+  await assert.rejects(
+    ensureBusLayout(createBusPaths(bus)),
+    error => error.exitCode === EXIT.DATA,
+  );
+  assert.deepEqual(await readdir(outside), []);
+});
+
+test("layout creation rejects a symlinked managed directory", async t => {
+  const root = await temporaryDirectory(t);
+  const bus = path.join(root, ".agents");
+  const outside = path.join(root, "outside");
+  await mkdir(bus);
+  await mkdir(outside);
+  await symlink(outside, path.join(bus, "inbox"));
+
+  await assert.rejects(
+    ensureBusLayout(createBusPaths(bus)),
+    error => error.exitCode === EXIT.DATA,
+  );
+  assert.deepEqual(await readdir(outside), []);
+});

--- a/prototype/integrated/tests/tools/agent_comms/paths.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/paths.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  createBusPaths,
+  ensureBusLayout,
+  resolveBusDir,
+} from "../../../tools/agents/lib/paths.mjs";
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import { createGitWorktreeFixture, pathExists } from "./helpers.mjs";
+
+test("environment override wins", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  const bus = await resolveBusDir({
+    cwd: fixture.root,
+    env: { PW2_AGENT_BUS_DIR: fixture.bus },
+    runGit: () => assert.fail("Git discovery must not run for an override"),
+  });
+
+  assert.equal(bus, fixture.bus);
+});
+
+test("main and linked worktree resolve one shared bus", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+
+  assert.equal(await fixture.resolveFrom(fixture.main), fixture.bus);
+  assert.equal(await fixture.resolveFrom(fixture.worktree), fixture.bus);
+});
+
+test("ambiguous Git common directories require an override", async () => {
+  await assert.rejects(
+    resolveBusDir({
+      cwd: "/repo/worktree",
+      env: {},
+      runGit: async () => "/repo/bare.git\n",
+    }),
+    error => error.exitCode === EXIT.DATA,
+  );
+});
+
+test("bus paths expose the complete version-one layout", () => {
+  const paths = createBusPaths("/checkout/.agents");
+
+  assert.equal(paths.protocol, "/checkout/.agents/protocol.json");
+  for (const directory of [
+    "registry",
+    "presence",
+    "inbox",
+    "seen",
+    "acknowledgements",
+    "claims",
+    "handoffs",
+    "archive",
+    "artifacts",
+    "locks",
+    "quarantine",
+    "tmp",
+  ]) {
+    assert.equal(paths[directory], path.join("/checkout/.agents", directory));
+  }
+  assert.equal(Object.isFrozen(paths), true);
+});
+
+test("layout creation is idempotent and preserves existing records", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  const paths = createBusPaths(fixture.bus);
+  await ensureBusLayout(paths);
+  const record = path.join(paths.registry, "visual.json");
+  await writeFile(record, "existing-record\n", "utf8");
+
+  await ensureBusLayout(paths);
+
+  assert.equal(await readFile(record, "utf8"), "existing-record\n");
+  for (const directory of [
+    paths.registry,
+    paths.presence,
+    paths.inbox,
+    paths.seen,
+    paths.acknowledgements,
+    paths.claims,
+    paths.handoffs,
+    paths.archive,
+    paths.artifacts,
+    paths.locks,
+    paths.quarantine,
+    paths.tmp,
+  ]) {
+    assert.equal(await pathExists(directory), true);
+  }
+});

--- a/prototype/integrated/tests/tools/agent_comms/presence.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/presence.test.mjs
@@ -1,0 +1,299 @@
+import assert from "node:assert/strict";
+import { readFile, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import { listInbox, markSeen, sendMessage } from "../../../tools/agents/lib/messages.mjs";
+import { presenceState, startWatcher, waitForMessage } from "../../../tools/agents/lib/presence.mjs";
+import { validatePresence } from "../../../tools/agents/lib/schema.mjs";
+import { createMessagingFixture, messageRequest, pathExists } from "./helpers.mjs";
+const ownerFile = context => path.join(context.paths.locks, "watcher-models.json");
+const watch = context => startWatcher(context, { agentId: "models" });
+const presenceAt = (heartbeatAt, pid = 42, status = "online") => ({
+  schema_version: 1, agent_id: "models", pid, status, heartbeat_at: heartbeatAt });
+const instant = seconds => new Date(
+  `2026-08-14T18:00:${String(seconds).padStart(2, "0")}.000Z`);
+function createScheduler(clock, { eagerZeroTimeout = false } = {}) {
+  let current = 0, nextId = 1;
+  const tasks = new Map();
+  const schedule = (callback, delay, interval) => {
+    const id = nextId++; tasks.set(id, { callback, due: current + delay, interval });
+    return id;
+  };
+  return {
+    setInterval: (callback, delay) => schedule(callback, delay, delay),
+    clearInterval: id => tasks.delete(id),
+    setTimeout: (callback, delay) => eagerZeroTimeout && delay === 0
+      ? (callback(), 0) : schedule(callback, delay, null),
+    clearTimeout: id => tasks.delete(id),
+    size: () => tasks.size,
+    advance: async milliseconds => {
+      const target = current + milliseconds;
+      while (true) {
+        const pending = [...tasks.entries()].filter(([, task]) => task.due <= target)
+          .sort((left, right) => left[1].due - right[1].due)[0];
+        if (pending === undefined) break;
+        const [id, task] = pending;
+        clock.advance(task.due - current);
+        current = task.due;
+        if (task.interval === null) tasks.delete(id); else task.due += task.interval;
+        await task.callback();
+      }
+      clock.advance(target - current);
+      current = target;
+    },
+  };
+}
+function deferred() {
+  let resolve;
+  const promise = new Promise(done => { resolve = done; });
+  return { promise, resolve };
+}
+function createWatchControl() {
+  const watchers = new Set();
+  return {
+    watchDirectory: (_directory, callback) => {
+      const watcher = { callback, closed: false };
+      watchers.add(watcher);
+      return { close: () => { watcher.closed = true; } };
+    },
+    active: () => [...watchers].filter(watcher => !watcher.closed).length,
+    emit: () => Promise.all([...watchers].filter(watcher => !watcher.closed)
+      .map(watcher => watcher.callback("rename", "message.json"))),
+  };
+}
+async function watcherFixture(t, overrides = {}) {
+  const fixture = await createMessagingFixture(t);
+  const scheduler = createScheduler(fixture.clock), watchControl = createWatchControl();
+  const events = [], extensions = [];
+  const livePids = new Set([4242]);
+  const context = {
+    ...fixture.context,
+    pid: 4242, scheduler,
+    pidIsAlive: pid => livePids.has(pid),
+    watchDirectory: watchControl.watchDirectory,
+    output: async event => { events.push(event); },
+    extendOwnedClaims: async agentId => { extensions.push(agentId); },
+    ...overrides,
+  };
+  return { ...fixture, context, scheduler, watchControl, events, extensions, livePids };
+}
+async function readPresence(context, agentId = "models") {
+  const source = await readFile(context.paths.presenceFile(agentId), "utf8");
+  return validatePresence(JSON.parse(source));
+}
+async function waitUntil(predicate) {
+  for (let index = 0; index < 1_000; index += 1)
+    if (predicate()) return; else await new Promise(resolve => setImmediate(resolve));
+  assert.fail("condition did not become true");
+}
+test("heartbeat transitions online to stale to offline", () => {
+  const record = presenceAt("2026-08-14T18:00:00.000Z");
+  assert.equal(presenceState(record, instant(44), () => true), "online");
+  assert.equal(presenceState(record, instant(46), () => true), "stale");
+  assert.equal(presenceState(record, instant(46), () => false), "offline");
+  assert.equal(presenceState({ ...record, status: "offline" }, instant(1), () => true),
+    "offline");
+});
+test("concurrent watcher starts acquire one atomic owner", async t => {
+  const fixture = await watcherFixture(t);
+  fixture.livePids.add(4343);
+  const attempts = await Promise.allSettled([
+    watch(fixture.context), watch({ ...fixture.context, pid: 4343 }),
+  ]);
+  const started = attempts.filter(attempt => attempt.status === "fulfilled");
+  const rejected = attempts.filter(attempt => attempt.status === "rejected");
+  assert.equal(started.length, 1); assert.equal(rejected.length, 1);
+  assert.equal(rejected[0].reason.exitCode, EXIT.CONFLICT);
+  const owner = JSON.parse(await readFile(ownerFile(fixture.context), "utf8"));
+  assert.deepEqual(Object.keys(owner).sort(), ["acquired_at", "agent_id", "pid",
+    "schema_version", "token"]);
+  await started[0].value.stop();
+});
+test("a former owner token cannot heartbeat or stop over its successor", async t => {
+  const fixture = await watcherFixture(t);
+  const first = await watch(fixture.context);
+  const owner = JSON.parse(await readFile(ownerFile(fixture.context), "utf8"));
+  const successor = { ...owner, pid: 4343,
+    token: "11111111-1111-4111-8111-111111111111" };
+  await writeFile(ownerFile(fixture.context), `${JSON.stringify(successor)}\n`);
+  await writeFile(fixture.context.paths.presenceFile("models"),
+    `${JSON.stringify(presenceAt("2026-08-14T18:00:00.000Z", 4343))}\n`);
+  const lostDone = first.done.catch(error => error);
+  await fixture.scheduler.advance(15_000);
+  assert.equal((await lostDone).exitCode, EXIT.CONFLICT);
+  assert.deepEqual(JSON.parse(await readFile(ownerFile(fixture.context), "utf8")), successor);
+  assert.equal((await readPresence(fixture.context)).pid, 4343);
+});
+test("a dead owner blocks all contenders and remains unchanged", async t => {
+  const fixture = await watcherFixture(t);
+  const incumbent = await watch(fixture.context);
+  const ownerBytes = await readFile(ownerFile(fixture.context), "utf8");
+  fixture.livePids.delete(4242);
+  await Promise.all([4343, 4444].map(pid => assert.rejects(watch({
+    ...fixture.context, pid, scheduler: createScheduler(fixture.clock),
+  }), error => error.exitCode === EXIT.CONFLICT)));
+  assert.equal(await readFile(ownerFile(fixture.context), "utf8"), ownerBytes);
+  assert.deepEqual(await readdir(fixture.context.paths.quarantine), []);
+  await incumbent.stop();
+});
+test("an owner whose agent disagrees with its lock path fails as data corruption", async t => {
+  const fixture = await watcherFixture(t);
+  await watch(fixture.context);
+  const owner = JSON.parse(await readFile(ownerFile(fixture.context), "utf8"));
+  await writeFile(ownerFile(fixture.context),
+    `${JSON.stringify({ ...owner, agent_id: "planner" })}\n`);
+  await assert.rejects(watch({ ...fixture.context, pid: 4343 }),
+    error => error.exitCode === EXIT.DATA);
+});
+test("malformed watcher ownership fails as data corruption", async t => {
+  const fixture = await watcherFixture(t);
+  await writeFile(ownerFile(fixture.context), "{\"schema_version\":1}\n");
+  await assert.rejects(watch(fixture.context), error => error.exitCode === EXIT.DATA);
+});
+test("watcher immediately prints an existing unseen message and then marks it seen", async t => {
+  const fixture = await watcherFixture(t);
+  const message = await sendMessage(fixture.context, messageRequest());
+  const watcher = await watch(fixture.context);
+  assert.deepEqual(fixture.events, [{ event: "message", message, state: "unseen" }]);
+  assert.equal(await pathExists(fixture.context.paths.seenFile(message.id, "models")), true);
+  assert.equal((await listInbox(fixture.context, { agentId: "models" }))[0].state, "seen");
+  await watcher.stop();
+});
+test("fallback scan delivers messages without a filesystem event and prints each id once", async t => {
+  const fixture = await watcherFixture(t);
+  const watcher = await watch(fixture.context);
+  const message = await sendMessage(fixture.context, messageRequest());
+  await fixture.scheduler.advance(1_999);
+  assert.deepEqual(fixture.events, []);
+  await fixture.scheduler.advance(1);
+  await fixture.watchControl.emit();
+  await fixture.scheduler.advance(2_000);
+  assert.deepEqual(fixture.events.map(event => event.message.id), [message.id]);
+  await watcher.stop();
+});
+test("restart prints unseen messages but leaves seen unacknowledged work discoverable", async t => {
+  const fixture = await watcherFixture(t);
+  const alreadySeen = await sendMessage(fixture.context, messageRequest({ subject: "seen" }));
+  await markSeen(fixture.context, alreadySeen, "models");
+  const first = await watch(fixture.context);
+  assert.deepEqual(fixture.events, []);
+  await first.stop();
+  const unseen = await sendMessage(fixture.context, messageRequest({ subject: "new" }));
+  const second = await watch(fixture.context);
+  assert.deepEqual(fixture.events.map(event => event.message.id), [unseen.id]);
+  const inbox = await listInbox(fixture.context, { agentId: "models" });
+  assert.deepEqual(inbox.map(item => item.message.id), [alreadySeen.id, unseen.id]);
+  assert.deepEqual(inbox.map(item => item.state), ["seen", "seen"]);
+  await second.stop();
+});
+test("seen receipt is created only after successful complete output", async t => {
+  let outputFinished = false;
+  const fixture = await watcherFixture(t, {
+    output: async () => {
+      await Promise.resolve();
+      outputFinished = true;
+      throw new Error("terminal closed");
+    },
+  });
+  const message = await sendMessage(fixture.context, messageRequest());
+  await assert.rejects(watch(fixture.context), /terminal closed/);
+  assert.equal(outputFinished, true);
+  assert.equal(await pathExists(fixture.context.paths.seenFile(message.id, "models")), false);
+  assert.equal((await readPresence(fixture.context)).status, "offline");
+});
+test("heartbeat refreshes presence every 15 seconds and extends owned claims", async t => {
+  const fixture = await watcherFixture(t);
+  const watcher = await watch(fixture.context);
+  assert.deepEqual(fixture.extensions, ["models"]);
+  assert.equal((await readPresence(fixture.context)).heartbeat_at, "2026-08-14T18:00:00.000Z");
+  await fixture.scheduler.advance(14_999);
+  assert.equal((await readPresence(fixture.context)).heartbeat_at, "2026-08-14T18:00:00.000Z");
+  await fixture.scheduler.advance(1);
+  assert.equal((await readPresence(fixture.context)).heartbeat_at, "2026-08-14T18:00:15.000Z");
+  assert.deepEqual(fixture.extensions, ["models", "models"]);
+  await watcher.stop();
+});
+test("heartbeat stays live while initial message output is blocked", async t => {
+  const fixture = await watcherFixture(t);
+  const gate = deferred(), outputCalled = deferred();
+  fixture.context.output = async event => {
+    fixture.events.push(event);
+    outputCalled.resolve();
+    await gate.promise;
+  };
+  await sendMessage(fixture.context, messageRequest());
+  const starting = watch(fixture.context);
+  await outputCalled.promise;
+  await fixture.scheduler.advance(46_000);
+  assert.equal((await readPresence(fixture.context)).heartbeat_at, "2026-08-14T18:00:45.000Z");
+  fixture.livePids.add(4343);
+  const contender = await watch({
+    ...fixture.context, pid: 4343,
+    scheduler: createScheduler(fixture.clock),
+    output: async () => {},
+  }).then(value => ({ value }), error => ({ error }));
+  if (contender.value !== undefined) await contender.value.stop();
+  assert.equal(contender.error?.exitCode, EXIT.CONFLICT);
+  gate.resolve();
+  const watcher = await starting;
+  await watcher.stop();
+});
+test("a start racing normal stop waits for owner removal", async t => {
+  const gate = deferred(), outputCalled = deferred();
+  const fixture = await watcherFixture(t, { output: async () => {
+    outputCalled.resolve(); await gate.promise;
+  } });
+  const incumbent = await watch(fixture.context);
+  await sendMessage(fixture.context, messageRequest());
+  const scanning = fixture.watchControl.emit();
+  await outputCalled.promise;
+  const stopping = incumbent.stop();
+  fixture.livePids.add(4343);
+  const successorContext = { ...fixture.context, pid: 4343,
+    scheduler: createScheduler(fixture.clock) };
+  await assert.rejects(watch(successorContext), error => error.exitCode === EXIT.CONFLICT);
+  gate.resolve(); await scanning; await stopping;
+  const successor = await watch(successorContext);
+  await successor.stop();
+});
+test("stop closes event sources, writes offline presence, and resolves done", async t => {
+  const fixture = await watcherFixture(t);
+  const watcher = await watch(fixture.context);
+  assert.equal(fixture.watchControl.active(), 1);
+  await watcher.stop();
+  await watcher.done;
+  assert.equal(fixture.watchControl.active(), 0);
+  assert.equal(fixture.scheduler.size(), 0);
+  assert.equal((await readPresence(fixture.context)).status, "offline");
+});
+test("wait prioritizes its initial scan and catches delivery after watching starts", async t => {
+  const fixture = await watcherFixture(t);
+  const timedOut = waitForMessage(fixture.context, { agentId: "models", timeoutMs: 5 });
+  await waitUntil(() => fixture.scheduler.size() > 0);
+  await fixture.scheduler.advance(5);
+  assert.equal(await timedOut, null);
+  const existing = await sendMessage(fixture.context, messageRequest({ subject: "existing" }));
+  const eagerContext = { ...fixture.context,
+    scheduler: createScheduler(fixture.clock, { eagerZeroTimeout: true }),
+  };
+  assert.equal((await waitForMessage(eagerContext,
+    { agentId: "models", timeoutMs: 0 })).id, existing.id);
+  await markSeen(fixture.context, existing, "models");
+  const scanGate = deferred();
+  let initialScan = true;
+  const waitingContext = { ...fixture.context, listInbox: async input => {
+    const items = await listInbox(fixture.context, input);
+    if (initialScan) { initialScan = false; await scanGate.promise; }
+    return items;
+  } };
+  const pending = waitForMessage(waitingContext, { agentId: "models", timeoutMs: 100 });
+  await waitUntil(() => !initialScan || fixture.scheduler.size() > 0);
+  assert.equal(initialScan, false);
+  const message = await sendMessage(fixture.context, messageRequest({ subject: "wake" }));
+  const emitted = fixture.watchControl.emit();
+  scanGate.resolve();
+  await emitted;
+  assert.equal((await pending).id, message.id);
+  assert.equal(fixture.watchControl.active(), 0);
+});

--- a/prototype/integrated/tests/tools/agent_comms/prompt.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/prompt.test.mjs
@@ -20,6 +20,10 @@ test("rendered prompt is the committed template with literal substitutions", asy
     ownership: "game/presentation",
   });
   const expected = template
+    .replaceAll("<AGENT_ID_SHELL>", "'visual-m2-7'")
+    .replaceAll("<ROLE_SHELL>", "'visual'")
+    .replaceAll("<TASK_SHELL>", "'M2.7'")
+    .replaceAll("<OWNERSHIP_SHELL>", "'game/presentation'")
     .replaceAll("<AGENT_ID>", "visual-m2-7")
     .replaceAll("<ROLE>", "visual")
     .replaceAll("<TASK>", "M2.7")
@@ -28,7 +32,8 @@ test("rendered prompt is the committed template with literal substitutions", asy
   assert.equal(rendered, expected);
   assert.deepEqual(
     [...new Set(template.match(/<[A-Z_]+>/gu) ?? [])].sort(),
-    ["<AGENT_ID>", "<OWNERSHIP>", "<ROLE>", "<TASK>"],
+    ["<AGENT_ID>", "<AGENT_ID_SHELL>", "<OWNERSHIP>", "<OWNERSHIP_SHELL>",
+      "<ROLE>", "<ROLE_SHELL>", "<TASK>", "<TASK_SHELL>"],
   );
 });
 
@@ -57,6 +62,22 @@ test("canonical prompt requires the complete safe coordination lifecycle", async
   assert.match(rendered, /`action` or `blocker`[\s\S]*`reply`[\s\S]*`ack`/u);
   assert.match(rendered, /evidence-bearing handoff even when blocked[\s\S]*`close/u);
   assert.match(rendered, /may not interrupt an active reasoning-turn/u);
+  assert.match(rendered, /read `AGENTS\.md` and `docs\/AGENT_COMMS\.md` completely before/u);
+  assert.match(rendered, /report your id, task, and\s+ownership scopes to the orchestrator/u);
+});
+
+test("rendered bootstrap shell-quotes every substituted command value", async () => {
+  const rendered = await renderPrompt({
+    templatePath,
+    agentId: "visual",
+    role: "visual lead",
+    task: "actor's polish",
+    ownership: "game/presentation --ownership contract:camera rig-v1",
+  });
+
+  assert.match(rendered, /--id 'visual' --role 'visual lead' --task 'actor'"'"'s polish'/u);
+  assert.match(rendered,
+    /--ownership 'game\/presentation' --ownership 'contract:camera rig-v1'/u);
 });
 
 test("renderer rejects unsafe agent identifiers and NUL-bearing values", async () => {

--- a/prototype/integrated/tests/tools/agent_comms/prompt.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/prompt.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { copyFile, mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { renderPrompt } from "../../../tools/agents/lib/prompt.mjs";
+import { createGitWorktreeFixture, runCli } from "./helpers.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const templatePath = path.join(root, "docs/AGENT_COMMS_PROMPT.md");
+
+test("rendered prompt is the committed template with literal substitutions", async () => {
+  const template = await readFile(templatePath, "utf8");
+  const rendered = await renderPrompt({
+    templatePath,
+    agentId: "visual-m2-7",
+    role: "visual",
+    task: "M2.7",
+    ownership: "game/presentation",
+  });
+  const expected = template
+    .replaceAll("<AGENT_ID>", "visual-m2-7")
+    .replaceAll("<ROLE>", "visual")
+    .replaceAll("<TASK>", "M2.7")
+    .replaceAll("<OWNERSHIP>", "game/presentation");
+
+  assert.equal(rendered, expected);
+  assert.deepEqual(
+    [...new Set(template.match(/<[A-Z_]+>/gu) ?? [])].sort(),
+    ["<AGENT_ID>", "<OWNERSHIP>", "<ROLE>", "<TASK>"],
+  );
+});
+
+test("canonical prompt requires the complete safe coordination lifecycle", async () => {
+  const rendered = await renderPrompt({
+    templatePath,
+    agentId: "visual-m2-7",
+    role: "visual",
+    task: "M2.7",
+    ownership: "game/presentation",
+  });
+
+  for (const checkpoint of [
+    "одразу після `register`",
+    "перед першою зміною файлів",
+    "після кожної довгої команди або повернення до задачі",
+    "перед зміною shared contract",
+    "перед commit",
+    "перед push/PR",
+    "перед переходом до нового етапу",
+    "через `wait`, коли агент не має іншої роботи",
+  ]) assert.match(rendered, new RegExp(checkpoint.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(rendered, /Відмова `register` або неможливість запустити watcher —\s*блокер/u);
+  assert.match(rendered, /explicit peer\s+підтвердження.*before changing the shared contract/u);
+  assert.match(rendered, /`reply`[\s\S]*`ack`/u);
+  assert.match(rendered, /`action` or `blocker`[\s\S]*`reply`[\s\S]*`ack`/u);
+  assert.match(rendered, /evidence-bearing handoff even when blocked[\s\S]*`close/u);
+  assert.match(rendered, /may not interrupt an active reasoning-turn/u);
+});
+
+test("renderer rejects unsafe agent identifiers and NUL-bearing values", async () => {
+  await assert.rejects(
+    renderPrompt({ templatePath, agentId: "INVALID", role: "visual", task: "M2.7", ownership: "game/presentation" }),
+    /invalid agent id/u,
+  );
+  await assert.rejects(
+    renderPrompt({ templatePath, agentId: "visual-m2-7", role: "visual\0", task: "M2.7", ownership: "game/presentation" }),
+    /NUL/u,
+  );
+});
+
+test("prompt command writes the renderer output without stderr", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  const fixtureTemplate = path.join(fixture.worktree, "docs/AGENT_COMMS_PROMPT.md");
+  await mkdir(path.dirname(fixtureTemplate), { recursive: true });
+  await copyFile(templatePath, fixtureTemplate);
+  const expected = await renderPrompt({
+    templatePath: fixtureTemplate,
+    agentId: "visual",
+    role: "visual",
+    task: "M2.7",
+    ownership: "game/presentation",
+  });
+  const result = await runCli(fixture, ["prompt", "--id", "visual", "--role", "visual", "--task",
+    "M2.7", "--ownership", "game/presentation"]);
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(result.stdout, expected);
+  assert.equal(result.stderr, "");
+});
+
+test("prompt command rejects missing ownership before rendering", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  const result = await runCli(fixture, ["prompt", "--id", "visual", "--role", "visual", "--task", "M2.7"]);
+
+  assert.equal(result.code, 2);
+  assert.match(result.stderr, /prompt requires every --ownership/u);
+  assert.equal(result.stdout, "");
+});
+
+test("prompt command rejects a blank ownership among repeated scopes", async t => {
+  const fixture = await createGitWorktreeFixture();
+  t.after(fixture.cleanup);
+  const result = await runCli(fixture, ["prompt", "--id", "visual", "--role", "visual", "--task",
+    "M2.7", "--ownership", "", "--ownership", "game/presentation"]);
+
+  assert.equal(result.code, 2);
+  assert.match(result.stderr, /prompt requires every --ownership/u);
+  assert.equal(result.stdout, "");
+});

--- a/prototype/integrated/tests/tools/agent_comms/repair-mutex.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/repair-mutex.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, readdir, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { inspectRepairMutex, repairStaleRepairMutex, withRepairMutex }
+  from "../../../tools/agents/lib/repair-mutex.mjs";
+import { createBusFixture, pathExists } from "./helpers.mjs";
+
+const DEAD = 999_999;
+function deferred() { let resolve;
+  const promise = new Promise(done => { resolve = done; }); return { promise, resolve }; }
+function owner(context, kind, age, pid = DEAD, agentId = null) {
+  return { schema_version: 1, kind, agent_id: agentId, pid,
+    token: "11111111-1111-4111-8111-111111111111",
+    acquired_at: new Date(context.now().getTime() - age).toISOString() };
+}
+async function seed(context, name, record, raw = null) {
+  const directory = path.join(context.paths.locks, `${name}.lock`);
+  await mkdir(directory);
+  await writeFile(path.join(directory, "owner.json"), raw ?? `${JSON.stringify(record)}\n`);
+  return directory;
+}
+async function fixtureFor(t) {
+  const fixture = await createBusFixture(); t.after(fixture.cleanup);
+  let next = 2;
+  return { ...fixture, context: { ...fixture.context, pid: 4242,
+    pidIsAlive: pid => pid === 4242,
+    randomMutexUUID: () => `22222222-2222-4222-8222-${String(next++).padStart(12, "0")}` } };
+}
+
+test("repair mutex reports live, young, stale, and corrupt ownership", async t => {
+  const { context } = await fixtureFor(t);
+  await seed(context, "doctor", owner(context, "doctor", 100_000, 4242));
+  await seed(context, "watcher-young", owner(context, "watcher", 60_000, DEAD, "young"));
+  await seed(context, "watcher-stale", owner(context, "watcher", 60_001, DEAD, "stale"));
+  await seed(context, "watcher-corrupt", null, "{}\n");
+  assert.equal((await inspectRepairMutex(context, "doctor")).state, "live");
+  assert.equal((await inspectRepairMutex(context, "watcher", "young")).state, "young");
+  assert.equal((await inspectRepairMutex(context, "watcher", "stale")).state, "stale");
+  assert.equal((await inspectRepairMutex(context, "watcher", "corrupt")).state, "corrupt");
+});
+
+test("only a dead watcher mutex older than sixty seconds is atomically quarantined", async t => {
+  const { context } = await fixtureFor(t);
+  const stale = owner(context, "watcher", 60_001, DEAD, "models");
+  const directory = await seed(context, "watcher-models", stale);
+  const repairContext = { ...context, renameRepairMutex: async (from, to) => {
+    assert.equal((await readdir(context.paths.quarantine))
+      .some(name => name.startsWith("mutex-audit-")), true);
+    return rename(from, to);
+  } };
+  assert.equal(await repairStaleRepairMutex(repairContext, "watcher", "models"), true);
+  assert.equal(await pathExists(directory), false);
+  const quarantine = await readdir(context.paths.quarantine);
+  assert.equal(quarantine.some(name => name.startsWith("mutex-audit-")), true);
+  const moved = quarantine.find(name => name.startsWith("mutex-stale-"));
+  assert.deepEqual(JSON.parse(await readFile(path.join(context.paths.quarantine,
+    moved, "owner.json"), "utf8")), stale);
+});
+
+test("live, young, and corrupt mutexes are never repaired", async t => {
+  const { context } = await fixtureFor(t);
+  for (const [agentId, record, raw] of [
+    ["live", owner(context, "watcher", 60_001, 4242, "live")],
+    ["young", owner(context, "watcher", 60_000, DEAD, "young")],
+    ["corrupt", null, "{}\n"],
+  ]) {
+    const directory = await seed(context, `watcher-${agentId}`, record, raw);
+    assert.equal(await repairStaleRepairMutex(context, "watcher", agentId), false);
+    assert.equal(await pathExists(directory), true);
+  }
+});
+
+test("release moves only its generation before allowing a replacement", async t => {
+  const { context } = await fixtureFor(t);
+  let held;
+  const first = withRepairMutex(context, "watcher", "models", async acquired => {
+    held = acquired;
+    return "done";
+  });
+  assert.equal(await first, "done");
+  const result = await withRepairMutex(context, "watcher", "models", async acquired => acquired);
+  assert.notEqual(result.token, held.token);
+});
+
+test("two stale repairs cannot move a replacement mutex generation", async t => {
+  const { context } = await fixtureFor(t);
+  await seed(context, "watcher-models",
+    owner(context, "watcher", 60_001, DEAD, "models"));
+  const entered = [deferred(), deferred()], proceed = [deferred(), deferred()];
+  let calls = 0;
+  const racing = { ...context, renameRepairMutex: async (from, to) => {
+    const index = calls++; entered[index].resolve(); await proceed[index].promise;
+    return rename(from, to);
+  } };
+  const first = repairStaleRepairMutex(racing, "watcher", "models");
+  await entered[0].promise;
+  const second = repairStaleRepairMutex(racing, "watcher", "models");
+  await entered[1].promise; proceed[0].resolve(); assert.equal(await first, true);
+  const replacementHeld = deferred(), releaseReplacement = deferred();
+  const replacement = withRepairMutex(context, "watcher", "models", async value => {
+    replacementHeld.resolve(value); await releaseReplacement.promise;
+  });
+  const ownerB = await replacementHeld.promise; proceed[1].resolve();
+  assert.equal(await second, false);
+  assert.equal((await inspectRepairMutex(context, "watcher", "models")).owner.token,
+    ownerB.token);
+  releaseReplacement.resolve(); await replacement;
+});

--- a/prototype/integrated/tests/tools/agent_comms/schema-storage.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/schema-storage.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import {
+  validateAcknowledgement,
+  validateMessage,
+  validateSeenReceipt,
+} from "../../../tools/agents/lib/schema.mjs";
+
+const timestamp = "2026-08-14T18:00:00.000Z";
+
+function message(id, replyTo = null) {
+  return {
+    schema_version: 1,
+    id,
+    from: "visual",
+    to: "models",
+    type: "question",
+    severity: "action",
+    subject: "subject",
+    body: "body",
+    task: "M2.7",
+    reply_to: replyTo,
+    requires_ack: true,
+    created_at: timestamp,
+    sender_head: "a".repeat(40),
+    attachments: [],
+  };
+}
+
+function receipt(messageId, seen) {
+  return {
+    schema_version: 1,
+    message_id: messageId,
+    recipient: "models",
+    [seen ? "seen_at" : "acknowledged_at"]: timestamp,
+  };
+}
+
+test("message and receipt ids use a portable path-safe alphabet", () => {
+  const unsafe = [
+    "bad\0id",
+    "bad\nid",
+    "../escape",
+    "back\\slash",
+    "colon:id",
+    "question?mark",
+    "star*name",
+    "white space",
+    ".hidden",
+    "trailing.",
+    "NUL",
+    "com1.log",
+    "a".repeat(217),
+  ];
+  for (const id of unsafe) {
+    assert.throws(() => validateMessage(message(id)), error => error.exitCode === EXIT.DATA);
+    assert.throws(() => validateMessage(message("valid-id", id)),
+      error => error.exitCode === EXIT.DATA);
+    assert.throws(() => validateSeenReceipt(receipt(id, true)),
+      error => error.exitCode === EXIT.DATA);
+    assert.throws(() => validateAcknowledgement(receipt(id, false)),
+      error => error.exitCode === EXIT.DATA);
+  }
+});
+
+test("generated-style message ids remain valid", () => {
+  const id = "20260814T180000.000Z-visual-00000000-0000-4000-8000-000000000001";
+  assert.equal(validateMessage(message(id)).id, id);
+  assert.equal(validateSeenReceipt(receipt(id, true)).message_id, id);
+});

--- a/prototype/integrated/tests/tools/agent_comms/schema.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/schema.test.mjs
@@ -1,0 +1,299 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import {
+  validateAcknowledgement,
+  validateAgentId,
+  validateAttachment,
+  validateClaim,
+  validateHandoff,
+  validateLock,
+  validateMessage,
+  validatePresence,
+  validateProtocol,
+  validateRegistry,
+  validateRepoPath,
+  validateSeenReceipt,
+} from "../../../tools/agents/lib/schema.mjs";
+
+const NOW = "2026-08-14T18:30:12.123Z";
+const GIT_SHA = "a".repeat(40);
+const SHA256 = "b".repeat(64);
+
+function validAttachment(overrides = {}) {
+  return {
+    path: "game/presentation/tank.gd",
+    sha256: SHA256,
+    size: 42,
+    ephemeral: false,
+    ...overrides,
+  };
+}
+
+function validMessage(overrides = {}) {
+  return {
+    schema_version: 1,
+    id: "20260814T183012.123Z-visual-550e8400-e29b-41d4-a716-446655440000",
+    from: "visual",
+    to: "models",
+    type: "contract_request",
+    severity: "action",
+    subject: "Material slots required",
+    body: "Provide stable surface names.",
+    task: "M2.7",
+    reply_to: null,
+    requires_ack: true,
+    created_at: NOW,
+    sender_head: GIT_SHA,
+    attachments: [],
+    ...overrides,
+  };
+}
+
+function validHandoff(overrides = {}) {
+  return {
+    schema_version: 1,
+    id: "handoff-visual-models-1",
+    from: "visual",
+    to: "models",
+    task: "M2.7",
+    result: "Stable material slots added.",
+    branch: "m2/visual",
+    commit: GIT_SHA,
+    base: "c".repeat(40),
+    changed_paths: ["game/presentation/tank.gd"],
+    verification: [{ command: "node --test", exitCode: 0, summary: "pass" }],
+    contracts: { added: [], changed: ["tank-registration-v1"], consumed: [] },
+    follow_up: ["models"],
+    artifacts: [validAttachment({ commit: GIT_SHA })],
+    limitations: [],
+    uncommitted: false,
+    ready_to_merge: true,
+    state: "READY",
+    created_at: NOW,
+    ...overrides,
+  };
+}
+
+function expectDataError(callback) {
+  assert.throws(callback, error => error.exitCode === EXIT.DATA);
+}
+
+test("agent ids enforce the version-one lexical contract", () => {
+  for (const value of ["a1", "visual", "models-m2_7", `a${"b".repeat(31)}`]) {
+    assert.equal(validateAgentId(value), value);
+  }
+  for (const value of ["a", "Visual", "-visual", "visual.dot", `a${"b".repeat(32)}`, 7, null]) {
+    expectDataError(() => validateAgentId(value));
+  }
+});
+
+test("every message type and severity enum is accepted", () => {
+  for (const type of [
+    "status",
+    "question",
+    "contract_request",
+    "contract_response",
+    "blocker",
+    "handoff",
+    "broadcast",
+  ]) {
+    assert.equal(validateMessage(validMessage({ type })).type, type);
+  }
+  for (const severity of ["info", "action", "blocker"]) {
+    assert.equal(validateMessage(validMessage({ severity })).severity, severity);
+  }
+  expectDataError(() => validateMessage(validMessage({ type: "request" })));
+  expectDataError(() => validateMessage(validMessage({ severity: "warning" })));
+});
+
+test("unknown message versions fail loudly", () => {
+  expectDataError(() => validateMessage(validMessage({ schema_version: 2 })));
+});
+
+test("messages reject absent required fields and wrong scalar or array types", () => {
+  for (const field of Object.keys(validMessage())) {
+    const message = validMessage();
+    delete message[field];
+    expectDataError(() => validateMessage(message));
+  }
+  for (const [field, value] of [
+    ["id", 1],
+    ["from", []],
+    ["requires_ack", "true"],
+    ["created_at", 1],
+    ["reply_to", false],
+    ["attachments", {}],
+  ]) {
+    expectDataError(() => validateMessage(validMessage({ [field]: value })));
+  }
+});
+
+test("protocol-owned records reject unknown keys", () => {
+  expectDataError(() => validateMessage(validMessage({ require_ack: true })));
+  expectDataError(() => validateProtocol({
+    schema_version: 1,
+    protocol_version: 1,
+    checkout_id: SHA256,
+    checkout_root: "/checkout",
+    initialized_at: NOW,
+    typo: true,
+  }));
+});
+
+test("attachments accept only normalized allowed relative paths", () => {
+  for (const attachment of [
+    validAttachment(),
+    validAttachment({ path: ".agents/artifacts/render.png", ephemeral: true }),
+  ]) {
+    assert.equal(validateAttachment(attachment), attachment);
+  }
+  for (const invalidPath of [
+    "/tmp/render.png",
+    "../render.png",
+    "game/../render.png",
+    "game//render.png",
+    "game\\render.png",
+    ".",
+  ]) {
+    expectDataError(() => validateAttachment(validAttachment({ path: invalidPath })));
+  }
+  expectDataError(() => validateAttachment(validAttachment({
+    path: "build/render.png",
+    ephemeral: true,
+  })));
+});
+
+test("repository paths reject the exact parent-directory escape", () => {
+  expectDataError(() => validateRepoPath(".."));
+});
+
+test("attachments reject invalid checksums, sizes, and commit combinations", () => {
+  for (const sha256 of ["abc", "A".repeat(64), 64]) {
+    expectDataError(() => validateAttachment(validAttachment({ sha256 })));
+  }
+  for (const size of [-1, 1.5, "42"]) {
+    expectDataError(() => validateAttachment(validAttachment({ size })));
+  }
+  expectDataError(() => validateAttachment(validAttachment({ ephemeral: "false" })));
+  expectDataError(() => validateAttachment(validAttachment({
+    path: ".agents/artifacts/render.png",
+    ephemeral: true,
+    commit: GIT_SHA,
+  })));
+});
+
+test("identity and lifecycle records validate without cloning", () => {
+  const protocol = {
+    schema_version: 1,
+    protocol_version: 1,
+    checkout_id: SHA256,
+    checkout_root: "/checkout",
+    initialized_at: NOW,
+  };
+  const registry = {
+    schema_version: 1,
+    agent_id: "visual",
+    role: "visual",
+    task: "M2.7",
+    worktree: "/checkout/.gitworktrees/visual",
+    branch: "m2/visual",
+    head: GIT_SHA,
+    ownership: ["game/presentation", "contract:tank-registration-v1"],
+    client: "codex",
+    status: "open",
+    registered_at: NOW,
+    updated_at: NOW,
+  };
+  const presence = {
+    schema_version: 1,
+    agent_id: "visual",
+    pid: 1234,
+    status: "online",
+    heartbeat_at: NOW,
+  };
+  assert.equal(validateProtocol(protocol), protocol);
+  assert.equal(validateRegistry(registry), registry);
+  assert.equal(validatePresence(presence), presence);
+  expectDataError(() => validateRegistry({ ...registry, ownership: "game/presentation" }));
+  expectDataError(() => validatePresence({ ...presence, pid: "1234" }));
+});
+
+test("handoffs require at least one verification record", () => {
+  expectDataError(() => validateHandoff(validHandoff({ verification: [] })));
+});
+
+test("handoff readiness matches its state and verification results", () => {
+  const failedVerification = [{ command: "node --test", exitCode: 1, summary: "failed" }];
+  expectDataError(() => validateHandoff(validHandoff({ verification: failedVerification })));
+  expectDataError(() => validateHandoff(validHandoff({ state: "NOT_READY" })));
+  expectDataError(() => validateHandoff(validHandoff({
+    ready_to_merge: false,
+    state: "READY",
+  })));
+
+  const failedNotReady = validHandoff({
+    verification: failedVerification,
+    ready_to_merge: false,
+    state: "NOT_READY",
+  });
+  assert.equal(validateHandoff(failedNotReady), failedNotReady);
+
+  const uncommitted = validHandoff({
+    commit: null,
+    uncommitted: true,
+    ready_to_merge: false,
+    state: "UNCOMMITTED",
+  });
+  assert.equal(validateHandoff(uncommitted), uncommitted);
+  expectDataError(() => validateHandoff({ ...uncommitted, ready_to_merge: true }));
+  expectDataError(() => validateHandoff({ ...uncommitted, state: "NOT_READY" }));
+});
+
+test("receipt, claim, handoff, and lock records are strict", () => {
+  const seen = {
+    schema_version: 1,
+    message_id: validMessage().id,
+    recipient: "models",
+    seen_at: NOW,
+  };
+  const acknowledgement = {
+    schema_version: 1,
+    message_id: validMessage().id,
+    recipient: "models",
+    acknowledged_at: NOW,
+  };
+  const claim = {
+    schema_version: 1,
+    agent_id: "visual",
+    task: "M2.7",
+    scope: "game/presentation",
+    reason: "camera integration",
+    created_at: NOW,
+    updated_at: NOW,
+    expires_at: NOW,
+  };
+  const handoff = validHandoff();
+  const lock = {
+    schema_version: 1,
+    owner_agent: "visual",
+    pid: 1234,
+    acquired_at: NOW,
+  };
+
+  assert.equal(validateSeenReceipt(seen), seen);
+  assert.equal(validateAcknowledgement(acknowledgement), acknowledgement);
+  assert.equal(validateClaim(claim), claim);
+  assert.equal(validateHandoff(handoff), handoff);
+  assert.equal(validateLock(lock), lock);
+  for (const [validate, record] of [
+    [validateSeenReceipt, seen],
+    [validateAcknowledgement, acknowledgement],
+    [validateClaim, claim],
+    [validateHandoff, handoff],
+    [validateLock, lock],
+  ]) {
+    expectDataError(() => validate({ ...record, unknown: true }));
+  }
+});

--- a/prototype/integrated/tests/tools/agent_comms/status-recovery-audits.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/status-recovery-audits.test.mjs
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { writeJsonAtomic } from "../../../tools/agents/lib/atomic-json.mjs";
+import { claimScope, forceReleaseStaleScope } from "../../../tools/agents/lib/claims.mjs";
+import { sendMessage } from "../../../tools/agents/lib/messages.mjs";
+import { repairStaleRepairMutex } from "../../../tools/agents/lib/repair-mutex.mjs";
+import { validateProtocol } from "../../../tools/agents/lib/schema.mjs";
+import { collectStatus, runDoctor } from "../../../tools/agents/lib/status.mjs";
+import { createBusFixture, messageRequest, pathExists, seedAcknowledgement,
+  seedOpenAgent } from "./helpers.mjs";
+
+const UUID = "11111111-1111-4111-8111-111111111111";
+async function setup(t) {
+  const fixture = await createBusFixture(); t.after(fixture.cleanup);
+  const context = { ...fixture.context, pid: 4242, pidIsAlive: pid => pid === 4242,
+    randomMutexUUID: () => "22222222-2222-4222-8222-222222222222" };
+  await Promise.all(["visual", "models"].map(agentId => seedOpenAgent(context,
+    { agentId, task: "M2.7" })).concat(seedOpenAgent(context,
+    { agentId: "ops", role: "orchestrator", task: "M2.7" })));
+  const protocol = validateProtocol({ schema_version: 1, protocol_version: 1,
+    checkout_id: "c".repeat(64), checkout_root: fixture.root,
+    initialized_at: context.now().toISOString() });
+  await writeJsonAtomic(context.paths.protocol, protocol,
+    { tmpDir: context.paths.tmp, exclusive: true });
+  return { ...fixture, context };
+}
+function mutexOwner(context, overrides = {}) {
+  return { schema_version: 1, kind: "watcher", agent_id: "models", pid: 9999,
+    token: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    acquired_at: new Date(context.now().getTime() - 60_001).toISOString(), ...overrides };
+}
+async function seedMutex(context, owner) {
+  const directory = path.join(context.paths.locks, "watcher-models.lock");
+  await mkdir(directory);
+  await writeJsonAtomic(path.join(directory, "owner.json"), owner,
+    { tmpDir: context.paths.tmp, exclusive: true });
+  return directory;
+}
+function claimLockOwner(context, overrides = {}) {
+  return { schema_version: 1, owner_agent: "visual", pid: 9999,
+    acquired_at: new Date(context.now().getTime() - 60_001).toISOString(), ...overrides };
+}
+function claimLockDigest(owner) {
+  return createHash("sha256").update(JSON.stringify([
+    owner.schema_version, owner.owner_agent, owner.pid, owner.acquired_at,
+  ])).digest("hex");
+}
+function claimAudit(context, owner, overrides = {}) {
+  return { schema_version: 1, action: "repair_stale_claim_lock", actor_agent: null,
+    recorded_at: context.now().toISOString(), target: owner, ...overrides };
+}
+function staleClaim(context) {
+  return { schema_version: 1, agent_id: "visual", task: "M2.7",
+    scope: "game/presentation", reason: "camera",
+    created_at: new Date(context.now().getTime() - 120_000).toISOString(),
+    updated_at: new Date(context.now().getTime() - 120_000).toISOString(),
+    expires_at: new Date(context.now().getTime() - 60_000).toISOString() };
+}
+function watcherOwner(context, overrides = {}) {
+  return { schema_version: 1, agent_id: "models", pid: 9999, token: UUID,
+    acquired_at: new Date(context.now().getTime() - 60_001).toISOString(), ...overrides };
+}
+async function json(context, filePath, value) {
+  await writeJsonAtomic(filePath, value, { tmpDir: context.paths.tmp, exclusive: true });
+}
+async function acknowledgedMessage(context) {
+  const message = await sendMessage(context, messageRequest());
+  await seedAcknowledgement(context, message); return message;
+}
+
+test("doctor replays an exact stale mutex generation after audit publication", async t => {
+  const { context } = await setup(t); const active = await seedMutex(context, mutexOwner(context));
+  const crash = new Error("synthetic crash after immutable audit publication");
+  await assert.rejects(repairStaleRepairMutex({ ...context,
+    renameRepairMutex: async () => { throw crash; } }, "watcher", "models"), crash);
+  assert.equal((await readdir(context.paths.quarantine))
+    .filter(name => name.startsWith("mutex-audit-")).length, 1);
+
+  const report = await runDoctor(context, { repair: true });
+
+  assert.equal(report.repairs.some(item => item.action === "repair_stale_watcher_mutex"), true);
+  assert.equal(await pathExists(active), false);
+  assert.equal(report.ok, true);
+});
+
+test("pending mutex audit with a different active owner generation fails closed", async t => {
+  const { context } = await setup(t); const active = await seedMutex(context, mutexOwner(context));
+  const crash = new Error("synthetic crash after immutable audit publication");
+  await assert.rejects(repairStaleRepairMutex({ ...context,
+    renameRepairMutex: async () => { throw crash; } }, "watcher", "models"), crash);
+  await writeFile(path.join(active, "owner.json"), `${JSON.stringify(mutexOwner(context,
+    { token: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" }), null, 2)}\n`);
+
+  const report = await runDoctor(context, { repair: true });
+
+  assert.equal(report.ok, false);
+  assert.equal(report.repairs.length, 0);
+  assert.equal(await pathExists(active), true);
+});
+
+test("pending mutex audit does not excuse a quarantine generation missing its owner", async t => {
+  const { context } = await setup(t); const active = await seedMutex(context, mutexOwner(context));
+  const crash = new Error("synthetic crash after immutable audit publication");
+  await assert.rejects(repairStaleRepairMutex({ ...context,
+    renameRepairMutex: async () => { throw crash; } }, "watcher", "models"), crash);
+  const auditName = (await readdir(context.paths.quarantine))
+    .find(name => name.startsWith("mutex-audit-"));
+  const audit = JSON.parse(await readFile(path.join(context.paths.quarantine, auditName)));
+  await mkdir(audit.quarantine_path);
+
+  const report = await runDoctor(context, { repair: true });
+
+  assert.equal(report.ok, false);
+  assert.equal(report.repairs.length, 0);
+  assert.equal(await pathExists(active), true);
+});
+
+test("status accepts fully bound claim and watcher recovery artifacts", async t => {
+  const { context } = await setup(t); const owner = claimLockOwner(context);
+  const digest = claimLockDigest(owner);
+  const stale = path.join(context.paths.quarantine, `claims-lock-stale-${digest}`);
+  await mkdir(stale);
+  await Promise.all([
+    json(context, path.join(stale, "owner.json"), owner),
+    json(context, path.join(context.paths.quarantine, `claims-audit-${UUID}.json`),
+      claimAudit(context, owner)),
+    json(context, path.join(context.paths.quarantine,
+      "claims-audit-33333333-3333-4333-8333-333333333333.json"),
+    claimAudit(context, staleClaim(context), { action: "force_release_stale_claim",
+      actor_agent: "models" })),
+    json(context, path.join(context.paths.quarantine, `watcher-owner-stale-${UUID}.json`),
+      watcherOwner(context)),
+  ]);
+
+  assert.deepEqual((await collectStatus(context)).corrupt, []);
+});
+
+test("status validates the force-release audit emitted by the public claims API", async t => {
+  const { context } = await setup(t);
+  await claimScope(context, { agentId: "visual", scope: "game/presentation",
+    reason: "camera", leaseSeconds: 60 });
+  const claimPath = path.join(context.paths.claims, (await readdir(context.paths.claims))[0]);
+  const claim = JSON.parse(await readFile(claimPath));
+  await writeJsonAtomic(claimPath, { ...claim,
+    expires_at: new Date(context.now().getTime() - 1).toISOString() },
+  { tmpDir: context.paths.tmp, exclusive: false });
+
+  await forceReleaseStaleScope(context, { agentId: "ops", ownerAgent: "visual",
+    scope: "game/presentation" });
+
+  assert.deepEqual((await collectStatus(context)).corrupt, []);
+});
+
+for (const [name, damage] of [
+  ["malformed claim audit filename", async context => {
+    const filePath = path.join(context.paths.quarantine, "claims-audit-invalid.json");
+    await json(context, filePath, claimAudit(context, claimLockOwner(context)));
+    return filePath;
+  }],
+  ["claim-lock audit without its quarantined generation", async context => {
+    const filePath = path.join(context.paths.quarantine, `claims-audit-${UUID}.json`);
+    await json(context, filePath, claimAudit(context, claimLockOwner(context)));
+    return filePath;
+  }],
+  ["force-release audit without an actor", async context => {
+    const filePath = path.join(context.paths.quarantine, `claims-audit-${UUID}.json`);
+    await json(context, filePath, claimAudit(context, staleClaim(context),
+      { action: "force_release_stale_claim" })); return filePath;
+  }],
+  ["force-release audit for a non-stale claim", async context => {
+    const filePath = path.join(context.paths.quarantine, `claims-audit-${UUID}.json`);
+    const target = { ...staleClaim(context),
+      expires_at: new Date(context.now().getTime() + 60_000).toISOString() };
+    await json(context, filePath, claimAudit(context, target,
+      { action: "force_release_stale_claim", actor_agent: "models" })); return filePath;
+  }],
+  ["claim-lock generation without its audit", async context => {
+    const owner = claimLockOwner(context); const digest = claimLockDigest(owner);
+    const filePath = path.join(context.paths.quarantine, `claims-lock-stale-${digest}`);
+    await mkdir(filePath); await json(context, path.join(filePath, "owner.json"), owner);
+    return filePath;
+  }],
+  ["claim-lock filename digest mismatch", async context => {
+    const owner = claimLockOwner(context); const filePath = path.join(context.paths.quarantine,
+      `claims-lock-stale-${"0".repeat(64)}`);
+    await mkdir(filePath); await json(context, path.join(filePath, "owner.json"), owner);
+    await json(context, path.join(context.paths.quarantine, `claims-audit-${UUID}.json`),
+      claimAudit(context, owner)); return filePath;
+  }],
+  ["claim-lock generation with no owner record", async context => {
+    const filePath = path.join(context.paths.quarantine, `claims-lock-stale-${"0".repeat(64)}`);
+    await mkdir(filePath); return filePath;
+  }],
+  ["claim-lock audit owner mismatch", async context => {
+    const owner = claimLockOwner(context); const digest = claimLockDigest(owner);
+    const filePath = path.join(context.paths.quarantine, `claims-audit-${UUID}.json`);
+    const stale = path.join(context.paths.quarantine, `claims-lock-stale-${digest}`);
+    await mkdir(stale); await json(context, path.join(stale, "owner.json"), owner);
+    await json(context, filePath, claimAudit(context, { ...owner, pid: 9998 })); return filePath;
+  }],
+  ["watcher owner filename token mismatch", async context => {
+    const filePath = path.join(context.paths.quarantine,
+      "watcher-owner-stale-22222222-2222-4222-8222-222222222222.json");
+    await json(context, filePath, watcherOwner(context)); return filePath;
+  }],
+  ["watcher owner malformed canonical filename", async context => {
+    const filePath = path.join(context.paths.quarantine, `watcher-owner-stale-${UUID}.json.extra`);
+    await json(context, filePath, watcherOwner(context)); return filePath;
+  }],
+]) test(`${name} is corrupt and blocks unrelated repair`, async t => {
+  const { context } = await setup(t); const artifact = await damage(context);
+  const message = await acknowledgedMessage(context);
+
+  const report = await runDoctor(context, { repair: true });
+
+  assert.equal(report.issues.some(item => item.path === artifact), true);
+  assert.equal(report.repairs.length, 0);
+  assert.equal(await pathExists(context.paths.inboxFile(message.to, message.id)), true);
+});

--- a/prototype/integrated/tests/tools/agent_comms/status-review.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/status-review.test.mjs
@@ -1,0 +1,261 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { link, mkdir, readFile, readdir, rename, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { writeJsonAtomic } from "../../../tools/agents/lib/atomic-json.mjs";
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import { sendMessage } from "../../../tools/agents/lib/messages.mjs";
+import {
+  repairStaleWatcherOwnership, startWatcher,
+} from "../../../tools/agents/lib/presence.mjs";
+import { validateClaim, validateProtocol } from "../../../tools/agents/lib/schema.mjs";
+import { collectStatus, enforcementExit, runDoctor } from "../../../tools/agents/lib/status.mjs";
+import {
+  createBusFixture, messageRequest, pathExists, seedAcknowledgement,
+  seedOpenAgent, seedPresence,
+} from "./helpers.mjs";
+
+async function fixtureFor(t, { protocol = true } = {}) {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const livePids = new Set([4242]);
+  const context = {
+    ...fixture.context, pid: 4242, pidIsAlive: pid => livePids.has(pid),
+    randomUUID: () => "00000000-0000-4000-8000-000000000001",
+    listActiveAgentIds: async () => ["visual", "models"],
+  };
+  await Promise.all(["visual", "models"].map(agentId => seedOpenAgent(context,
+    { agentId, task: "M2.7" })));
+  if (protocol) {
+    const record = validateProtocol({ schema_version: 1, protocol_version: 1,
+      checkout_id: "c".repeat(64), checkout_root: fixture.root,
+      initialized_at: context.now().toISOString() });
+    await writeJsonAtomic(context.paths.protocol, record,
+      { tmpDir: context.paths.tmp, exclusive: true });
+  }
+  return { ...fixture, context, livePids };
+}
+
+function storedMessage(context, id, overrides = {}) {
+  return {
+    schema_version: 1, id, from: "visual", to: "models", type: "status",
+    severity: "info", subject: "replacement", body: "valid B", task: "M2.7",
+    reply_to: null, requires_ack: false, created_at: context.now().toISOString(),
+    sender_head: "a".repeat(40), attachments: [], ...overrides,
+  };
+}
+
+async function seedStaleClaimLock(context) {
+  const directory = path.join(context.paths.locks, "claims.lock");
+  await mkdir(directory);
+  await writeFile(path.join(directory, "owner.json"), `${JSON.stringify({
+    schema_version: 1, owner_agent: "visual", pid: 9999,
+    acquired_at: new Date(context.now().getTime() - 60_001).toISOString(),
+  })}\n`);
+  return directory;
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise(done => { resolve = done; });
+  return { promise, resolve };
+}
+
+test("corrupt quarantine retains a valid replacement published before snapshot", async t => {
+  const { context } = await fixtureFor(t);
+  const source = context.paths.inboxFile("models", "broken");
+  await mkdir(path.dirname(source), { recursive: true });
+  await writeFile(source, "{not-json");
+  const replacement = storedMessage(context, "broken");
+  const racing = { ...context, linkCorruptRecord: async (from, destination) => {
+    await unlink(from);
+    await writeFile(from, `${JSON.stringify(replacement)}\n`);
+    return link(from, destination);
+  } };
+  const report = await runDoctor(racing, { repair: true });
+  assert.equal(report.ok, true);
+  assert.deepEqual(JSON.parse(await readFile(source, "utf8")), replacement);
+  assert.equal(report.repairs.some(item => item.action === "quarantine_corrupt_json"), false);
+});
+
+test("doctor refuses to quarantine mutable presence without its writer mutex", async t => {
+  const { context } = await fixtureFor(t);
+  const presencePath = context.paths.presenceFile("models");
+  await writeFile(presencePath, "{not-json");
+  const report = await runDoctor(context, { repair: true });
+  assert.equal(report.ok, false);
+  assert.equal(await pathExists(presencePath), true);
+  assert.equal(report.repairs.some(item => item.path === presencePath), false);
+});
+
+test("watcher mutex serializes two repairs with a replacement owner", async t => {
+  const { context, livePids } = await fixtureFor(t);
+  livePids.delete(4242);
+  const active = path.join(context.paths.locks, "watcher-models.json");
+  const ownerA = { schema_version: 1, agent_id: "models", pid: 9999,
+    token: "11111111-1111-4111-8111-111111111111",
+    acquired_at: new Date(context.now().getTime() - 60_001).toISOString() };
+  await writeFile(active, `${JSON.stringify(ownerA)}\n`);
+  const linked = deferred(), release = deferred();
+  const repairContext = { ...context, linkWatcherOwner: async (source, destination) => {
+    try {
+      const result = await link(source, destination);
+      linked.resolve(); await release.promise; return result;
+    } catch (error) {
+      if (error.code === "EEXIST") await release.promise;
+      throw error;
+    }
+  } };
+  const first = repairStaleWatcherOwnership(repairContext, "models");
+  await linked.promise;
+  const mutexHeld = await pathExists(path.join(context.paths.locks, "watcher-models.lock"));
+  livePids.add(4242);
+  const scheduler = { setInterval: () => 1, clearInterval: () => {},
+    setTimeout: () => 2, clearTimeout: () => {} };
+  const watcherResult = startWatcher({ ...context, scheduler,
+    watchDirectory: () => ({ close: () => {}, once: () => {} }), output: async () => {},
+    extendOwnedClaims: async () => {} }, { agentId: "models" })
+    .then(value => ({ value }), error => ({ error }));
+  const second = repairStaleWatcherOwnership(repairContext, "models");
+  release.resolve();
+  assert.equal(await first, true);
+  const watcher = await watcherResult;
+  assert.equal(watcher.error, undefined);
+  assert.equal(await second, false);
+  assert.equal(mutexHeld, true);
+  assert.equal(JSON.parse(await readFile(active, "utf8")).pid, 4242);
+  await watcher.value.stop();
+});
+
+test("missing protocol is data corruption until init", async t => {
+  const { context } = await fixtureFor(t, { protocol: false });
+  const status = await collectStatus(context);
+  assert.equal(enforcementExit(status, {}), EXIT.DATA);
+  const doctor = await runDoctor(context, {});
+  assert.equal(doctor.ok, false);
+  assert.equal(doctor.issues[0].code, "PROTOCOL_MISSING");
+});
+
+test("corrupt data takes precedence over stale and pending enforcement", async t => {
+  const { context, clock } = await fixtureFor(t);
+  await seedPresence(context, { agentId: "visual", pid: 4242,
+    heartbeatAt: clock.advance(-45_001).toISOString() });
+  clock.advance(45_001);
+  await sendMessage(context, messageRequest());
+  const corruptPath = context.paths.inboxFile("models", "broken");
+  await writeFile(corruptPath, "{not-json");
+  const status = await collectStatus(context);
+  assert.equal(enforcementExit(status, { failOnStale: true, failOnPending: true }), EXIT.DATA);
+});
+
+test("heartbeat-less open registry becomes stale only after forty-five seconds", async t => {
+  const { context, clock } = await fixtureFor(t);
+  let status = await collectStatus(context);
+  assert.deepEqual(status.agents.offline.map(item => item.agent_id), ["models", "visual"]);
+  clock.advance(45_000);
+  status = await collectStatus(context);
+  assert.deepEqual(status.agents.stale, []);
+  clock.advance(1);
+  status = await collectStatus(context);
+  assert.deepEqual(status.agents.stale.map(item => item.agent_id), ["models", "visual"]);
+});
+
+test("claim path digest and scope uniqueness are status invariants", async t => {
+  const { context } = await fixtureFor(t);
+  const claim = validateClaim({ schema_version: 1, agent_id: "visual", task: "M2.7",
+    scope: "game/presentation", reason: "camera", created_at: context.now().toISOString(),
+    updated_at: context.now().toISOString(),
+    expires_at: new Date(context.now().getTime() + 60_000).toISOString() });
+  const canonical = path.join(context.paths.claims,
+    `${createHash("sha256").update(claim.scope).digest("hex")}.json`);
+  const duplicate = path.join(context.paths.claims, "wrong-name.json");
+  await Promise.all([canonical, duplicate].map(filePath => writeJsonAtomic(filePath, claim,
+    { tmpDir: context.paths.tmp, exclusive: true })));
+  const report = await collectStatus(context);
+  assert.deepEqual(report.claims.active, []);
+  assert.deepEqual(report.corrupt, [canonical, duplicate].sort());
+});
+
+test("doctor inventories audit checksum and filename binding on every run", async t => {
+  const { context } = await fixtureFor(t);
+  const source = context.paths.inboxFile("models", "broken");
+  await mkdir(path.dirname(source), { recursive: true });
+  await writeFile(source, "{not-json");
+  const repaired = await runDoctor(context, { repair: true });
+  const record = repaired.repairs[0];
+  const original = await readFile(record.quarantine_path);
+  await writeFile(record.quarantine_path, "changed");
+  let doctor = await runDoctor(context, {});
+  assert.equal(doctor.ok, false);
+  assert.equal(doctor.issues.some(item => item.path === record.audit_path), true);
+  await writeFile(record.quarantine_path, original);
+  const wrong = path.join(context.paths.quarantine, `doctor-audit-${"0".repeat(64)}.json`);
+  await rename(record.audit_path, wrong);
+  doctor = await runDoctor(context, {});
+  assert.equal(doctor.issues.some(item => item.path === wrong), true);
+});
+
+test("unknown protocol version blocks every repair mutation", async t => {
+  const { context } = await fixtureFor(t, { protocol: false });
+  const unknown = { schema_version: 1, protocol_version: 2, checkout_id: "c".repeat(64),
+    checkout_root: path.dirname(context.paths.root), initialized_at: context.now().toISOString() };
+  await writeFile(context.paths.protocol, `${JSON.stringify(unknown)}\n`);
+  const message = await sendMessage(context, messageRequest());
+  await seedAcknowledgement(context, message);
+  const lockDirectory = await seedStaleClaimLock(context);
+  const report = await runDoctor(context, { repair: true });
+  assert.equal(report.ok, false);
+  assert.equal(await pathExists(context.paths.inboxFile("models", message.id)), true);
+  assert.equal(await pathExists(context.paths.archiveFile("models", message.id)), false);
+  assert.equal(await pathExists(lockDirectory), true);
+  assert.deepEqual(await readdir(context.paths.quarantine), []);
+});
+
+test("quarantining a corrupt protocol stops all later repairs until init", async t => {
+  const { context } = await fixtureFor(t);
+  await writeFile(context.paths.protocol, "{not-json");
+  const message = await sendMessage(context, messageRequest());
+  await seedAcknowledgement(context, message);
+  const lockDirectory = await seedStaleClaimLock(context);
+  const report = await runDoctor(context, { repair: true });
+  assert.equal(report.ok, false);
+  assert.equal(report.issues.some(item => item.code === "PROTOCOL_MISSING"), true);
+  assert.deepEqual(report.repairs.map(item => item.path), [context.paths.protocol]);
+  assert.equal(await pathExists(context.paths.inboxFile("models", message.id)), true);
+  assert.equal(await pathExists(context.paths.archiveFile("models", message.id)), false);
+  assert.equal(await pathExists(lockDirectory), true);
+});
+
+test("archive recovery never overwrites a concurrently published destination", async t => {
+  const { context } = await fixtureFor(t);
+  const message = await sendMessage(context, messageRequest());
+  await seedAcknowledgement(context, message);
+  const source = context.paths.inboxFile("models", message.id);
+  const destination = context.paths.archiveFile("models", message.id);
+  const replacement = Buffer.from(`${JSON.stringify({ ...message, body: "concurrent B" })}\n`);
+  const racing = { ...context, linkArchiveRecord: async (from, to) => {
+    await mkdir(path.dirname(to), { recursive: true });
+    await writeFile(to, replacement);
+    return link(from, to);
+  } };
+  await assert.rejects(runDoctor(racing, { repair: true }),
+    error => error.exitCode === EXIT.DATA);
+  assert.equal(await readFile(destination, "utf8"), replacement.toString());
+  assert.equal(await pathExists(source), true);
+});
+
+test("archive recovery accepts an identical immutable destination", async t => {
+  const { context } = await fixtureFor(t);
+  const message = await sendMessage(context, messageRequest());
+  await seedAcknowledgement(context, message);
+  const source = context.paths.inboxFile("models", message.id);
+  const destination = context.paths.archiveFile("models", message.id);
+  await mkdir(path.dirname(destination), { recursive: true });
+  await writeFile(destination, await readFile(source));
+  const report = await runDoctor(context, { repair: true });
+  assert.equal(report.ok, true);
+  assert.equal(await pathExists(source), false);
+  assert.deepEqual(JSON.parse(await readFile(destination, "utf8")), message);
+});

--- a/prototype/integrated/tests/tools/agent_comms/status-round2.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/status-round2.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { link, mkdir, readFile, symlink, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { writeJsonAtomic } from "../../../tools/agents/lib/atomic-json.mjs";
+import { sendMessage } from "../../../tools/agents/lib/messages.mjs";
+import { validateProtocol } from "../../../tools/agents/lib/schema.mjs";
+import { collectStatus, runDoctor } from "../../../tools/agents/lib/status.mjs";
+import { createBusFixture, messageRequest, pathExists, seedAcknowledgement,
+  seedOpenAgent } from "./helpers.mjs";
+
+async function setup(t) {
+  const fixture = await createBusFixture(); t.after(fixture.cleanup);
+  const context = { ...fixture.context, pid: 4242, pidIsAlive: pid => pid === 4242,
+    randomUUID: () => "22222222-2222-4222-8222-222222222222",
+    listActiveAgentIds: async () => ["visual", "models"] };
+  await Promise.all(["visual", "models"].map(agentId => seedOpenAgent(context,
+    { agentId, task: "M2.7" })));
+  const protocol = validateProtocol({ schema_version: 1, protocol_version: 1,
+    checkout_id: "c".repeat(64), checkout_root: fixture.root,
+    initialized_at: context.now().toISOString() });
+  await writeJsonAtomic(context.paths.protocol, protocol,
+    { tmpDir: context.paths.tmp, exclusive: true });
+  return { ...fixture, context };
+}
+
+test("unknown schema version blocks all repair mutation", async t => {
+  const { context } = await setup(t);
+  const unknown = { schema_version: 2, protocol_version: 1, checkout_id: "c".repeat(64),
+    checkout_root: path.dirname(context.paths.root), initialized_at: context.now().toISOString() };
+  const bytes = `${JSON.stringify(unknown)}\n`;
+  await writeFile(context.paths.protocol, bytes);
+  const message = await sendMessage(context, messageRequest());
+  await seedAcknowledgement(context, message);
+  const report = await runDoctor(context, { repair: true });
+  assert.equal(report.ok, false);
+  assert.equal(report.issues.some(item => item.code === "UNKNOWN_SCHEMA_VERSION"), true);
+  assert.equal(await readFile(context.paths.protocol, "utf8"), bytes);
+  assert.equal(await pathExists(context.paths.inboxFile("models", message.id)), true);
+});
+
+test("doctor audit rejects a canonical quarantine symlink before following it", async t => {
+  const { context, root } = await setup(t);
+  const source = context.paths.inboxFile("models", "broken");
+  const bytes = Buffer.from("outside secret");
+  const digest = createHash("sha256").update(source).update(bytes).digest("hex");
+  const quarantine = path.join(context.paths.quarantine, `corrupt-${digest}.data`);
+  const auditPath = path.join(context.paths.quarantine, `doctor-audit-${digest}.json`);
+  const outside = path.join(root, "outside.data");
+  await writeFile(outside, bytes); await symlink(outside, quarantine);
+  await writeFile(auditPath, `${JSON.stringify({ schema_version: 1,
+    action: "quarantine_corrupt_json", source_path: source, quarantine_path: quarantine,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    recorded_at: context.now().toISOString() })}\n`);
+  const report = await runDoctor(context, {});
+  assert.equal(report.ok, false);
+  assert.equal(report.issues.some(item => item.path === auditPath), true);
+});
+
+test("archive EEXIST after another repair removed source is idempotent", async t => {
+  const { context } = await setup(t);
+  const message = await sendMessage(context, messageRequest());
+  await seedAcknowledgement(context, message);
+  const racing = { ...context, linkArchiveRecord: async (source, destination) => {
+    await link(source, destination); await unlink(source);
+    const error = new Error("published concurrently"); error.code = "EEXIST"; throw error;
+  } };
+  const report = await runDoctor(racing, { repair: true });
+  assert.equal(report.ok, true);
+  assert.deepEqual(JSON.parse(await readFile(
+    context.paths.archiveFile("models", message.id), "utf8")), message);
+});
+
+test("status distinguishes watcher mutex live young stale and corrupt", async t => {
+  const { context } = await setup(t);
+  for (const [agentId, age, pid, raw] of [
+    ["live", 100_000, 4242], ["young", 60_000, 9999], ["stale", 60_001, 9999],
+    ["corrupt", 0, 9999, "{}\n"],
+  ]) {
+    const directory = path.join(context.paths.locks, `watcher-${agentId}.lock`);
+    await mkdir(directory);
+    const owner = { schema_version: 1, kind: "watcher", agent_id: agentId, pid,
+      token: `33333333-3333-4333-8333-${String(age).padStart(12, "0")}`,
+      acquired_at: new Date(context.now().getTime() - age).toISOString() };
+    await writeFile(path.join(directory, "owner.json"), raw ?? `${JSON.stringify(owner)}\n`);
+  }
+  const report = await collectStatus(context);
+  assert.deepEqual(report.locks.watcher.live.map(item => item.owner.agent_id), ["live"]);
+  assert.deepEqual(report.locks.watcher.young.map(item => item.owner.agent_id), ["young"]);
+  assert.deepEqual(report.locks.watcher.stale.map(item => item.owner.agent_id), ["stale"]);
+  assert.equal(report.locks.watcher.corrupt.length, 1);
+  assert.equal((await runDoctor(context, {})).ok, false);
+});
+
+test("doctor repair recovers a stale doctor mutex with an audit", async t => {
+  const { context } = await setup(t);
+  const directory = path.join(context.paths.locks, "doctor.lock"); await mkdir(directory);
+  const owner = { schema_version: 1, kind: "doctor", agent_id: null, pid: 9999,
+    token: "55555555-5555-4555-8555-555555555555",
+    acquired_at: new Date(context.now().getTime() - 60_001).toISOString() };
+  await writeFile(path.join(directory, "owner.json"), `${JSON.stringify(owner)}\n`);
+  const report = await runDoctor(context, { repair: true });
+  assert.equal(report.ok, true);
+  assert.equal(report.repairs.some(item => item.action === "repair_stale_doctor_mutex"), true);
+  assert.equal(await pathExists(directory), false);
+});
+
+test("doctor repairs stale watcher mutex before stale watcher ownership", async t => {
+  const { context } = await setup(t);
+  const mutex = path.join(context.paths.locks, "watcher-models.lock"); await mkdir(mutex);
+  const acquiredAt = new Date(context.now().getTime() - 60_001).toISOString();
+  await writeFile(path.join(mutex, "owner.json"), `${JSON.stringify({ schema_version: 1,
+    kind: "watcher", agent_id: "models", pid: 9999,
+    token: "66666666-6666-4666-8666-666666666666", acquired_at: acquiredAt })}\n`);
+  const ownership = path.join(context.paths.locks, "watcher-models.json");
+  await writeFile(ownership, `${JSON.stringify({ schema_version: 1, agent_id: "models",
+    pid: 9999, token: "77777777-7777-4777-8777-777777777777", acquired_at: acquiredAt })}\n`);
+  const report = await runDoctor(context, { repair: true });
+  assert.equal(report.ok, true);
+  assert.deepEqual(report.repairs.map(item => item.action).filter(action =>
+    action.includes("watcher")), ["repair_stale_watcher_mutex", "repair_stale_watcher_owner"]);
+  assert.equal(await pathExists(mutex), false); assert.equal(await pathExists(ownership), false);
+});

--- a/prototype/integrated/tests/tools/agent_comms/status-round3.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/status-round3.test.mjs
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { link, lstat, mkdir, open, readFile, readdir, rename, symlink, unlink, writeFile }
+  from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { writeJsonAtomic } from "../../../tools/agents/lib/atomic-json.mjs";
+import { archiveAcknowledged } from "../../../tools/agents/lib/doctor-storage.mjs";
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import { sendMessage } from "../../../tools/agents/lib/messages.mjs";
+import { inspectRepairMutex, repairStaleRepairMutex }
+  from "../../../tools/agents/lib/repair-mutex.mjs";
+import { validateProtocol } from "../../../tools/agents/lib/schema.mjs";
+import { collectStatus, runDoctor } from "../../../tools/agents/lib/status.mjs";
+import { createBusFixture, messageRequest, pathExists, seedAcknowledgement,
+  seedOpenAgent } from "./helpers.mjs";
+
+async function setup(t) {
+  const fixture = await createBusFixture(); t.after(fixture.cleanup);
+  let uuid = 1;
+  const context = { ...fixture.context, pid: 4242, pidIsAlive: pid => pid === 4242,
+    randomUUID: () => `88888888-8888-4888-8888-${String(uuid++).padStart(12, "0")}`,
+    randomMutexUUID: () => `99999999-9999-4999-8999-${String(uuid++).padStart(12, "0")}` };
+  await Promise.all(["visual", "models"].map(agentId => seedOpenAgent(context,
+    { agentId, task: "M2.7" })));
+  const protocol = validateProtocol({ schema_version: 1, protocol_version: 1,
+    checkout_id: "c".repeat(64), checkout_root: fixture.root,
+    initialized_at: context.now().toISOString() });
+  await writeJsonAtomic(context.paths.protocol, protocol,
+    { tmpDir: context.paths.tmp, exclusive: true });
+  return { ...fixture, context };
+}
+function enoent() { const error = new Error("source disappeared"); error.code = "ENOENT";
+  return error; }
+async function ackedMessage(context) {
+  const message = await sendMessage(context, messageRequest());
+  await seedAcknowledgement(context, message); return message;
+}
+
+test("direct archive link ENOENT accepts only an equal strict destination", async t => {
+  const { context } = await setup(t); const message = await ackedMessage(context);
+  const destination = context.paths.archiveFile(message.to, message.id);
+  await mkdir(path.dirname(destination), { recursive: true });
+  await writeFile(destination, `${JSON.stringify(message)}\n`);
+  const racing = { ...context, linkArchiveRecord: async () => { throw enoent(); } };
+  assert.equal(await archiveAcknowledged(racing, message), null);
+  assert.deepEqual(JSON.parse(await readFile(destination, "utf8")), message);
+});
+
+test("direct archive link ENOENT rejects a conflicting destination", async t => {
+  const { context } = await setup(t); const message = await ackedMessage(context);
+  const destination = context.paths.archiveFile(message.to, message.id);
+  await mkdir(path.dirname(destination), { recursive: true });
+  await writeFile(destination, `${JSON.stringify({ ...message, body: "conflicting B" })}\n`);
+  const racing = { ...context, linkArchiveRecord: async () => { throw enoent(); } };
+  await assert.rejects(archiveAcknowledged(racing, message),
+    error => error.exitCode === EXIT.DATA);
+  assert.equal(await pathExists(context.paths.inboxFile(message.to, message.id)), true);
+});
+
+test("blocking watcher mutex files and symlinks are corrupt and preserved", async t => {
+  const { context, root } = await setup(t);
+  const regular = path.join(context.paths.locks, "watcher-models.lock");
+  const target = path.join(root, "outside.lock");
+  const symbolic = path.join(context.paths.locks, "watcher-visual.lock");
+  await writeFile(regular, "blocking file"); await writeFile(target, "outside");
+  await symlink(target, symbolic);
+  const status = await collectStatus(context);
+  assert.deepEqual(status.locks.watcher.corrupt.map(item => item.path), [regular, symbolic]);
+  const doctor = await runDoctor(context, { repair: true });
+  assert.equal(doctor.ok, false); assert.equal(await pathExists(regular), true);
+  assert.equal((await lstat(symbolic)).isSymbolicLink(), true);
+});
+
+async function repairedMutex(context) {
+  const directory = path.join(context.paths.locks, "watcher-models.lock");
+  await mkdir(directory);
+  const target = { schema_version: 1, kind: "watcher", agent_id: "models", pid: 9999,
+    token: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    acquired_at: new Date(context.now().getTime() - 60_001).toISOString() };
+  await writeFile(path.join(directory, "owner.json"), `${JSON.stringify(target)}\n`);
+  assert.equal(await repairStaleRepairMutex(context, "watcher", "models"), true);
+  const names = await readdir(context.paths.quarantine);
+  return { auditPath: path.join(context.paths.quarantine,
+    names.find(name => name.startsWith("mutex-audit-"))), targetPath: path.join(
+    context.paths.quarantine, names.find(name => name.startsWith("mutex-stale-"))) };
+}
+
+for (const [name, damage] of [
+  ["missing audit", async ({ auditPath }, context) => rename(auditPath,
+    path.join(context.root, "missing-mutex-audit.json"))],
+  ["missing target", async ({ targetPath }, context) => rename(targetPath,
+    path.join(context.root, "missing-mutex-target"))],
+  ["filename digest", async ({ auditPath }) => rename(auditPath,
+    path.join(path.dirname(auditPath), `mutex-audit-${"0".repeat(64)}.json`))],
+  ["canonical target", async ({ auditPath }, context) => {
+    const audit = JSON.parse(await readFile(auditPath)); audit.quarantine_path = context.paths.tmp;
+    await writeFile(auditPath, `${JSON.stringify(audit)}\n`);
+  }],
+  ["audit target owner", async ({ auditPath }) => {
+    const audit = JSON.parse(await readFile(auditPath)); audit.target.pid = 9998;
+    await writeFile(auditPath, `${JSON.stringify(audit)}\n`);
+  }],
+  ["moved owner bytes", async ({ targetPath }) => {
+    const ownerPath = path.join(targetPath, "owner.json");
+    const owner = JSON.parse(await readFile(ownerPath)); owner.pid = 9998;
+    await writeFile(ownerPath, `${JSON.stringify(owner)}\n`);
+  }],
+]) test(`mutex audit rejects damaged ${name} and blocks archive repair`, async t => {
+  const { context, root } = await setup(t); const paths = await repairedMutex(context);
+  await damage(paths, { ...context, root }); const message = await ackedMessage(context);
+  const doctor = await runDoctor(context, { repair: true });
+  assert.equal(doctor.ok, false);
+  assert.equal(await pathExists(context.paths.inboxFile(message.to, message.id)), true);
+});
+
+test("doctor audit quarantine read rejects a swap at the no-follow open", async t => {
+  const { context, root } = await setup(t);
+  const source = context.paths.inboxFile("models", "broken");
+  await mkdir(path.dirname(source), { recursive: true }); await writeFile(source, "{broken");
+  const repaired = await runDoctor(context, { repair: true });
+  const quarantine = repaired.repairs[0].quarantine_path;
+  const outside = path.join(root, "outside.data");
+  await writeFile(outside, await readFile(quarantine)); let swapped = false;
+  const racing = { ...context, openImmutableRecord: async (filePath, flags) => {
+    if (!swapped && filePath === quarantine) {
+      swapped = true; await unlink(quarantine); await symlink(outside, quarantine);
+    }
+    return open(filePath, flags);
+  } };
+  assert.equal((await runDoctor(racing, {})).ok, false);
+});
+
+test("repair mutex owner read rejects a swap at the no-follow open", async t => {
+  const { context, root } = await setup(t);
+  const directory = path.join(context.paths.locks, "watcher-models.lock"); await mkdir(directory);
+  const ownerPath = path.join(directory, "owner.json");
+  const owner = { schema_version: 1, kind: "watcher", agent_id: "models", pid: 4242,
+    token: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    acquired_at: context.now().toISOString() };
+  await writeFile(ownerPath, `${JSON.stringify(owner)}\n`);
+  const outside = path.join(root, "outside-owner.json");
+  await writeFile(outside, `${JSON.stringify(owner)}\n`); let swapped = false;
+  const racing = { ...context, openMutexOwner: async (filePath, flags) => {
+    if (!swapped) { swapped = true; await unlink(filePath); await symlink(outside, filePath); }
+    return open(filePath, flags);
+  } };
+  assert.equal((await inspectRepairMutex(racing, "watcher", "models")).state, "corrupt");
+});

--- a/prototype/integrated/tests/tools/agent_comms/status-round4.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/status-round4.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { mkdir, open, symlink, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { writeJsonAtomic } from "../../../tools/agents/lib/atomic-json.mjs";
+import { archiveAcknowledged } from "../../../tools/agents/lib/doctor-storage.mjs";
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import { sendMessage } from "../../../tools/agents/lib/messages.mjs";
+import { validateProtocol } from "../../../tools/agents/lib/schema.mjs";
+import { collectStatus, enforcementExit, runDoctor }
+  from "../../../tools/agents/lib/status.mjs";
+import { createBusFixture, messageRequest, pathExists, seedAcknowledgement,
+  seedOpenAgent } from "./helpers.mjs";
+
+async function setup(t) {
+  const fixture = await createBusFixture(); t.after(fixture.cleanup);
+  let uuid = 1;
+  const context = { ...fixture.context, pid: 4242, pidIsAlive: pid => pid === 4242,
+    randomUUID: () => `aaaaaaaa-aaaa-4aaa-8aaa-${String(uuid++).padStart(12, "0")}`,
+    randomMutexUUID: () => `bbbbbbbb-bbbb-4bbb-8bbb-${String(uuid++).padStart(12, "0")}` };
+  await Promise.all(["visual", "models"].map(agentId => seedOpenAgent(context,
+    { agentId, task: "M2.7" })));
+  const protocol = validateProtocol({ schema_version: 1, protocol_version: 1,
+    checkout_id: "c".repeat(64), checkout_root: fixture.root,
+    initialized_at: context.now().toISOString() });
+  await writeJsonAtomic(context.paths.protocol, protocol,
+    { tmpDir: context.paths.tmp, exclusive: true });
+  return { ...fixture, context };
+}
+
+async function ackedMessage(context) {
+  const message = await sendMessage(context, messageRequest());
+  await seedAcknowledgement(context, message);
+  return message;
+}
+
+function enoent() {
+  const error = new Error("source disappeared"); error.code = "ENOENT";
+  return error;
+}
+
+for (const [name, basename, createArtifact] of [
+  ["audit without extension", "mutex-audit-malformed",
+    filePath => writeFile(filePath, "{malformed")],
+  ["stale target", "mutex-stale-malformed.extra", filePath => mkdir(filePath)],
+]) test(`malformed mutex ${name} is corrupt and blocks repair`, async t => {
+  const { context } = await setup(t);
+  const artifact = path.join(context.paths.quarantine, basename);
+  await createArtifact(artifact);
+  const message = await ackedMessage(context);
+
+  const doctor = await runDoctor(context, { repair: true });
+
+  assert.equal(doctor.issues.some(item => item.path === artifact), true);
+  assert.equal(await pathExists(context.paths.inboxFile(message.to, message.id)), true);
+});
+
+test("direct archive ENOENT rejects a destination swapped to a symlink at open", async t => {
+  const { context, root } = await setup(t);
+  const message = await ackedMessage(context);
+  const destination = context.paths.archiveFile(message.to, message.id);
+  const outside = path.join(root, "outside-archive.json");
+  await mkdir(path.dirname(destination), { recursive: true });
+  await writeFile(destination, `${JSON.stringify(message)}\n`);
+  await writeFile(outside, `${JSON.stringify(message)}\n`);
+  let swapped = false;
+  const racing = { ...context, linkArchiveRecord: async () => { throw enoent(); },
+    openArchiveRecord: async (filePath, flags) => {
+      if (!swapped) {
+        swapped = true; await unlink(filePath); await symlink(outside, filePath);
+      }
+      return open(filePath, flags);
+    } };
+
+  await assert.rejects(archiveAcknowledged(racing, message),
+    error => error.exitCode === EXIT.DATA);
+  assert.equal(await pathExists(context.paths.inboxFile(message.to, message.id)), true);
+});
+
+for (const [kind, basename] of [
+  ["doctor", "doctor.lock"], ["watcher", "watcher-models.lock"],
+]) test(`enforcement treats a corrupt ${kind} mutex as data corruption`, async t => {
+  const { context } = await setup(t);
+  const mutex = path.join(context.paths.locks, basename);
+  await mkdir(mutex);
+  await writeFile(path.join(mutex, "owner.json"), "{}\n");
+
+  const status = await collectStatus(context);
+
+  assert.equal(kind === "doctor" ? status.locks.doctor.state
+    : status.locks.watcher.corrupt[0].state, "corrupt");
+  assert.equal(enforcementExit(status, {}), EXIT.DATA);
+});

--- a/prototype/integrated/tests/tools/agent_comms/status.test.mjs
+++ b/prototype/integrated/tests/tools/agent_comms/status.test.mjs
@@ -1,0 +1,298 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, rmdir, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { writeJsonAtomic } from "../../../tools/agents/lib/atomic-json.mjs";
+import { claimScope } from "../../../tools/agents/lib/claims.mjs";
+import { EXIT } from "../../../tools/agents/lib/errors.mjs";
+import { ackMessage, markSeen, sendMessage } from "../../../tools/agents/lib/messages.mjs";
+import { validateHandoff, validateProtocol } from "../../../tools/agents/lib/schema.mjs";
+import { collectStatus, enforcementExit, runDoctor } from "../../../tools/agents/lib/status.mjs";
+import {
+  createBusFixture, messageRequest, pathExists, seedOpenAgent, seedPresence,
+} from "./helpers.mjs";
+
+async function fixtureFor(t) {
+  const fixture = await createBusFixture();
+  t.after(fixture.cleanup);
+  const context = {
+    ...fixture.context,
+    pid: 4242,
+    pidIsAlive: pid => pid === 4242,
+    randomUUID: (() => {
+      let index = 0;
+      return () => `00000000-0000-4000-8000-${String(++index).padStart(12, "0")}`;
+    })(),
+    listActiveAgentIds: async () => ["visual", "models", "offline"],
+  };
+  await Promise.all([
+    seedOpenAgent(context, { agentId: "visual", task: "M2.7" }),
+    seedOpenAgent(context, { agentId: "models", task: "M2.7" }),
+    seedOpenAgent(context, { agentId: "offline", task: "M2.7" }),
+  ]);
+  await seedPresence(context, { agentId: "visual", pid: 4242 });
+  await seedPresence(context, { agentId: "models", pid: 4242 });
+  const protocol = validateProtocol({
+    schema_version: 1,
+    protocol_version: 1,
+    checkout_id: "c".repeat(64),
+    checkout_root: fixture.root,
+    initialized_at: context.now().toISOString(),
+  });
+  await writeJsonAtomic(context.paths.protocol, protocol,
+    { tmpDir: context.paths.tmp, exclusive: true });
+  return { ...fixture, context };
+}
+
+async function requiredMessage(context, overrides = {}) {
+  return sendMessage(context, messageRequest(overrides));
+}
+
+async function seedClaimLock(context, ageMs = 60_001) {
+  const directory = path.join(context.paths.locks, "claims.lock");
+  await mkdir(directory);
+  await writeFile(path.join(directory, "owner.json"), `${JSON.stringify({
+    schema_version: 1,
+    owner_agent: "visual",
+    pid: 9999,
+    acquired_at: new Date(context.now().getTime() - ageMs).toISOString(),
+  })}\n`);
+  return directory;
+}
+
+function watcherOwner(context, overrides = {}) {
+  return {
+    schema_version: 1,
+    agent_id: "models",
+    pid: 9999,
+    token: "11111111-1111-4111-8111-111111111111",
+    acquired_at: new Date(context.now().getTime() - 60_001).toISOString(),
+    ...overrides,
+  };
+}
+
+test("seen required action stays pending until acknowledgement", async t => {
+  const { context } = await fixtureFor(t);
+  const message = await requiredMessage(context);
+  await markSeen(context, message, "models");
+  const report = await collectStatus(context);
+  assert.equal(report.counts.seen_but_unacked, 1);
+  assert.equal(report.counts.required_unacked, 1);
+  assert.deepEqual(report.protocol,
+    { schema_version: 1, protocol_version: 1, checkout_id: "c".repeat(64) });
+  assert.deepEqual(report.messages.required_unacked, [message]);
+});
+
+test("validated acknowledgement is visible to the original sender", async t => {
+  const { context } = await fixtureFor(t);
+  const message = await requiredMessage(context);
+  const acknowledgement = await ackMessage(context,
+    { agentId: "models", messageId: message.id });
+  const report = await collectStatus(context);
+  assert.deepEqual(report.messages.acknowledgements, [{
+    message, acknowledgement, location: "archive",
+  }]);
+  assert.equal(report.counts.acknowledgements, 1);
+  assert.deepEqual(report.messages.required_unacked, []);
+});
+
+test("ack filename cannot impersonate acknowledgement of another message", async t => {
+  const { context } = await fixtureFor(t);
+  const message = await requiredMessage(context);
+  const ackPath = context.paths.ackFile(message.id, "models");
+  await writeFile(ackPath, `${JSON.stringify({
+    schema_version: 1,
+    message_id: `${message.id}-other`,
+    recipient: "models",
+    acknowledged_at: context.now().toISOString(),
+  })}\n`);
+  const report = await collectStatus(context);
+  assert.deepEqual(report.messages.acknowledgements, []);
+  assert.deepEqual(report.corrupt, [ackPath]);
+});
+
+test("status distinguishes agents, messages, claims, blockers, and handoffs", async t => {
+  const { context, clock } = await fixtureFor(t);
+  await seedPresence(context, { agentId: "models", pid: 4242,
+    heartbeatAt: new Date(context.now().getTime() - 45_001).toISOString() });
+  const blocker = await requiredMessage(context,
+    { type: "blocker", severity: "blocker", subject: "Blocked" });
+  const info = await requiredMessage(context, { type: "status", severity: "info",
+    subject: "FYI", requiresAck: false });
+  await markSeen(context, info, "models");
+  await claimScope(context, { agentId: "visual", scope: "game/presentation",
+    reason: "camera", leaseSeconds: 1 });
+  clock.advance(1_001);
+  await claimScope(context, { agentId: "models", scope: "game/models",
+    reason: "mesh", leaseSeconds: 10 });
+  const handoff = validateHandoff({
+    schema_version: 1, id: "handoff-one", from: "visual", to: "models",
+    task: "M2.7", result: "ready", branch: "models", commit: "d".repeat(40),
+    base: "a".repeat(40), changed_paths: ["game/models"],
+    verification: [{ command: "node --test", exitCode: 0, summary: "pass" }],
+    contracts: { added: [], changed: [], consumed: [] }, follow_up: [], artifacts: [],
+    limitations: [], uncommitted: false, ready_to_merge: true, state: "READY",
+    created_at: context.now().toISOString(),
+  });
+  await writeJsonAtomic(context.paths.handoffFile(handoff.id), handoff,
+    { tmpDir: context.paths.tmp, exclusive: true });
+  const report = await collectStatus(context);
+  assert.deepEqual(report.agents.live.map(item => item.agent_id), ["visual"]);
+  assert.deepEqual(report.agents.stale.map(item => item.agent_id), ["models"]);
+  assert.deepEqual(report.agents.offline.map(item => item.agent_id), ["offline"]);
+  assert.deepEqual(report.messages.unseen, [blocker]);
+  assert.deepEqual(report.messages.seen_but_unacked, [info]);
+  assert.deepEqual(report.messages.blockers, [blocker]);
+  assert.deepEqual(report.claims.stale.map(item => item.scope), ["game/presentation"]);
+  assert.deepEqual(report.claims.active.map(item => item.scope), ["game/models"]);
+  assert.deepEqual(report.handoffs, [handoff]);
+  assert.equal(enforcementExit(report, { failOnPending: true }), EXIT.REQUIRED);
+  await ackMessage(context, { agentId: "models", messageId: blocker.id });
+  assert.equal(enforcementExit(await collectStatus(context), { failOnPending: true }), EXIT.OK);
+});
+
+test("require-live and fail-on-stale report required agents only", async t => {
+  const { context } = await fixtureFor(t);
+  const report = await runDoctor(context, { requireLive: ["models", "offline"] });
+  assert.deepEqual(report.issues.map(issue => issue.code), ["REQUIRED_AGENT_OFFLINE"]);
+  const status = await collectStatus(context);
+  assert.equal(enforcementExit(status, { failOnStale: true }), EXIT.OK);
+  await seedPresence(context, { agentId: "models", pid: 4242,
+    heartbeatAt: new Date(context.now().getTime() - 45_001).toISOString() });
+  assert.equal(enforcementExit(await collectStatus(context), { failOnStale: true }),
+    EXIT.REQUIRED);
+});
+
+test("doctor reports corrupt JSON read-only and repair quarantines with immutable audit", async t => {
+  const { context, clock } = await fixtureFor(t);
+  const corruptPath = context.paths.inboxFile("models", "broken");
+  await mkdir(path.dirname(corruptPath), { recursive: true });
+  await writeFile(corruptPath, "{not-json");
+  const normal = await runDoctor(context, {});
+  assert.equal(normal.ok, false);
+  assert.equal(normal.issues[0].code, "CORRUPT_JSON");
+  assert.equal(await pathExists(corruptPath), true);
+  assert.equal(enforcementExit(await collectStatus(context), {}), EXIT.DATA);
+  const repaired = await runDoctor(context, { repair: true });
+  assert.equal(repaired.ok, true);
+  assert.equal(repaired.repairs[0].action, "quarantine_corrupt_json");
+  assert.equal(await pathExists(corruptPath), false);
+  const auditPath = repaired.repairs[0].audit_path;
+  const before = await readFile(auditPath, "utf8");
+  clock.advance(1_000);
+  await mkdir(path.dirname(corruptPath), { recursive: true });
+  await writeFile(corruptPath, "{not-json");
+  await runDoctor(context, { repair: true });
+  assert.equal(await readFile(auditPath, "utf8"), before);
+});
+
+test("doctor finishes only an acknowledgement-backed archive move", async t => {
+  const { context } = await fixtureFor(t);
+  const message = await requiredMessage(context);
+  await writeJsonAtomic(context.paths.ackFile(message.id, "models"), {
+    schema_version: 1, message_id: message.id, recipient: "models",
+    acknowledged_at: context.now().toISOString(),
+  }, { tmpDir: context.paths.tmp, exclusive: true });
+  const normal = await runDoctor(context, {});
+  assert.equal(await pathExists(context.paths.inboxFile("models", message.id)), true);
+  assert.equal(normal.issues[0].code, "ACKED_MESSAGE_NOT_ARCHIVED");
+  const repaired = await runDoctor(context, { repair: true });
+  assert.equal(repaired.ok, true);
+  assert.equal(await pathExists(context.paths.archiveFile("models", message.id)), true);
+  assert.equal(repaired.repairs[0].action, "archive_acknowledged_message");
+});
+
+test("doctor fails closed on a corrupt pre-existing repair audit", async t => {
+  const { context, clock } = await fixtureFor(t);
+  const corruptPath = context.paths.inboxFile("models", "broken");
+  await mkdir(path.dirname(corruptPath), { recursive: true });
+  await writeFile(corruptPath, "{not-json");
+  const repaired = await runDoctor(context, { repair: true });
+  const auditPath = repaired.repairs[0].audit_path;
+  const audit = JSON.parse(await readFile(auditPath, "utf8"));
+  await writeFile(auditPath, `${JSON.stringify({ ...audit, recorded_at: "invalid" })}\n`);
+  clock.advance(1_000);
+  await writeFile(corruptPath, "{not-json");
+  const blocked = await runDoctor(context, { repair: true });
+  assert.equal(blocked.ok, false);
+  assert.deepEqual(blocked.repairs, []);
+  assert.equal(await pathExists(corruptPath), true);
+});
+
+test("doctor protects unknown protocol versions from repair", async t => {
+  const { context } = await fixtureFor(t);
+  await writeFile(context.paths.protocol, `${JSON.stringify({
+    schema_version: 1, protocol_version: 2, checkout_id: "c".repeat(64),
+    checkout_root: path.dirname(context.paths.root),
+    initialized_at: context.now().toISOString(),
+  })}\n`);
+  const before = await readFile(context.paths.protocol, "utf8");
+  const report = await runDoctor(context, { repair: true });
+  assert.equal(report.ok, false);
+  assert.equal(report.issues[0].code, "UNKNOWN_PROTOCOL_VERSION");
+  assert.equal(await readFile(context.paths.protocol, "utf8"), before);
+});
+
+test("doctor invokes stale claim-lock repair but preserves young locks", async t => {
+  const { context } = await fixtureFor(t);
+  const young = await seedClaimLock(context, 60_000);
+  assert.equal((await runDoctor(context, { repair: true })).repairs.length, 0);
+  assert.equal(await pathExists(young), true);
+  await unlink(path.join(young, "owner.json"));
+  await rmdir(young);
+  const stale = await seedClaimLock(context);
+  const report = await runDoctor(context, { repair: true });
+  assert.equal(report.repairs.some(item => item.action === "repair_stale_claim_lock"), true);
+  assert.equal(await pathExists(stale), false);
+});
+
+test("doctor reports a corrupt claim-lock owner instead of skipping it", async t => {
+  const { context } = await fixtureFor(t);
+  const directory = path.join(context.paths.locks, "claims.lock");
+  await mkdir(directory);
+  const ownerPath = path.join(directory, "owner.json");
+  await writeFile(ownerPath, "{not-json");
+  assert.equal(enforcementExit(await collectStatus(context), {}), EXIT.DATA);
+  const report = await runDoctor(context, {});
+  assert.equal(report.ok, false);
+  assert.equal(report.issues.some(item => item.code === "CORRUPT_JSON"
+    && item.path === ownerPath), true);
+  const repaired = await runDoctor(context, { repair: true });
+  assert.equal(repaired.ok, false);
+  assert.equal(repaired.issues[0].code, "CORRUPT_JSON");
+  assert.equal(await pathExists(directory), true);
+  assert.equal(await pathExists(ownerPath), true);
+});
+
+test("doctor repairs stale watcher ownership and never removes a replacement", async t => {
+  const { context } = await fixtureFor(t);
+  const active = path.join(context.paths.locks, "watcher-models.json");
+  const ownerA = watcherOwner(context);
+  await writeFile(active, `${JSON.stringify(ownerA)}\n`);
+  const repaired = await runDoctor(context, { repair: true });
+  const audit = path.join(context.paths.quarantine,
+    `watcher-owner-stale-${ownerA.token}.json`);
+  assert.equal(repaired.repairs.some(item => item.action === "repair_stale_watcher_owner"), true);
+  assert.equal(await pathExists(active), false);
+  assert.deepEqual(JSON.parse(await readFile(audit, "utf8")), ownerA);
+
+  await writeFile(active, `${JSON.stringify(ownerA)}\n`);
+  const ownerB = watcherOwner(context, { pid: 4242,
+    token: "22222222-2222-4222-8222-222222222222",
+    acquired_at: context.now().toISOString() });
+  let raced = false;
+  const racingContext = { ...context, linkWatcherOwner: async () => {
+    if (!raced) {
+      raced = true;
+      await unlink(active);
+      await writeFile(active, `${JSON.stringify(ownerB)}\n`);
+    }
+    const error = new Error("exists");
+    error.code = "EEXIST";
+    throw error;
+  } };
+  const raceReport = await runDoctor(racingContext, { repair: true });
+  assert.equal(raceReport.repairs.some(item => item.action === "repair_stale_watcher_owner"), false);
+  assert.deepEqual(JSON.parse(await readFile(active, "utf8")), ownerB);
+});

--- a/prototype/integrated/tools/agents/comms.mjs
+++ b/prototype/integrated/tools/agents/comms.mjs
@@ -79,8 +79,9 @@ async function attachments(context, options) {
 }
 
 async function openAgentIds(context) {
-  const records = await Promise.all((await listJsonFiles(context.paths.registry)).map(file =>
-    readJsonStrict(file, validateRegistry)));
+  const records = await Promise.all((await listJsonFiles(context.paths.registry,
+    { root: context.paths.root })).map(file =>
+    readJsonStrict(file, validateRegistry, context.paths.root)));
   return records.filter(record => record.status === "open").map(record => record.agent_id).sort();
 }
 

--- a/prototype/integrated/tools/agents/comms.mjs
+++ b/prototype/integrated/tools/agents/comms.mjs
@@ -2,7 +2,7 @@
 import { randomUUID } from "node:crypto";
 import { execFile } from "node:child_process";
 import { watch as fsWatch } from "node:fs";
-import { access, readFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 
@@ -11,15 +11,15 @@ import { claimScope, extendClaims, forceReleaseStaleScope, releaseOwnedClaims, r
   from "./lib/claims.mjs";
 import { CommsError, EXIT } from "./lib/errors.mjs";
 import { createHandoff } from "./lib/handoff.mjs";
-import { closeAgent, initBus, registerAgent } from "./lib/identity.mjs";
+import { closeAgent, initBus, registerAgent, requireCheckoutProtocol } from "./lib/identity.mjs";
 import { renderPrompt } from "./lib/prompt.mjs";
 import { ackMessage, broadcastMessage, listInbox, markSeen, replyToMessage, sendMessage }
   from "./lib/messages.mjs";
 import { createBusPaths, resolveBusDir } from "./lib/paths.mjs";
-import { startWatcher, waitForMessage } from "./lib/presence.mjs";
-import { parseArgs } from "./lib/args.mjs";
+import { presenceState, startWatcher, waitForMessage } from "./lib/presence.mjs";
+import { errorPayload, parseArgs } from "./lib/args.mjs";
 import { listJsonFiles, readJsonStrict } from "./lib/atomic-json.mjs";
-import { validateRegistry } from "./lib/schema.mjs";
+import { validatePresence, validateRegistry } from "./lib/schema.mjs";
 import { withSignalStop } from "./lib/signal-stop.mjs";
 import { collectStatus, enforcementExit, runDoctor } from "./lib/status.mjs";
 
@@ -78,19 +78,19 @@ async function attachments(context, options) {
   return Promise.all([...regular, ...ephemeral].map(item => describeAttachment(context, item)));
 }
 
-async function openAgentIds(context) {
+async function activeAgentIds(context) {
   const records = await Promise.all((await listJsonFiles(context.paths.registry,
     { root: context.paths.root })).map(file =>
     readJsonStrict(file, validateRegistry, context.paths.root)));
-  return records.filter(record => record.status === "open").map(record => record.agent_id).sort();
-}
-
-async function requireInitialized(context) {
-  try { await access(context.paths.protocol); }
-  catch (error) {
-    if (error.code === "ENOENT") throw new CommsError("agent bus protocol is not initialized; run init", EXIT.DATA);
-    throw error;
-  }
+  const active = await Promise.all(records.filter(record => record.status === "open").map(async record => {
+    try {
+      const presence = await readJsonStrict(context.paths.presenceFile(record.agent_id),
+        validatePresence, context.paths.root);
+      return presenceState(presence, context.now(), context.pidIsAlive) === "online"
+        ? record.agent_id : null;
+    } catch (error) { if (error.code === "ENOENT") return null; throw error; }
+  }));
+  return active.filter(agentId => agentId !== null).sort();
 }
 
 async function emit(context, value, json, human) {
@@ -117,7 +117,6 @@ async function runPrompt(context, options) {
 }
 
 async function runRegister(context, options) {
-  await requireInitialized(context);
   const value = await registerAgent(context, { agentId: options.id, role: options.role, task: options.task,
     ownership: options.ownership ?? [], client: options.client, resume: options.resume === true,
     worktree: context.cwd });
@@ -126,7 +125,6 @@ async function runRegister(context, options) {
 }
 
 async function runClose(context, options) {
-  await requireInitialized(context);
   const value = await closeAgent(context, options.id);
   await emit(context, value, options.json, `closed ${value.agent_id}`);
   return EXIT.OK;
@@ -141,7 +139,6 @@ async function messageInput(context, options, extra = {}) {
 }
 
 async function runSend(context, options) {
-  await requireInitialized(context);
   const input = await messageInput(context, options);
   input.attachments = await attachments(context, options);
   const value = await sendMessage(context, input);
@@ -150,7 +147,6 @@ async function runSend(context, options) {
 }
 
 async function runBroadcast(context, options) {
-  await requireInitialized(context);
   const input = await messageInput(context, options);
   input.attachments = await attachments(context, options);
   const value = await broadcastMessage(context, input);
@@ -159,7 +155,6 @@ async function runBroadcast(context, options) {
 }
 
 async function runInbox(context, options) {
-  await requireInitialized(context);
   const value = await listInbox(context, { agentId: options.id, types: options.type, severities: options.severity });
   await emit(context, value, options.json, value.map(item => `${item.state}: ${item.message.subject}`).join("\n") || "inbox empty");
   for (const item of value) await markSeen(context, item.message, options.id);
@@ -167,14 +162,12 @@ async function runInbox(context, options) {
 }
 
 async function runAck(context, options) {
-  await requireInitialized(context);
   const value = await ackMessage(context, { agentId: options.id, messageId: options.message });
   await emit(context, value, options.json, `acknowledged ${value.message_id}`);
   return EXIT.OK;
 }
 
 async function runReply(context, options) {
-  await requireInitialized(context);
   const input = await messageInput(context, options, { messageId: options.message });
   input.attachments = await attachments(context, options);
   const value = await replyToMessage(context, input);
@@ -183,7 +176,6 @@ async function runReply(context, options) {
 }
 
 async function runWatch(context, options) {
-  await requireInitialized(context);
   const watcher = await startWatcher(context, { agentId: options.id, heartbeatMs: options.heartbeat && seconds(options.heartbeat, "heartbeat"),
     scanIntervalMs: options.scanInterval && seconds(options.scanInterval, "scan interval") });
   await context.beforeWatcherPublish?.(watcher);
@@ -193,18 +185,20 @@ async function runWatch(context, options) {
 }
 
 async function runWait(context, options) {
-  await requireInitialized(context);
   const value = await waitForMessage(context, { agentId: options.id,
     timeoutMs: options.timeout === undefined ? undefined : seconds(options.timeout, "timeout"),
     scanIntervalMs: options.scanInterval && seconds(options.scanInterval, "scan interval") });
-  if (value === null) return EXIT.TIMEOUT;
+  if (value === null) {
+    if (options.json) await emit(context,
+      errorPayload(new CommsError("wait timed out", EXIT.TIMEOUT), EXIT.TIMEOUT), true, "");
+    return EXIT.TIMEOUT;
+  }
   await emit(context, value, options.json, `message: ${value.subject}`);
   await markSeen(context, value, options.id);
   return EXIT.OK;
 }
 
 async function runClaim(context, options) {
-  await requireInitialized(context);
   const value = await claimScope(context, { agentId: options.id, scope: options.scope, reason: options.reason,
     leaseSeconds: options.lease === undefined ? undefined : Number(options.lease) });
   await emit(context, value, options.json, `claimed ${value.scope}`);
@@ -212,7 +206,6 @@ async function runClaim(context, options) {
 }
 
 async function runRelease(context, options) {
-  await requireInitialized(context);
   const value = options.forceStale ? await forceReleaseStaleScope(context, { agentId: options.id,
     owner: options.owner, scope: options.scope }) : await releaseScope(context, { agentId: options.id, scope: options.scope });
   await emit(context, value, options.json, `released ${value.scope}`);
@@ -220,14 +213,16 @@ async function runRelease(context, options) {
 }
 
 async function runHandoff(context, options) {
-  await requireInitialized(context);
   const [verification, contracts, limitations] = await Promise.all([
     jsonFile(context.cwd, options.verificationFile, "verification file"),
     jsonFile(context.cwd, options.contractsFile, "contracts file"),
     jsonFile(context.cwd, options.limitationsFile, "limitations file"),
   ]);
-  const artifacts = await Promise.all((options.artifact ?? []).map(file => describeAttachment(context, {
-    path: file, ephemeral: false, ...(options.commit === undefined ? {} : { commit: options.commit }) })));
+  const artifacts = await Promise.all([
+    ...(options.artifact ?? []).map(path => ({ path, ephemeral: false,
+      ...(options.commit === undefined ? {} : { commit: options.commit }) })),
+    ...(options.ephemeralArtifact ?? []).map(path => ({ path, ephemeral: true })),
+  ].map(input => describeAttachment(context, input)));
   const value = await createHandoff(context, { from: options.id, to: options.to, task: options.task,
     result: options.result, branch: options.branch, commit: options.commit ?? null, base: options.base,
     changedPaths: options.changed ?? [], verification, contracts, followUp: options.followUp ?? [], artifacts, limitations,
@@ -237,19 +232,18 @@ async function runHandoff(context, options) {
 }
 
 async function runStatus(context, options) {
-  await requireInitialized(context);
   const value = await collectStatus(context);
   await emit(context, value, options.json, `agents: ${value.counts.live_agents} live; pending: ${value.counts.required_unacked}`);
   return enforcementExit(value, options);
 }
 
 async function runDoctorCommand(context, options) {
-  await requireInitialized(context);
   const value = await runDoctor(context, { repair: options.repair === true,
     requireLive: (options.requireLive ?? []).flatMap(value => value.split(",")).filter(Boolean) });
   await emit(context, value, options.json, value.ok ? "doctor: healthy" : `doctor: ${value.issues.length} issue(s)`);
   if (value.ok) return EXIT.OK;
-  if (value.issues.some(item => item.code.includes("CORRUPT") || item.code === "PROTOCOL_MISSING")) return EXIT.DATA;
+  if (value.issues.some(item => item.code.includes("CORRUPT") || item.code === "PROTOCOL_MISSING"
+    || item.code === "UNKNOWN_SCHEMA_VERSION" || item.code === "UNKNOWN_PROTOCOL_VERSION")) return EXIT.DATA;
   if (value.issues.some(item => item.code.startsWith("REQUIRED_") || item.code === "ACKED_MESSAGE_NOT_ARCHIVED")) return EXIT.REQUIRED;
   return EXIT.CONFLICT;
 }
@@ -270,11 +264,15 @@ export async function main(argv, runtime = {}) {
     pid: runtime.pid ?? process.pid, pidIsAlive: runtime.pidIsAlive ?? defaultPidIsAlive,
     randomUUID: runtime.uuid ?? randomUUID, scheduler: runtime.scheduler, watchDirectory: runtime.watchDirectory ?? fallbackWatch,
     setActiveWatcher: runtime.setActiveWatcher, beforeWatcherPublish: runtime.beforeWatcherPublish,
+    gitCommonDir: () => runGit(cwd, ["rev-parse", "--path-format=absolute", "--git-common-dir"]),
     gitState: async directory => ({ branch: (await runGit(directory, ["branch", "--show-current"])).trim(),
       head: (await runGit(directory, ["rev-parse", "HEAD"])).trim() }),
     releaseOwnedClaims: agentId => releaseOwnedClaims(context, agentId),
-    extendOwnedClaims: agentId => extendClaims(context, agentId), listActiveAgentIds: () => openAgentIds(context),
+    extendOwnedClaims: agentId => extendClaims(context, agentId), listActiveAgentIds: () => activeAgentIds(context),
     output: async event => { await write(context.stdout, `${JSON.stringify(event)}\n`); await write(context.stderr, "\u0007"); } };
+  if (!["init", "prompt"].includes(parsed.command)) await requireCheckoutProtocol(context,
+    { allowInvalid: parsed.command === "doctor",
+      repair: parsed.command === "doctor" && parsed.options.repair === true });
   return COMMANDS[parsed.command](context, parsed.options);
 }
 
@@ -283,10 +281,13 @@ export function runWithSignals(argv, runtime = {}, signals = process) {
 }
 
 async function invoke() {
-  try { process.exitCode = await runWithSignals(process.argv.slice(2)); }
+  const argv = process.argv.slice(2);
+  try { process.exitCode = await runWithSignals(argv); }
   catch (error) {
     process.exitCode = error instanceof CommsError ? error.exitCode : 1;
-    await write(process.stderr, `${error instanceof CommsError ? error.message : error.stack}\n`);
+    if (argv.includes("--json")) await write(process.stdout,
+      `${JSON.stringify(errorPayload(error, process.exitCode))}\n`);
+    else await write(process.stderr, `${error instanceof CommsError ? error.message : error.stack}\n`);
   }
 }
 

--- a/prototype/integrated/tools/agents/comms.mjs
+++ b/prototype/integrated/tools/agents/comms.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+import { randomUUID } from "node:crypto";
+import { execFile } from "node:child_process";
+import { watch as fsWatch } from "node:fs";
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { describeAttachment } from "./lib/attachments.mjs";
+import { claimScope, extendClaims, forceReleaseStaleScope, releaseOwnedClaims, releaseScope }
+  from "./lib/claims.mjs";
+import { CommsError, EXIT } from "./lib/errors.mjs";
+import { createHandoff } from "./lib/handoff.mjs";
+import { closeAgent, initBus, registerAgent } from "./lib/identity.mjs";
+import { renderPrompt } from "./lib/prompt.mjs";
+import { ackMessage, broadcastMessage, listInbox, markSeen, replyToMessage, sendMessage }
+  from "./lib/messages.mjs";
+import { createBusPaths, resolveBusDir } from "./lib/paths.mjs";
+import { startWatcher, waitForMessage } from "./lib/presence.mjs";
+import { parseArgs } from "./lib/args.mjs";
+import { listJsonFiles, readJsonStrict } from "./lib/atomic-json.mjs";
+import { validateRegistry } from "./lib/schema.mjs";
+import { withSignalStop } from "./lib/signal-stop.mjs";
+import { collectStatus, enforcementExit, runDoctor } from "./lib/status.mjs";
+
+const execFileAsync = promisify(execFile);
+
+function defaultPidIsAlive(pid) {
+  try { process.kill(pid, 0); return true; }
+  catch (error) { return error.code !== "ESRCH"; }
+}
+
+function fallbackWatch(directory, listener) {
+  try {
+    const watcher = fsWatch(directory, listener);
+    watcher.on("error", () => {});
+    return { close: () => watcher.close(), once: (event, handler) => {
+      if (event !== "error") watcher.once(event, handler);
+    } };
+  }
+  catch (error) {
+    if (!["EMFILE", "ENOSPC"].includes(error.code)) throw error;
+    return { close() {}, once() {} };
+  }
+}
+
+async function defaultGitQuery(cwd, args) {
+  return (await execFileAsync("git", args, { cwd })).stdout;
+}
+
+async function write(stream, text) {
+  await new Promise((resolve, reject) => stream.write(text, error => error ? reject(error) : resolve()));
+}
+
+async function readStdin(stdin) {
+  if (typeof stdin === "string") return stdin;
+  let result = "";
+  for await (const chunk of stdin) result += chunk;
+  return result;
+}
+
+function seconds(value, name) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number < 0) {
+    throw new CommsError(`${name} must be a non-negative number of seconds`, EXIT.DATA);
+  }
+  return Math.round(number * 1_000);
+}
+
+async function jsonFile(cwd, filePath, name) {
+  try { return JSON.parse(await readFile(path.resolve(cwd, filePath), "utf8")); }
+  catch (error) { throw new CommsError(`cannot read ${name}`, EXIT.DATA, { cause: error.message }); }
+}
+
+async function attachments(context, options) {
+  const regular = (options.attachment ?? []).map(file => ({ path: file, ephemeral: false }));
+  const ephemeral = (options.ephemeralAttachment ?? []).map(file => ({ path: file, ephemeral: true }));
+  return Promise.all([...regular, ...ephemeral].map(item => describeAttachment(context, item)));
+}
+
+async function openAgentIds(context) {
+  const records = await Promise.all((await listJsonFiles(context.paths.registry)).map(file =>
+    readJsonStrict(file, validateRegistry)));
+  return records.filter(record => record.status === "open").map(record => record.agent_id).sort();
+}
+
+async function requireInitialized(context) {
+  try { await access(context.paths.protocol); }
+  catch (error) {
+    if (error.code === "ENOENT") throw new CommsError("agent bus protocol is not initialized; run init", EXIT.DATA);
+    throw error;
+  }
+}
+
+async function emit(context, value, json, human) {
+  await write(context.stdout, json ? `${JSON.stringify(value)}\n` : `${human}\n`);
+}
+
+async function runInit(context, options) {
+  const value = await initBus(context);
+  await emit(context, value, options.json, "agent bus initialized");
+  return EXIT.OK;
+}
+
+async function runPrompt(context, options) {
+  const ownership = options.ownership?.join(" --ownership ") ?? "";
+  const value = await renderPrompt({
+    templatePath: path.join(context.repoRoot, "docs/AGENT_COMMS_PROMPT.md"),
+    agentId: options.id,
+    role: options.role,
+    task: options.task,
+    ownership,
+  });
+  await write(context.stdout, value);
+  return EXIT.OK;
+}
+
+async function runRegister(context, options) {
+  await requireInitialized(context);
+  const value = await registerAgent(context, { agentId: options.id, role: options.role, task: options.task,
+    ownership: options.ownership ?? [], client: options.client, resume: options.resume === true,
+    worktree: context.cwd });
+  await emit(context, value, options.json, `registered ${value.agent_id}`);
+  return EXIT.OK;
+}
+
+async function runClose(context, options) {
+  await requireInitialized(context);
+  const value = await closeAgent(context, options.id);
+  await emit(context, value, options.json, `closed ${value.agent_id}`);
+  return EXIT.OK;
+}
+
+async function messageInput(context, options, extra = {}) {
+  const input = { ...extra, from: options.from, to: options.to, type: options.type, severity: options.severity,
+    subject: options.subject, body: options.body, bodyFile: options.bodyFile && path.resolve(context.cwd, options.bodyFile),
+    task: options.task, requiresAck: options.requiresAck === true };
+  if (options.body === undefined && options.bodyFile === undefined) input.stdin = await readStdin(context.stdin);
+  return input;
+}
+
+async function runSend(context, options) {
+  await requireInitialized(context);
+  const input = await messageInput(context, options);
+  input.attachments = await attachments(context, options);
+  const value = await sendMessage(context, input);
+  await emit(context, value, options.json, `sent ${value.id}`);
+  return EXIT.OK;
+}
+
+async function runBroadcast(context, options) {
+  await requireInitialized(context);
+  const input = await messageInput(context, options);
+  input.attachments = await attachments(context, options);
+  const value = await broadcastMessage(context, input);
+  await emit(context, value, options.json, `broadcast to ${value.length} agents`);
+  return EXIT.OK;
+}
+
+async function runInbox(context, options) {
+  await requireInitialized(context);
+  const value = await listInbox(context, { agentId: options.id, types: options.type, severities: options.severity });
+  await emit(context, value, options.json, value.map(item => `${item.state}: ${item.message.subject}`).join("\n") || "inbox empty");
+  for (const item of value) await markSeen(context, item.message, options.id);
+  return EXIT.OK;
+}
+
+async function runAck(context, options) {
+  await requireInitialized(context);
+  const value = await ackMessage(context, { agentId: options.id, messageId: options.message });
+  await emit(context, value, options.json, `acknowledged ${value.message_id}`);
+  return EXIT.OK;
+}
+
+async function runReply(context, options) {
+  await requireInitialized(context);
+  const input = await messageInput(context, options, { messageId: options.message });
+  input.attachments = await attachments(context, options);
+  const value = await replyToMessage(context, input);
+  await emit(context, value, options.json, `replied ${value.id}`);
+  return EXIT.OK;
+}
+
+async function runWatch(context, options) {
+  await requireInitialized(context);
+  const watcher = await startWatcher(context, { agentId: options.id, heartbeatMs: options.heartbeat && seconds(options.heartbeat, "heartbeat"),
+    scanIntervalMs: options.scanInterval && seconds(options.scanInterval, "scan interval") });
+  await context.beforeWatcherPublish?.(watcher);
+  context.setActiveWatcher?.(watcher);
+  try { await watcher.done; return EXIT.OK; }
+  finally { context.setActiveWatcher?.(null); }
+}
+
+async function runWait(context, options) {
+  await requireInitialized(context);
+  const value = await waitForMessage(context, { agentId: options.id,
+    timeoutMs: options.timeout === undefined ? undefined : seconds(options.timeout, "timeout"),
+    scanIntervalMs: options.scanInterval && seconds(options.scanInterval, "scan interval") });
+  if (value === null) return EXIT.TIMEOUT;
+  await emit(context, value, options.json, `message: ${value.subject}`);
+  await markSeen(context, value, options.id);
+  return EXIT.OK;
+}
+
+async function runClaim(context, options) {
+  await requireInitialized(context);
+  const value = await claimScope(context, { agentId: options.id, scope: options.scope, reason: options.reason,
+    leaseSeconds: options.lease === undefined ? undefined : Number(options.lease) });
+  await emit(context, value, options.json, `claimed ${value.scope}`);
+  return EXIT.OK;
+}
+
+async function runRelease(context, options) {
+  await requireInitialized(context);
+  const value = options.forceStale ? await forceReleaseStaleScope(context, { agentId: options.id,
+    owner: options.owner, scope: options.scope }) : await releaseScope(context, { agentId: options.id, scope: options.scope });
+  await emit(context, value, options.json, `released ${value.scope}`);
+  return EXIT.OK;
+}
+
+async function runHandoff(context, options) {
+  await requireInitialized(context);
+  const [verification, contracts, limitations] = await Promise.all([
+    jsonFile(context.cwd, options.verificationFile, "verification file"),
+    jsonFile(context.cwd, options.contractsFile, "contracts file"),
+    jsonFile(context.cwd, options.limitationsFile, "limitations file"),
+  ]);
+  const artifacts = await Promise.all((options.artifact ?? []).map(file => describeAttachment(context, {
+    path: file, ephemeral: false, ...(options.commit === undefined ? {} : { commit: options.commit }) })));
+  const value = await createHandoff(context, { from: options.id, to: options.to, task: options.task,
+    result: options.result, branch: options.branch, commit: options.commit ?? null, base: options.base,
+    changedPaths: options.changed ?? [], verification, contracts, followUp: options.followUp ?? [], artifacts, limitations,
+    uncommitted: options.uncommitted === true });
+  await emit(context, value, options.json, `handoff ${value.record.id}`);
+  return EXIT.OK;
+}
+
+async function runStatus(context, options) {
+  await requireInitialized(context);
+  const value = await collectStatus(context);
+  await emit(context, value, options.json, `agents: ${value.counts.live_agents} live; pending: ${value.counts.required_unacked}`);
+  return enforcementExit(value, options);
+}
+
+async function runDoctorCommand(context, options) {
+  await requireInitialized(context);
+  const value = await runDoctor(context, { repair: options.repair === true,
+    requireLive: (options.requireLive ?? []).flatMap(value => value.split(",")).filter(Boolean) });
+  await emit(context, value, options.json, value.ok ? "doctor: healthy" : `doctor: ${value.issues.length} issue(s)`);
+  if (value.ok) return EXIT.OK;
+  if (value.issues.some(item => item.code.includes("CORRUPT") || item.code === "PROTOCOL_MISSING")) return EXIT.DATA;
+  if (value.issues.some(item => item.code.startsWith("REQUIRED_") || item.code === "ACKED_MESSAGE_NOT_ARCHIVED")) return EXIT.REQUIRED;
+  return EXIT.CONFLICT;
+}
+
+const COMMANDS = Object.freeze({ init: runInit, prompt: runPrompt, register: runRegister, close: runClose, send: runSend,
+  broadcast: runBroadcast, inbox: runInbox, ack: runAck, reply: runReply, watch: runWatch,
+  wait: runWait, claim: runClaim, release: runRelease, handoff: runHandoff, status: runStatus,
+  doctor: runDoctorCommand });
+
+export async function main(argv, runtime = {}) {
+  const parsed = parseArgs(argv);
+  const cwd = runtime.cwd ?? process.cwd();
+  const runGit = runtime.gitQuery ?? defaultGitQuery;
+  const busDir = await resolveBusDir({ cwd, env: runtime.env ?? process.env,
+    runGit: directory => runGit(directory, ["rev-parse", "--path-format=absolute", "--git-common-dir"]) });
+  const context = { cwd, paths: createBusPaths(busDir), repoRoot: cwd, stdout: runtime.stdout ?? process.stdout,
+    stderr: runtime.stderr ?? process.stderr, stdin: runtime.stdin ?? process.stdin, now: runtime.time ?? (() => new Date()),
+    pid: runtime.pid ?? process.pid, pidIsAlive: runtime.pidIsAlive ?? defaultPidIsAlive,
+    randomUUID: runtime.uuid ?? randomUUID, scheduler: runtime.scheduler, watchDirectory: runtime.watchDirectory ?? fallbackWatch,
+    setActiveWatcher: runtime.setActiveWatcher, beforeWatcherPublish: runtime.beforeWatcherPublish,
+    gitState: async directory => ({ branch: (await runGit(directory, ["branch", "--show-current"])).trim(),
+      head: (await runGit(directory, ["rev-parse", "HEAD"])).trim() }),
+    releaseOwnedClaims: agentId => releaseOwnedClaims(context, agentId),
+    extendOwnedClaims: agentId => extendClaims(context, agentId), listActiveAgentIds: () => openAgentIds(context),
+    output: async event => { await write(context.stdout, `${JSON.stringify(event)}\n`); await write(context.stderr, "\u0007"); } };
+  return COMMANDS[parsed.command](context, parsed.options);
+}
+
+export function runWithSignals(argv, runtime = {}, signals = process) {
+  return withSignalStop(setActiveWatcher => main(argv, { ...runtime, setActiveWatcher }), signals);
+}
+
+async function invoke() {
+  try { process.exitCode = await runWithSignals(process.argv.slice(2)); }
+  catch (error) {
+    process.exitCode = error instanceof CommsError ? error.exitCode : 1;
+    await write(process.stderr, `${error instanceof CommsError ? error.message : error.stack}\n`);
+  }
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) void invoke();

--- a/prototype/integrated/tools/agents/lib/args.mjs
+++ b/prototype/integrated/tools/agents/lib/args.mjs
@@ -1,0 +1,99 @@
+import { CommsError, EXIT } from "./errors.mjs";
+
+const COMMANDS = Object.freeze({
+  init: { optional: ["json"] },
+  prompt: { required: ["id", "role", "task"], repeated: ["ownership"] },
+  register: { required: ["id", "role", "task"], repeated: ["ownership"], flags: ["resume"],
+    optional: ["client", "json"] },
+  close: { required: ["id"], optional: ["json"] },
+  send: messageSpec(["from", "to"]),
+  broadcast: { required: ["from", "severity", "subject"], optional: ["body", "body-file", "json"],
+    repeated: ["attachment", "ephemeral-attachment"], flags: ["requires-ack"] },
+  inbox: { required: ["id"], repeated: ["type", "severity"], optional: ["json"] },
+  ack: { required: ["id", "message"], optional: ["json"] },
+  reply: messageSpec(["from", "message"]),
+  watch: { required: ["id"], optional: ["heartbeat", "scan-interval"] },
+  wait: { required: ["id"], optional: ["timeout", "scan-interval", "json"] },
+  claim: { required: ["id", "scope", "reason"], optional: ["lease", "json"] },
+  release: { required: ["id", "scope"], flags: ["force-stale"], optional: ["owner", "json"] },
+  handoff: { required: ["id", "to", "task", "result", "branch", "base", "verification-file",
+    "contracts-file", "limitations-file"], optional: ["commit", "json"], flags: ["uncommitted"],
+  repeated: ["changed", "follow-up", "artifact"] },
+  status: { flags: ["fail-on-stale", "fail-on-pending"], optional: ["json"] },
+  doctor: { repeated: ["require-live"], flags: ["repair"], optional: ["json"] },
+});
+
+function messageSpec(required) {
+  return { required: [...required, "type", "severity", "subject"], optional: ["body", "body-file", "json"],
+    repeated: ["attachment", "ephemeral-attachment"], flags: ["requires-ack"] };
+}
+
+function usage(message) { throw new CommsError(message, EXIT.USAGE); }
+function keyFor(option) {
+  return option.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+}
+
+function allNames(spec) {
+  return new Set([...(spec.required ?? []), ...(spec.optional ?? []), ...(spec.repeated ?? []),
+    ...(spec.flags ?? [])]);
+}
+
+function addOption(options, spec, name, value) {
+  const key = keyFor(name);
+  if ((spec.repeated ?? []).includes(name)) {
+    (options[key] ??= []).push(value);
+    return;
+  }
+  if (Object.hasOwn(options, key)) usage(`option --${name} may be used only once`);
+  options[key] = value;
+}
+
+function validate(spec, command, options) {
+  for (const name of spec.required ?? []) {
+    if (!Object.hasOwn(options, keyFor(name))) usage(`${command} requires --${name}`);
+  }
+  if (["send", "reply", "broadcast"].includes(command)) {
+    const sources = ["body", "bodyFile"].filter(key => Object.hasOwn(options, key));
+    if (sources.length > 1) usage(`${command} accepts exactly one of --body, --body-file, or stdin`);
+  }
+  if (command === "prompt" && (!Array.isArray(options.ownership) || options.ownership.length === 0
+    || options.ownership.some(value => value.trim().length === 0))) {
+    usage("prompt requires every --ownership to contain non-whitespace content");
+  }
+  if (command === "release" && options.forceStale && !Object.hasOwn(options, "owner")) {
+    usage("release --force-stale requires --owner");
+  }
+  if (command === "handoff" && !options.uncommitted && !Object.hasOwn(options, "commit")) {
+    usage("handoff requires --commit unless --uncommitted is set");
+  }
+  if (command === "handoff" && options.uncommitted && Object.hasOwn(options, "commit")) {
+    usage("handoff --uncommitted cannot include --commit");
+  }
+}
+
+export function parseArgs(argv) {
+  if (!Array.isArray(argv) || argv.length === 0) usage("a command is required");
+  const [command, ...tokens] = argv;
+  const spec = COMMANDS[command];
+  if (spec === undefined) usage(`unknown command: ${command}`);
+  const known = allNames(spec);
+  const options = {};
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (!token.startsWith("--") || token.length === 2) usage(`unexpected argument: ${token}`);
+    const name = token.slice(2);
+    if (!known.has(name)) usage(`unknown option for ${command}: --${name}`);
+    if ((spec.flags ?? []).includes(name) || name === "json") {
+      const key = keyFor(name);
+      if (Object.hasOwn(options, key)) usage(`option --${name} may be used only once`);
+      options[key] = true;
+      continue;
+    }
+    const value = tokens[index + 1];
+    if (value === undefined || value.startsWith("--")) usage(`option --${name} requires a value`);
+    addOption(options, spec, name, value);
+    index += 1;
+  }
+  validate(spec, command, options);
+  return { command, options };
+}

--- a/prototype/integrated/tools/agents/lib/args.mjs
+++ b/prototype/integrated/tools/agents/lib/args.mjs
@@ -18,7 +18,7 @@ const COMMANDS = Object.freeze({
   release: { required: ["id", "scope"], flags: ["force-stale"], optional: ["owner", "json"] },
   handoff: { required: ["id", "to", "task", "result", "branch", "base", "verification-file",
     "contracts-file", "limitations-file"], optional: ["commit", "json"], flags: ["uncommitted"],
-  repeated: ["changed", "follow-up", "artifact"] },
+  repeated: ["changed", "follow-up", "artifact", "ephemeral-artifact"] },
   status: { flags: ["fail-on-stale", "fail-on-pending"], optional: ["json"] },
   doctor: { repeated: ["require-live"], flags: ["repair"], optional: ["json"] },
 });
@@ -29,6 +29,9 @@ function messageSpec(required) {
 }
 
 function usage(message) { throw new CommsError(message, EXIT.USAGE); }
+export function errorPayload(error, exitCode) { return { error: {
+  message: error instanceof CommsError ? error.message : error.stack, exit_code: exitCode,
+  details: error instanceof CommsError ? error.details : null } }; }
 function keyFor(option) {
   return option.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
 }

--- a/prototype/integrated/tools/agents/lib/atomic-json.mjs
+++ b/prototype/integrated/tools/agents/lib/atomic-json.mjs
@@ -1,0 +1,128 @@
+import { randomUUID } from "node:crypto";
+import {
+  link,
+  mkdir,
+  open,
+  readFile,
+  readdir,
+  rename,
+  unlink,
+} from "node:fs/promises";
+import path from "node:path";
+
+import { CommsError, EXIT } from "./errors.mjs";
+
+async function syncDirectory(directory) {
+  const handle = await open(directory, "r");
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function unlinkIfPresent(filePath) {
+  try {
+    await unlink(filePath);
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+}
+
+export async function readJsonStrict(filePath, validate) {
+  const source = await readFile(filePath, "utf8");
+  let value;
+  try {
+    value = JSON.parse(source);
+  } catch (error) {
+    throw new CommsError("invalid JSON record", EXIT.DATA, {
+      filePath,
+      cause: error.message,
+    });
+  }
+
+  try {
+    return validate(value);
+  } catch (error) {
+    if (error instanceof CommsError) throw error;
+    throw new CommsError("invalid JSON record", EXIT.DATA, {
+      filePath,
+      cause: error.message,
+    });
+  }
+}
+
+export async function writeJsonAtomic(
+  filePath,
+  value,
+  { tmpDir, exclusive = false },
+) {
+  const serialized = JSON.stringify(value, null, 2);
+  if (serialized === undefined) {
+    throw new CommsError("record is not JSON serializable", EXIT.DATA, { filePath });
+  }
+  const buffer = Buffer.from(`${serialized}\n`, "utf8");
+  const destinationDir = path.dirname(filePath);
+  await Promise.all([
+    mkdir(tmpDir, { recursive: true }),
+    mkdir(destinationDir, { recursive: true }),
+  ]);
+  const temporaryPath = path.join(
+    tmpDir,
+    `${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  const handle = await open(temporaryPath, "wx");
+  try {
+    await handle.writeFile(buffer);
+    await handle.sync();
+  } catch (error) {
+    await handle.close();
+    await unlinkIfPresent(temporaryPath);
+    throw error;
+  }
+  await handle.close();
+
+  try {
+    if (exclusive) {
+      try {
+        await link(temporaryPath, filePath);
+      } catch (error) {
+        if (error.code === "EEXIST") {
+          throw new CommsError("immutable record already exists", EXIT.CONFLICT, {
+            filePath,
+          });
+        }
+        throw error;
+      }
+      await unlink(temporaryPath);
+    } else {
+      await rename(temporaryPath, filePath);
+    }
+    await syncDirectory(destinationDir);
+  } catch (error) {
+    await unlinkIfPresent(temporaryPath);
+    throw error;
+  }
+}
+
+export async function listJsonFiles(dirPath) {
+  let entries;
+  try {
+    entries = await readdir(dirPath, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === "ENOENT") return [];
+    throw error;
+  }
+
+  return entries
+    .filter(entry => entry.isFile() && entry.name.endsWith(".json"))
+    .map(entry => path.join(dirPath, entry.name))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+export async function moveFileAtomic(source, destination) {
+  const destinationDir = path.dirname(destination);
+  await mkdir(destinationDir, { recursive: true });
+  await rename(source, destination);
+  await syncDirectory(destinationDir);
+}

--- a/prototype/integrated/tools/agents/lib/atomic-json.mjs
+++ b/prototype/integrated/tools/agents/lib/atomic-json.mjs
@@ -1,9 +1,7 @@
 import { randomUUID } from "node:crypto";
 import {
   link,
-  mkdir,
   open,
-  readFile,
   readdir,
   rename,
   unlink,
@@ -11,6 +9,8 @@ import {
 import path from "node:path";
 
 import { CommsError, EXIT } from "./errors.mjs";
+import { assertManagedDirectory, ensureManagedDirectory } from "./safe-directory.mjs";
+import { readJsonRegularNoFollow, readRegularNoFollow } from "./safe-file.mjs";
 
 async function syncDirectory(directory) {
   const handle = await open(directory, "r");
@@ -29,27 +29,8 @@ async function unlinkIfPresent(filePath) {
   }
 }
 
-export async function readJsonStrict(filePath, validate) {
-  const source = await readFile(filePath, "utf8");
-  let value;
-  try {
-    value = JSON.parse(source);
-  } catch (error) {
-    throw new CommsError("invalid JSON record", EXIT.DATA, {
-      filePath,
-      cause: error.message,
-    });
-  }
-
-  try {
-    return validate(value);
-  } catch (error) {
-    if (error instanceof CommsError) throw error;
-    throw new CommsError("invalid JSON record", EXIT.DATA, {
-      filePath,
-      cause: error.message,
-    });
-  }
+export async function readJsonStrict(filePath, validate, root, openFile) {
+  return (await readJsonRegularNoFollow(filePath, validate, root, openFile)).record;
 }
 
 export async function writeJsonAtomic(
@@ -63,9 +44,10 @@ export async function writeJsonAtomic(
   }
   const buffer = Buffer.from(`${serialized}\n`, "utf8");
   const destinationDir = path.dirname(filePath);
+  const root = path.dirname(path.resolve(tmpDir));
   await Promise.all([
-    mkdir(tmpDir, { recursive: true }),
-    mkdir(destinationDir, { recursive: true }),
+    ensureManagedDirectory(root, tmpDir),
+    ensureManagedDirectory(root, destinationDir),
   ]);
   const temporaryPath = path.join(
     tmpDir,
@@ -105,24 +87,107 @@ export async function writeJsonAtomic(
   }
 }
 
-export async function listJsonFiles(dirPath) {
-  let entries;
+function sameDirectory(left, right) {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+export async function listDirectoryEntries(
+  dirPath,
+  { root, readDirectory = readdir } = {},
+) {
+  let before;
   try {
-    entries = await readdir(dirPath, { withFileTypes: true });
+    before = await assertManagedDirectory(root, dirPath);
   } catch (error) {
     if (error.code === "ENOENT") return [];
     throw error;
   }
+  let entries;
+  try {
+    entries = await readDirectory(dirPath, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === "ENOENT") return [];
+    throw error;
+  }
+  const after = await assertManagedDirectory(root, dirPath);
+  if (!sameDirectory(before.stat, after.stat)) {
+    throw new CommsError("managed directory changed while listing", EXIT.DATA,
+      { dirPath, root });
+  }
+  return entries;
+}
 
-  return entries
+export async function listJsonFiles(dirPath, options) {
+  return (await listDirectoryEntries(dirPath, options))
     .filter(entry => entry.isFile() && entry.name.endsWith(".json"))
     .map(entry => path.join(dirPath, entry.name))
     .sort((left, right) => left.localeCompare(right));
 }
 
-export async function moveFileAtomic(source, destination) {
+export async function moveFileAtomic(source, destination, { root } = {}) {
+  if (typeof root !== "string" || !path.isAbsolute(root)) {
+    throw new CommsError("atomic move requires an absolute managed root", EXIT.DATA, { root });
+  }
+  const sourceDir = path.dirname(source);
   const destinationDir = path.dirname(destination);
-  await mkdir(destinationDir, { recursive: true });
+  await Promise.all([
+    ensureManagedDirectory(root, sourceDir),
+    ensureManagedDirectory(root, destinationDir),
+  ]);
   await rename(source, destination);
-  await syncDirectory(destinationDir);
+  await Promise.all([...new Set([sourceDir, destinationDir])].map(syncDirectory));
+}
+
+async function bytesIfPresent(filePath, root) {
+  try {
+    return await readRegularNoFollow(filePath, root);
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function requireEqualBytes(actual, expected, source, destination, name) {
+  if (actual === null || !actual.equals(expected)) {
+    throw new CommsError(`${name} conflicts with immutable message evidence`, EXIT.DATA, {
+      source,
+      destination,
+    });
+  }
+}
+
+export async function archiveFileNoReplace(
+  source,
+  destination,
+  { root, expectedBytes },
+) {
+  const expected = Buffer.from(expectedBytes);
+  const sourceDir = path.dirname(source);
+  const destinationDir = path.dirname(destination);
+  await Promise.all([
+    ensureManagedDirectory(root, sourceDir),
+    ensureManagedDirectory(root, destinationDir),
+  ]);
+
+  let linked = false;
+  try {
+    await link(source, destination);
+    linked = true;
+  } catch (error) {
+    if (error.code !== "EEXIST" && error.code !== "ENOENT") throw error;
+  }
+
+  requireEqualBytes(await bytesIfPresent(destination, root), expected,
+    source, destination, "archive destination");
+  const sourceBytes = await bytesIfPresent(source, root);
+  if (sourceBytes !== null) {
+    requireEqualBytes(sourceBytes, expected, source, destination, "inbox source");
+    try {
+      await unlink(source);
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+  }
+  await Promise.all([...new Set([sourceDir, destinationDir])].map(syncDirectory));
+  return { linked, sourceRemoved: sourceBytes !== null };
 }

--- a/prototype/integrated/tools/agents/lib/attachments.mjs
+++ b/prototype/integrated/tools/agents/lib/attachments.mjs
@@ -1,0 +1,109 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { realpath, stat } from "node:fs/promises";
+import path from "node:path";
+
+import { CommsError, EXIT } from "./errors.mjs";
+import { validateAttachment } from "./schema.mjs";
+
+const EMPTY_SHA256 = "0".repeat(64);
+const ARTIFACT_PREFIX = ".agents/artifacts/";
+
+function isWithin(candidate, root) {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".."
+    && !path.isAbsolute(relative));
+}
+
+function assertWithin(candidate, root, displayPath) {
+  if (isWithin(candidate, root)) return;
+  throw new CommsError("attachment resolves outside its allowed root", EXIT.DATA, {
+    path: displayPath,
+  });
+}
+
+function validateInput(input) {
+  return validateAttachment({
+    path: input.path,
+    sha256: EMPTY_SHA256,
+    size: 0,
+    ephemeral: input.ephemeral,
+    ...(input.commit === undefined ? {} : { commit: input.commit }),
+  });
+}
+
+function sourcePath(context, record) {
+  if (record.ephemeral) {
+    const suffix = record.path.slice(ARTIFACT_PREFIX.length);
+    return path.join(context.paths.artifacts, suffix);
+  }
+  return path.join(context.repoRoot ?? path.dirname(context.paths.root), record.path);
+}
+
+async function digestFile(filePath) {
+  const hash = createHash("sha256");
+  await new Promise((resolve, reject) => {
+    const stream = createReadStream(filePath);
+    stream.on("data", chunk => hash.update(chunk));
+    stream.once("error", reject);
+    stream.once("end", resolve);
+  });
+  return hash.digest("hex");
+}
+
+async function inspectAttachment(context, input) {
+  const validated = validateInput(input);
+  const allowedRoot = validated.ephemeral
+    ? context.paths.artifacts
+    : context.repoRoot ?? path.dirname(context.paths.root);
+  try {
+    const [canonicalRoot, canonicalFile, canonicalArtifacts] = await Promise.all([
+      realpath(allowedRoot),
+      realpath(sourcePath(context, validated)),
+      realpath(context.paths.artifacts),
+    ]);
+    assertWithin(canonicalFile, canonicalRoot, validated.path);
+    if (!validated.ephemeral && isWithin(canonicalFile, canonicalArtifacts)) {
+      throw new CommsError("artifact attachment must be ephemeral", EXIT.DATA, {
+        path: validated.path,
+      });
+    }
+    const metadata = await stat(canonicalFile);
+    if (!metadata.isFile()) {
+      throw new CommsError("attachment must be a regular file", EXIT.DATA, {
+        path: validated.path,
+      });
+    }
+    const sha256 = await digestFile(canonicalFile);
+    return { validated, sha256, size: metadata.size };
+  } catch (error) {
+    if (error instanceof CommsError) throw error;
+    throw new CommsError("cannot read attachment", EXIT.DATA, {
+      path: validated.path,
+      cause: error.message,
+    });
+  }
+}
+
+export async function describeAttachment(context, input) {
+  const { validated, sha256, size } = await inspectAttachment(context, input);
+  return validateAttachment({
+    ...validated,
+    sha256,
+    size,
+  });
+}
+
+export async function verifyAttachment(context, record) {
+  const validated = validateAttachment(record);
+  const actual = await inspectAttachment(context, validated);
+  if (actual.sha256 !== validated.sha256 || actual.size !== validated.size) {
+    throw new CommsError("attachment evidence does not match file", EXIT.DATA, {
+      path: validated.path,
+      expectedSha256: validated.sha256,
+      actualSha256: actual.sha256,
+      expectedSize: validated.size,
+      actualSize: actual.size,
+    });
+  }
+}

--- a/prototype/integrated/tools/agents/lib/claim-records.mjs
+++ b/prototype/integrated/tools/agents/lib/claim-records.mjs
@@ -1,0 +1,36 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+
+import { listJsonFiles, readJsonStrict } from "./atomic-json.mjs";
+import { CommsError, EXIT } from "./errors.mjs";
+import { validateClaim } from "./schema.mjs";
+
+export function claimFilePath(context, scope) {
+  const digest = createHash("sha256").update(scope).digest("hex");
+  return path.join(context.paths.claims, `${digest}.json`);
+}
+
+export async function inspectClaimRecords(context) {
+  const records = [], corrupt = [];
+  for (const file of await listJsonFiles(context.paths.claims)) {
+    try { records.push({ file, record: await readJsonStrict(file, validateClaim) }); }
+    catch { corrupt.push(file); }
+  }
+  const counts = new Map();
+  for (const item of records) counts.set(item.record.scope,
+    (counts.get(item.record.scope) ?? 0) + 1);
+  const valid = [];
+  for (const item of records) {
+    if (item.file !== claimFilePath(context, item.record.scope)
+      || counts.get(item.record.scope) > 1) corrupt.push(item.file);
+    else valid.push(item);
+  }
+  return { records: valid, corrupt: [...new Set(corrupt)].sort() };
+}
+
+export async function requireValidClaimRecords(context) {
+  const result = await inspectClaimRecords(context);
+  if (result.corrupt.length > 0) throw new CommsError("invalid claim store", EXIT.DATA,
+    { paths: result.corrupt });
+  return result.records;
+}

--- a/prototype/integrated/tools/agents/lib/claim-records.mjs
+++ b/prototype/integrated/tools/agents/lib/claim-records.mjs
@@ -12,8 +12,9 @@ export function claimFilePath(context, scope) {
 
 export async function inspectClaimRecords(context) {
   const records = [], corrupt = [];
-  for (const file of await listJsonFiles(context.paths.claims)) {
-    try { records.push({ file, record: await readJsonStrict(file, validateClaim) }); }
+  for (const file of await listJsonFiles(context.paths.claims, { root: context.paths.root })) {
+    try { records.push({ file,
+      record: await readJsonStrict(file, validateClaim, context.paths.root) }); }
     catch { corrupt.push(file); }
   }
   const counts = new Map();

--- a/prototype/integrated/tools/agents/lib/claims-audit.mjs
+++ b/prototype/integrated/tools/agents/lib/claims-audit.mjs
@@ -1,0 +1,46 @@
+import { createHash, randomUUID } from "node:crypto";
+import path from "node:path";
+
+import { writeJsonAtomic } from "./atomic-json.mjs";
+import { CommsError, EXIT } from "./errors.mjs";
+import { validateAgentId, validateClaim, validateLock } from "./schema.mjs";
+
+function data(message) { throw new CommsError(message, EXIT.DATA); }
+function validTime(value) {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
+}
+export function validateClaimAudit(value) {
+  const keys = ["action", "actor_agent", "recorded_at", "schema_version", "target"];
+  if (value === null || typeof value !== "object" || Array.isArray(value)
+    || Object.keys(value).sort().join() !== keys.join() || value.schema_version !== 1
+    || !validTime(value.recorded_at)) data("invalid claims audit");
+  if (value.action === "force_release_stale_claim") {
+    if (value.actor_agent === null) data("force release audit has no actor");
+    validateAgentId(value.actor_agent); validateClaim(value.target);
+    if (Date.parse(value.target.expires_at) > Date.parse(value.recorded_at))
+      data("force release audit target was not stale");
+  } else if (value.action === "repair_stale_claim_lock") {
+    if (value.actor_agent !== null) data("claim lock repair audit has an actor");
+    validateLock(value.target);
+    if (Date.parse(value.recorded_at) - Date.parse(value.target.acquired_at) <= 60_000)
+      data("claim lock repair audit target was not stale");
+  } else data("invalid claims audit action");
+  return value;
+}
+export function claimLockDigest(owner) {
+  return createHash("sha256").update(JSON.stringify([
+    owner.schema_version, owner.owner_agent, owner.pid, owner.acquired_at,
+  ])).digest("hex");
+}
+export function staleClaimLockDestination(context, owner) {
+  return path.join(context.paths.quarantine, `claims-lock-stale-${claimLockDigest(owner)}`);
+}
+export async function writeClaimAudit(context, action, actorAgent, target) {
+  const audit = validateClaimAudit({ schema_version: 1, action, actor_agent: actorAgent,
+    recorded_at: context.now().toISOString(), target });
+  const uuid = (context.randomUUID ?? randomUUID)();
+  const filePath = path.join(context.paths.quarantine, `claims-audit-${uuid}.json`);
+  await writeJsonAtomic(filePath, audit, { tmpDir: context.paths.tmp, exclusive: true });
+  return { audit, filePath };
+}

--- a/prototype/integrated/tools/agents/lib/claims.mjs
+++ b/prototype/integrated/tools/agents/lib/claims.mjs
@@ -1,11 +1,13 @@
-import { createHash, randomUUID } from "node:crypto";
 import { mkdir, rename, rmdir, unlink } from "node:fs/promises";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 
 import { readJsonStrict, writeJsonAtomic } from "./atomic-json.mjs";
+import { staleClaimLockDestination, writeClaimAudit } from "./claims-audit.mjs";
 import { claimFilePath, requireValidClaimRecords } from "./claim-records.mjs";
 import { CommsError, EXIT } from "./errors.mjs";
 import { requireOpenAgent } from "./identity.mjs";
+import { inspectRecoveryAudits } from "./recovery-audits.mjs";
 import {
   validateAgentId,
   validateClaim,
@@ -107,45 +109,6 @@ function expiresAt(context, seconds = DEFAULT_LEASE_SECONDS) {
 }
 function claimIsStale(claim, context) {
   return Date.parse(claim.expires_at) <= context.now().getTime();
-}
-function auditName(context) {
-  const uuid = (context.randomUUID ?? randomUUID)();
-  return path.join(context.paths.quarantine, `claims-audit-${uuid}.json`);
-}
-function validateAudit(value) {
-  const keys = ["action", "actor_agent", "recorded_at", "schema_version", "target"];
-  const validShape = value.schema_version === 1
-    && Object.keys(value).sort().join() === keys.join();
-  const timestamp = Date.parse(value.recorded_at);
-  if (!validShape || !Number.isFinite(timestamp)
-    || new Date(timestamp).toISOString() !== value.recorded_at) {
-    throw new CommsError("invalid claims audit", EXIT.DATA);
-  }
-  if (value.actor_agent !== null) validateAgentId(value.actor_agent);
-  if (value.action === "force_release_stale_claim") validateClaim(value.target);
-  else if (value.action === "repair_stale_claim_lock") validateLock(value.target);
-  else throw new CommsError("invalid claims audit action", EXIT.DATA);
-  return value;
-}
-async function writeAudit(context, action, actorAgent, target) {
-  const audit = validateAudit({
-    schema_version: 1,
-    action,
-    actor_agent: actorAgent,
-    recorded_at: context.now().toISOString(),
-    target,
-  });
-  await writeJsonAtomic(auditName(context), audit, {
-    tmpDir: context.paths.tmp,
-    exclusive: true,
-  });
-}
-function staleLockDestination(context, owner) {
-  const canonical = JSON.stringify([
-    owner.schema_version, owner.owner_agent, owner.pid, owner.acquired_at,
-  ]);
-  const digest = createHash("sha256").update(canonical).digest("hex");
-  return path.join(context.paths.quarantine, `claims-lock-stale-${digest}`);
 }
 function findExactClaim(items, scope) {
   return items.find(item => item.record.scope === scope) ?? null;
@@ -264,8 +227,8 @@ export async function forceReleaseStaleScope(context, input) {
     if (!claimIsStale(claim.record, context)) {
       conflict("active claim cannot be force-released", { owner, scope });
     }
-    await writeAudit(context, "force_release_stale_claim", actor.agent_id, claim.record);
-    await unlink(claim.file);
+    await writeClaimAudit(context, "force_release_stale_claim", actor.agent_id, claim.record);
+    await (context.unlinkClaimRecord ?? unlink)(claim.file);
     return claim.record;
   });
 }
@@ -275,8 +238,12 @@ export async function repairStaleClaimLock(context) {
   if (owner === null) return false;
   const age = context.now().getTime() - Date.parse(owner.acquired_at);
   if (age <= STALE_LOCK_MS || context.pidIsAlive(owner.pid)) return false;
-  await writeAudit(context, "repair_stale_claim_lock", null, owner);
-  const destination = staleLockDestination(context, owner);
+  const recovery = await inspectRecoveryAudits(context);
+  if (recovery.corrupt.length > 0) throw new CommsError("corrupt claim recovery audit",
+    EXIT.DATA, { paths: recovery.corrupt });
+  if (!recovery.pending_claim_locks.some(item => isDeepStrictEqual(item.audit.target, owner)))
+    await writeClaimAudit(context, "repair_stale_claim_lock", null, owner);
+  const destination = staleClaimLockDestination(context, owner);
   try {
     await (context.renameClaimLock ?? rename)(paths.directory, destination);
   } catch (error) {
@@ -285,4 +252,23 @@ export async function repairStaleClaimLock(context) {
     return false;
   }
   return true;
+}
+export async function repairPendingForceReleases(context) {
+  const recovery = await inspectRecoveryAudits(context);
+  if (recovery.corrupt.length > 0) throw new CommsError("corrupt claim recovery audit",
+    EXIT.DATA, { paths: recovery.corrupt });
+  const repairs = [];
+  for (const pending of recovery.pending_force_releases) {
+    const removed = await withClaimLock(context, pending.audit.actor_agent, async () => {
+      const current = (await requireValidClaimRecords(context))
+        .find(item => item.file === pending.source_path);
+      if (current === undefined) return false;
+      if (!isDeepStrictEqual(current.record, pending.audit.target))
+        throw new CommsError("pending force-release generation changed", EXIT.DATA);
+      await (context.unlinkClaimRecord ?? unlink)(current.file); return true;
+    });
+    if (removed) repairs.push({ action: "complete_pending_force_release",
+      path: pending.source_path, audit_path: pending.audit_path });
+  }
+  return repairs;
 }

--- a/prototype/integrated/tools/agents/lib/claims.mjs
+++ b/prototype/integrated/tools/agents/lib/claims.mjs
@@ -39,7 +39,7 @@ function leaseSeconds(input) {
 }
 function claimLockPaths(context) {
   const directory = path.join(context.paths.locks, "claims.lock");
-  return { directory, owner: path.join(directory, "owner.json") };
+  return { directory, owner: path.join(directory, "owner.json"), root: context.paths.root };
 }
 async function removeIfPresent(file) {
   try {
@@ -51,7 +51,7 @@ async function removeIfPresent(file) {
 }
 async function readLockIfPresent(paths) {
   try {
-    return await readJsonStrict(paths.owner, validateLock);
+    return await readJsonStrict(paths.owner, validateLock, paths.root);
   } catch (error) {
     if (error.code === "ENOENT") return null;
     throw error;

--- a/prototype/integrated/tools/agents/lib/claims.mjs
+++ b/prototype/integrated/tools/agents/lib/claims.mjs
@@ -1,0 +1,288 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, rename, rmdir, unlink } from "node:fs/promises";
+import path from "node:path";
+
+import { readJsonStrict, writeJsonAtomic } from "./atomic-json.mjs";
+import { claimFilePath, requireValidClaimRecords } from "./claim-records.mjs";
+import { CommsError, EXIT } from "./errors.mjs";
+import { requireOpenAgent } from "./identity.mjs";
+import {
+  validateAgentId,
+  validateClaim,
+  validateLock,
+  validateScope,
+} from "./schema.mjs";
+
+const DEFAULT_LEASE_SECONDS = 1_800;
+const STALE_LOCK_MS = 60_000;
+function conflict(message, details = null) {
+  throw new CommsError(message, EXIT.CONFLICT, details);
+}
+function canonicalScope(scope) {
+  const normalized = normalizeScope(scope);
+  return normalized.kind === "contract"
+    ? `contract:${normalized.value}`
+    : normalized.value;
+}
+function inputAgentId(input) {
+  return validateAgentId(input.agentId ?? input.agent_id);
+}
+function ownerAgentId(input) {
+  return validateAgentId(input.ownerAgent ?? input.owner_agent ?? input.owner);
+}
+function leaseSeconds(input) {
+  const value = input.leaseSeconds ?? input.lease ?? DEFAULT_LEASE_SECONDS;
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new CommsError("claim lease must be a positive integer", EXIT.DATA, { value });
+  }
+  return value;
+}
+function claimLockPaths(context) {
+  const directory = path.join(context.paths.locks, "claims.lock");
+  return { directory, owner: path.join(directory, "owner.json") };
+}
+async function removeIfPresent(file) {
+  try {
+    await unlink(file);
+  } catch (error) {
+    if (error.code === "ENOENT") return;
+    throw error;
+  }
+}
+async function readLockIfPresent(paths) {
+  try {
+    return await readJsonStrict(paths.owner, validateLock);
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+async function acquireClaimLock(context, agentId) {
+  const paths = claimLockPaths(context);
+  try {
+    await mkdir(paths.directory);
+  } catch (error) {
+    if (error.code === "EEXIST") {
+      conflict("claim lock is already held", { lock: paths.directory });
+    }
+    throw error;
+  }
+  const record = validateLock({
+    schema_version: 1,
+    owner_agent: validateAgentId(agentId),
+    pid: context.pid ?? process.pid,
+    acquired_at: context.now().toISOString(),
+  });
+  const writeOwner = context.writeClaimLockOwner ?? writeJsonAtomic;
+  try {
+    await writeOwner(paths.owner, record, {
+      tmpDir: context.paths.tmp,
+      exclusive: true,
+    });
+  } catch (error) {
+    try { await removeIfPresent(paths.owner); } catch {}
+    try { await rmdir(paths.directory); } catch {}
+    throw error;
+  }
+  return paths;
+}
+async function releaseClaimLock(paths) {
+  await removeIfPresent(paths.owner);
+  try {
+    await rmdir(paths.directory);
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+}
+async function withClaimLock(context, agentId, operation) {
+  const lock = await acquireClaimLock(context, agentId);
+  try {
+    return await operation();
+  } finally {
+    await releaseClaimLock(lock);
+  }
+}
+function expiresAt(context, seconds = DEFAULT_LEASE_SECONDS) {
+  return new Date(context.now().getTime() + seconds * 1_000).toISOString();
+}
+function claimIsStale(claim, context) {
+  return Date.parse(claim.expires_at) <= context.now().getTime();
+}
+function auditName(context) {
+  const uuid = (context.randomUUID ?? randomUUID)();
+  return path.join(context.paths.quarantine, `claims-audit-${uuid}.json`);
+}
+function validateAudit(value) {
+  const keys = ["action", "actor_agent", "recorded_at", "schema_version", "target"];
+  const validShape = value.schema_version === 1
+    && Object.keys(value).sort().join() === keys.join();
+  const timestamp = Date.parse(value.recorded_at);
+  if (!validShape || !Number.isFinite(timestamp)
+    || new Date(timestamp).toISOString() !== value.recorded_at) {
+    throw new CommsError("invalid claims audit", EXIT.DATA);
+  }
+  if (value.actor_agent !== null) validateAgentId(value.actor_agent);
+  if (value.action === "force_release_stale_claim") validateClaim(value.target);
+  else if (value.action === "repair_stale_claim_lock") validateLock(value.target);
+  else throw new CommsError("invalid claims audit action", EXIT.DATA);
+  return value;
+}
+async function writeAudit(context, action, actorAgent, target) {
+  const audit = validateAudit({
+    schema_version: 1,
+    action,
+    actor_agent: actorAgent,
+    recorded_at: context.now().toISOString(),
+    target,
+  });
+  await writeJsonAtomic(auditName(context), audit, {
+    tmpDir: context.paths.tmp,
+    exclusive: true,
+  });
+}
+function staleLockDestination(context, owner) {
+  const canonical = JSON.stringify([
+    owner.schema_version, owner.owner_agent, owner.pid, owner.acquired_at,
+  ]);
+  const digest = createHash("sha256").update(canonical).digest("hex");
+  return path.join(context.paths.quarantine, `claims-lock-stale-${digest}`);
+}
+function findExactClaim(items, scope) {
+  return items.find(item => item.record.scope === scope) ?? null;
+}
+export function normalizeScope(scope) {
+  const value = validateScope(scope);
+  if (value.startsWith("contract:")) {
+    return Object.freeze({ kind: "contract", value: value.slice("contract:".length) });
+  }
+  return Object.freeze({ kind: "path", value: value.replace(/\/$/, "") });
+}
+export function scopesOverlap(leftInput, rightInput) {
+  const left = normalizeScope(leftInput);
+  const right = normalizeScope(rightInput);
+  if (left.kind !== right.kind) return false;
+  if (left.kind === "contract") return left.value === right.value;
+  const a = left.value.split("/");
+  const b = right.value.split("/");
+  return a.slice(0, Math.min(a.length, b.length))
+    .every((part, index) => part === b[index]);
+}
+export async function claimScope(context, input) {
+  const agentId = inputAgentId(input);
+  const scope = canonicalScope(input.scope);
+  const registry = await requireOpenAgent(context, agentId);
+  const seconds = leaseSeconds(input);
+  return withClaimLock(context, agentId, async () => {
+    const items = await requireValidClaimRecords(context);
+    const exact = findExactClaim(items, scope);
+    const blocking = items.find(item => item.record.agent_id !== agentId
+      && scopesOverlap(item.record.scope, scope));
+    if (blocking !== undefined) {
+      conflict("scope overlaps an existing claim", {
+        owner: blocking.record.agent_id,
+        scope: blocking.record.scope,
+        stale: claimIsStale(blocking.record, context),
+      });
+    }
+
+    const timestamp = context.now().toISOString();
+    const record = validateClaim({
+      schema_version: 1,
+      agent_id: agentId,
+      task: registry.task,
+      scope,
+      reason: input.reason,
+      created_at: exact?.record.created_at ?? timestamp,
+      updated_at: timestamp,
+      expires_at: expiresAt(context, seconds),
+    });
+    await writeJsonAtomic(claimFilePath(context, scope), record, {
+      tmpDir: context.paths.tmp,
+      exclusive: exact === null,
+    });
+    return record;
+  });
+}
+export async function releaseScope(context, input) {
+  const agentId = inputAgentId(input);
+  const scope = canonicalScope(input.scope);
+  await requireOpenAgent(context, agentId);
+  return withClaimLock(context, agentId, async () => {
+    const claim = findExactClaim(await requireValidClaimRecords(context), scope);
+    if (claim === null || claim.record.agent_id !== agentId) {
+      conflict("scope is not claimed by this agent", { agentId, scope });
+    }
+    await unlink(claim.file);
+    return claim.record;
+  });
+}
+export async function releaseOwnedClaims(context, agentId) {
+  const owner = validateAgentId(agentId);
+  return withClaimLock(context, owner, async () => {
+    const owned = (await requireValidClaimRecords(context))
+      .filter(item => item.record.agent_id === owner);
+    for (const item of owned) await unlink(item.file);
+    return owned.map(item => item.record);
+  });
+}
+export async function extendClaims(context, agentId) {
+  const owner = (await requireOpenAgent(context, validateAgentId(agentId))).agent_id;
+  return withClaimLock(context, owner, async () => {
+    const owned = (await requireValidClaimRecords(context))
+      .filter(item => item.record.agent_id === owner);
+    const timestamp = context.now().toISOString();
+    const extended = [];
+    for (const item of owned) {
+      const record = validateClaim({
+        ...item.record,
+        updated_at: timestamp,
+        expires_at: expiresAt(context),
+      });
+      await writeJsonAtomic(item.file, record, {
+        tmpDir: context.paths.tmp,
+        exclusive: false,
+      });
+      extended.push(record);
+    }
+    return extended;
+  });
+}
+export async function forceReleaseStaleScope(context, input) {
+  const actor = await requireOpenAgent(context, inputAgentId(input));
+  if (actor.role !== "orchestrator") {
+    conflict("only an orchestrator may force-release a stale claim", {
+      agentId: actor.agent_id,
+    });
+  }
+  const owner = ownerAgentId(input);
+  const scope = canonicalScope(input.scope);
+  return withClaimLock(context, actor.agent_id, async () => {
+    const claim = findExactClaim(await requireValidClaimRecords(context), scope);
+    if (claim === null || claim.record.agent_id !== owner) {
+      conflict("target claim does not exist", { owner, scope });
+    }
+    if (!claimIsStale(claim.record, context)) {
+      conflict("active claim cannot be force-released", { owner, scope });
+    }
+    await writeAudit(context, "force_release_stale_claim", actor.agent_id, claim.record);
+    await unlink(claim.file);
+    return claim.record;
+  });
+}
+export async function repairStaleClaimLock(context) {
+  const paths = claimLockPaths(context);
+  const owner = await readLockIfPresent(paths);
+  if (owner === null) return false;
+  const age = context.now().getTime() - Date.parse(owner.acquired_at);
+  if (age <= STALE_LOCK_MS || context.pidIsAlive(owner.pid)) return false;
+  await writeAudit(context, "repair_stale_claim_lock", null, owner);
+  const destination = staleLockDestination(context, owner);
+  try {
+    await (context.renameClaimLock ?? rename)(paths.directory, destination);
+  } catch (error) {
+    if (!["EEXIST", "ENOTEMPTY", "ENOENT"].includes(error.code)) throw error;
+    await readLockIfPresent(paths);
+    return false;
+  }
+  return true;
+}

--- a/prototype/integrated/tools/agents/lib/doctor-protocol.mjs
+++ b/prototype/integrated/tools/agents/lib/doctor-protocol.mjs
@@ -1,8 +1,9 @@
-import { readFile } from "node:fs/promises";
+import { readJsonStrict } from "./atomic-json.mjs";
 
 export async function protocolCompatibilityIssue(context) {
   try {
-    const value = JSON.parse(await readFile(context.paths.protocol, "utf8"));
+    const value = await readJsonStrict(context.paths.protocol, record => record,
+      context.paths.root);
     if (value?.schema_version !== 1) return { code: "UNKNOWN_SCHEMA_VERSION",
       severity: "error", path: context.paths.protocol, message: "unknown schema version" };
     if (value?.protocol_version !== 1) return { code: "UNKNOWN_PROTOCOL_VERSION",

--- a/prototype/integrated/tools/agents/lib/doctor-protocol.mjs
+++ b/prototype/integrated/tools/agents/lib/doctor-protocol.mjs
@@ -1,0 +1,12 @@
+import { readFile } from "node:fs/promises";
+
+export async function protocolCompatibilityIssue(context) {
+  try {
+    const value = JSON.parse(await readFile(context.paths.protocol, "utf8"));
+    if (value?.schema_version !== 1) return { code: "UNKNOWN_SCHEMA_VERSION",
+      severity: "error", path: context.paths.protocol, message: "unknown schema version" };
+    if (value?.protocol_version !== 1) return { code: "UNKNOWN_PROTOCOL_VERSION",
+      severity: "error", path: context.paths.protocol, message: "unknown protocol version" };
+  } catch {}
+  return null;
+}

--- a/prototype/integrated/tools/agents/lib/doctor-storage.mjs
+++ b/prototype/integrated/tools/agents/lib/doctor-storage.mjs
@@ -1,0 +1,183 @@
+import { createHash, randomUUID } from "node:crypto";
+import { link, lstat, mkdir, readFile, unlink } from "node:fs/promises";
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+
+import { listJsonFiles, readJsonStrict, writeJsonAtomic } from "./atomic-json.mjs";
+import { CommsError, EXIT } from "./errors.mjs";
+import { readJsonRegularNoFollow, readRegularNoFollow } from "./safe-file.mjs";
+import {
+  validateAcknowledgement, validateHandoff, validateMessage, validateProtocol,
+  validateSeenReceipt,
+} from "./schema.mjs";
+
+function inside(root, filePath) {
+  const relative = path.relative(root, filePath);
+  return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+function stem(filePath) { return path.basename(filePath, ".json"); }
+function immutableDescriptor(context, filePath) {
+  if (filePath === context.paths.protocol) return {
+    validate: validateProtocol, bound: () => true };
+  for (const root of [context.paths.inbox, context.paths.archive]) {
+    if (inside(root, filePath)) return { validate: validateMessage, bound: record =>
+      record.to === path.basename(path.dirname(filePath)) && record.id === stem(filePath) };
+  }
+  if (inside(context.paths.seen, filePath)) return { validate: validateSeenReceipt,
+    bound: record => filePath === context.paths.seenFile(record.message_id, record.recipient) };
+  if (inside(context.paths.acknowledgements, filePath)) return {
+    validate: validateAcknowledgement, bound: record =>
+      filePath === context.paths.ackFile(record.message_id, record.recipient) };
+  if (inside(context.paths.handoffs, filePath)) return { validate: validateHandoff,
+    bound: record => record.id === stem(filePath) };
+  return null;
+}
+function bytesAreValid(context, filePath, bytes) {
+  const descriptor = immutableDescriptor(context, filePath);
+  if (descriptor === null) return null;
+  try {
+    const record = descriptor.validate(JSON.parse(bytes.toString("utf8")));
+    return descriptor.bound(record);
+  } catch { return false; }
+}
+function sameGeneration(left, right) {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+function digestFor(sourcePath, bytes) {
+  return createHash("sha256").update(sourcePath).update(bytes).digest("hex");
+}
+function auditPaths(context, sourcePath, bytes) {
+  const digest = digestFor(sourcePath, bytes);
+  return {
+    digest,
+    quarantinePath: path.join(context.paths.quarantine, `corrupt-${digest}.data`),
+    auditPath: path.join(context.paths.quarantine, `doctor-audit-${digest}.json`),
+  };
+}
+function validateDoctorAudit(value) {
+  const keys = ["action", "quarantine_path", "recorded_at", "schema_version",
+    "sha256", "source_path"];
+  const timestamp = Date.parse(value?.recorded_at);
+  if (value === null || typeof value !== "object" || Array.isArray(value)
+    || Object.keys(value).sort().join() !== keys.join() || value.schema_version !== 1
+    || value.action !== "quarantine_corrupt_json" || !Number.isFinite(timestamp)
+    || new Date(timestamp).toISOString() !== value.recorded_at
+    || !/^[a-f0-9]{64}$/.test(value.sha256) || !path.isAbsolute(value.source_path)
+    || !path.isAbsolute(value.quarantine_path)) {
+    throw new CommsError("invalid doctor audit", EXIT.DATA);
+  }
+  return value;
+}
+async function publishAudit(context, sourcePath, bytes, paths) {
+  const audit = validateDoctorAudit({ schema_version: 1,
+    action: "quarantine_corrupt_json", source_path: sourcePath,
+    quarantine_path: paths.quarantinePath,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    recorded_at: context.now().toISOString() });
+  try {
+    await writeJsonAtomic(paths.auditPath, audit,
+      { tmpDir: context.paths.tmp, exclusive: true });
+  } catch (error) {
+    if (!(error instanceof CommsError) || error.exitCode !== EXIT.CONFLICT) throw error;
+    const existing = await readJsonStrict(paths.auditPath, validateDoctorAudit);
+    if (!isDeepStrictEqual(existing, { ...audit, recorded_at: existing.recorded_at }))
+      throw new CommsError("repair audit conflicts with snapshot", EXIT.DATA);
+  }
+}
+async function unlinkIfPresent(filePath) {
+  try { await unlink(filePath); }
+  catch (error) { if (error.code !== "ENOENT") throw error; }
+}
+
+export async function scanDoctorAudits(context) {
+  const corrupt = [];
+  for (const auditPath of await listJsonFiles(context.paths.quarantine)) {
+    if (!path.basename(auditPath).startsWith("doctor-audit-")) continue;
+    try {
+      const audit = await readJsonStrict(auditPath, validateDoctorAudit);
+      const match = /^doctor-audit-([a-f0-9]{64})\.json$/.exec(path.basename(auditPath));
+      if (match === null || !inside(context.paths.root, audit.source_path)
+        || immutableDescriptor(context, audit.source_path) === null) throw new Error("unsafe audit");
+      const canonicalQuarantine = path.join(context.paths.quarantine,
+        `corrupt-${match[1]}.data`);
+      if (audit.quarantine_path !== canonicalQuarantine) throw new Error("unsafe quarantine path");
+      const bytes = await readRegularNoFollow(canonicalQuarantine,
+        context.openImmutableRecord);
+      const paths = auditPaths(context, audit.source_path, bytes);
+      const checksum = createHash("sha256").update(bytes).digest("hex");
+      if (auditPath !== paths.auditPath || audit.quarantine_path !== paths.quarantinePath
+        || audit.sha256 !== checksum) throw new Error("audit binding mismatch");
+    } catch { corrupt.push(auditPath); }
+  }
+  return corrupt.sort();
+}
+
+export async function quarantineCorrupt(context, sourcePath) {
+  if (immutableDescriptor(context, sourcePath) === null) return null;
+  const token = (context.randomUUID ?? randomUUID)();
+  const snapshot = path.join(context.paths.quarantine, `doctor-snapshot-${token}.data`);
+  try {
+    try { await (context.linkCorruptRecord ?? link)(sourcePath, snapshot); }
+    catch (error) { if (error.code === "ENOENT") return null; throw error; }
+    const [bytes, sourceBytes, snapshotStat, sourceStat] = await Promise.all([
+      readFile(snapshot), readFile(sourcePath), lstat(snapshot), lstat(sourcePath),
+    ]);
+    if (!sameGeneration(snapshotStat, sourceStat) || !bytes.equals(sourceBytes)) return null;
+    if (bytesAreValid(context, sourcePath, bytes)) return null;
+    const paths = auditPaths(context, sourcePath, bytes);
+    try { await link(snapshot, paths.quarantinePath); }
+    catch (error) {
+      if (error.code !== "EEXIST") throw error;
+      if (!(await readFile(paths.quarantinePath)).equals(bytes)) {
+        throw new CommsError("quarantine snapshot conflicts", EXIT.DATA);
+      }
+    }
+    if (!(await readFile(paths.quarantinePath)).equals(bytes)) {
+      throw new CommsError("quarantine snapshot changed", EXIT.DATA);
+    }
+    await publishAudit(context, sourcePath, bytes, paths);
+    const [currentBytes, currentStat] = await Promise.all([readFile(sourcePath), lstat(sourcePath)]);
+    if (!sameGeneration(snapshotStat, currentStat) || !bytes.equals(currentBytes)) return null;
+    await (context.unlinkCorruptRecord ?? unlink)(sourcePath);
+    return { action: "quarantine_corrupt_json", path: sourcePath,
+      quarantine_path: paths.quarantinePath, audit_path: paths.auditPath };
+  } finally { await unlinkIfPresent(snapshot); }
+}
+
+export async function archiveAcknowledged(context, message) {
+  const source = context.paths.inboxFile(message.to, message.id);
+  const destination = context.paths.archiveFile(message.to, message.id);
+  await mkdir(path.dirname(destination), { recursive: true });
+  async function validateDestination() {
+    let existing;
+    try { existing = (await readJsonRegularNoFollow(destination, validateMessage,
+      context.openArchiveRecord)).record; }
+    catch (error) {
+      if (error.code === "ENOENT") throw new CommsError(
+        "archive destination is missing after inbox disappeared", EXIT.DATA);
+      if (error instanceof CommsError) throw error;
+      throw new CommsError("archive destination is not a strict regular record", EXIT.DATA,
+        { path: destination, cause: error.message });
+    }
+    if (!isDeepStrictEqual(existing, message)) throw new CommsError(
+      "archive destination conflicts with missing inbox message", EXIT.DATA);
+  }
+  try { await (context.linkArchiveRecord ?? link)(source, destination); }
+  catch (error) {
+    if (error.code === "ENOENT") { await validateDestination(); return null; }
+    if (error.code !== "EEXIST") throw error;
+    let sourceBytes;
+    try { sourceBytes = await readFile(source); }
+    catch (sourceError) {
+      if (sourceError.code !== "ENOENT") throw sourceError;
+      await validateDestination();
+      return null;
+    }
+    const destinationBytes = await readFile(destination);
+    if (!sourceBytes.equals(destinationBytes)) {
+      throw new CommsError("archive destination conflicts with inbox message", EXIT.DATA);
+    }
+  }
+  await unlinkIfPresent(source);
+  return { action: "archive_acknowledged_message", path: source, destination };
+}

--- a/prototype/integrated/tools/agents/lib/doctor-storage.mjs
+++ b/prototype/integrated/tools/agents/lib/doctor-storage.mjs
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { link, lstat, mkdir, readFile, unlink } from "node:fs/promises";
+import { link, lstat, mkdir, unlink } from "node:fs/promises";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 
@@ -79,7 +79,8 @@ async function publishAudit(context, sourcePath, bytes, paths) {
       { tmpDir: context.paths.tmp, exclusive: true });
   } catch (error) {
     if (!(error instanceof CommsError) || error.exitCode !== EXIT.CONFLICT) throw error;
-    const existing = await readJsonStrict(paths.auditPath, validateDoctorAudit);
+    const existing = await readJsonStrict(paths.auditPath, validateDoctorAudit,
+      context.paths.root);
     if (!isDeepStrictEqual(existing, { ...audit, recorded_at: existing.recorded_at }))
       throw new CommsError("repair audit conflicts with snapshot", EXIT.DATA);
   }
@@ -91,10 +92,11 @@ async function unlinkIfPresent(filePath) {
 
 export async function scanDoctorAudits(context) {
   const corrupt = [];
-  for (const auditPath of await listJsonFiles(context.paths.quarantine)) {
+  for (const auditPath of await listJsonFiles(context.paths.quarantine,
+    { root: context.paths.root })) {
     if (!path.basename(auditPath).startsWith("doctor-audit-")) continue;
     try {
-      const audit = await readJsonStrict(auditPath, validateDoctorAudit);
+      const audit = await readJsonStrict(auditPath, validateDoctorAudit, context.paths.root);
       const match = /^doctor-audit-([a-f0-9]{64})\.json$/.exec(path.basename(auditPath));
       if (match === null || !inside(context.paths.root, audit.source_path)
         || immutableDescriptor(context, audit.source_path) === null) throw new Error("unsafe audit");
@@ -102,7 +104,7 @@ export async function scanDoctorAudits(context) {
         `corrupt-${match[1]}.data`);
       if (audit.quarantine_path !== canonicalQuarantine) throw new Error("unsafe quarantine path");
       const bytes = await readRegularNoFollow(canonicalQuarantine,
-        context.openImmutableRecord);
+        context.paths.root, context.openImmutableRecord);
       const paths = auditPaths(context, audit.source_path, bytes);
       const checksum = createHash("sha256").update(bytes).digest("hex");
       if (auditPath !== paths.auditPath || audit.quarantine_path !== paths.quarantinePath
@@ -120,7 +122,9 @@ export async function quarantineCorrupt(context, sourcePath) {
     try { await (context.linkCorruptRecord ?? link)(sourcePath, snapshot); }
     catch (error) { if (error.code === "ENOENT") return null; throw error; }
     const [bytes, sourceBytes, snapshotStat, sourceStat] = await Promise.all([
-      readFile(snapshot), readFile(sourcePath), lstat(snapshot), lstat(sourcePath),
+      readRegularNoFollow(snapshot, context.paths.root),
+      readRegularNoFollow(sourcePath, context.paths.root),
+      lstat(snapshot), lstat(sourcePath),
     ]);
     if (!sameGeneration(snapshotStat, sourceStat) || !bytes.equals(sourceBytes)) return null;
     if (bytesAreValid(context, sourcePath, bytes)) return null;
@@ -128,15 +132,17 @@ export async function quarantineCorrupt(context, sourcePath) {
     try { await link(snapshot, paths.quarantinePath); }
     catch (error) {
       if (error.code !== "EEXIST") throw error;
-      if (!(await readFile(paths.quarantinePath)).equals(bytes)) {
+      if (!(await readRegularNoFollow(paths.quarantinePath, context.paths.root)).equals(bytes)) {
         throw new CommsError("quarantine snapshot conflicts", EXIT.DATA);
       }
     }
-    if (!(await readFile(paths.quarantinePath)).equals(bytes)) {
+    if (!(await readRegularNoFollow(paths.quarantinePath, context.paths.root)).equals(bytes)) {
       throw new CommsError("quarantine snapshot changed", EXIT.DATA);
     }
     await publishAudit(context, sourcePath, bytes, paths);
-    const [currentBytes, currentStat] = await Promise.all([readFile(sourcePath), lstat(sourcePath)]);
+    const [currentBytes, currentStat] = await Promise.all([
+      readRegularNoFollow(sourcePath, context.paths.root), lstat(sourcePath),
+    ]);
     if (!sameGeneration(snapshotStat, currentStat) || !bytes.equals(currentBytes)) return null;
     await (context.unlinkCorruptRecord ?? unlink)(sourcePath);
     return { action: "quarantine_corrupt_json", path: sourcePath,
@@ -151,7 +157,7 @@ export async function archiveAcknowledged(context, message) {
   async function validateDestination() {
     let existing;
     try { existing = (await readJsonRegularNoFollow(destination, validateMessage,
-      context.openArchiveRecord)).record; }
+      context.paths.root, context.openArchiveRecord)).record; }
     catch (error) {
       if (error.code === "ENOENT") throw new CommsError(
         "archive destination is missing after inbox disappeared", EXIT.DATA);
@@ -167,13 +173,13 @@ export async function archiveAcknowledged(context, message) {
     if (error.code === "ENOENT") { await validateDestination(); return null; }
     if (error.code !== "EEXIST") throw error;
     let sourceBytes;
-    try { sourceBytes = await readFile(source); }
+    try { sourceBytes = await readRegularNoFollow(source, context.paths.root); }
     catch (sourceError) {
       if (sourceError.code !== "ENOENT") throw sourceError;
       await validateDestination();
       return null;
     }
-    const destinationBytes = await readFile(destination);
+    const destinationBytes = await readRegularNoFollow(destination, context.paths.root);
     if (!sourceBytes.equals(destinationBytes)) {
       throw new CommsError("archive destination conflicts with inbox message", EXIT.DATA);
     }

--- a/prototype/integrated/tools/agents/lib/errors.mjs
+++ b/prototype/integrated/tools/agents/lib/errors.mjs
@@ -1,0 +1,17 @@
+export const EXIT = Object.freeze({
+  OK: 0,
+  USAGE: 2,
+  TIMEOUT: 3,
+  DATA: 4,
+  CONFLICT: 5,
+  REQUIRED: 6,
+});
+
+export class CommsError extends Error {
+  constructor(message, exitCode, details = null) {
+    super(message);
+    this.name = "CommsError";
+    this.exitCode = exitCode;
+    this.details = details;
+  }
+}

--- a/prototype/integrated/tools/agents/lib/handoff.mjs
+++ b/prototype/integrated/tools/agents/lib/handoff.mjs
@@ -1,0 +1,108 @@
+import { randomUUID } from "node:crypto";
+
+import { describeAttachment, verifyAttachment } from "./attachments.mjs";
+import { writeJsonAtomic } from "./atomic-json.mjs";
+import { CommsError, EXIT } from "./errors.mjs";
+import { sendMessage } from "./messages.mjs";
+import { validateHandoff } from "./schema.mjs";
+
+function handoffId(context, input, timestamp) {
+  const uuid = (context.randomUUID ?? randomUUID)();
+  return `handoff-${timestamp.replaceAll("-", "").replaceAll(":", "")}-${input.from}-${input.to}-${uuid}`;
+}
+
+function handoffInput(input) {
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    throw new CommsError("handoff input must be an object", EXIT.DATA, { input });
+  }
+  return input;
+}
+
+async function canonicalArtifacts(context, artifacts) {
+  if (!Array.isArray(artifacts)) return artifacts;
+  return Promise.all(artifacts.map(async artifact => {
+    await verifyAttachment(context, artifact);
+    return describeAttachment(context, artifact);
+  }));
+}
+
+function readiness(uncommitted, verification) {
+  const failed = Array.isArray(verification)
+    && verification.some(entry => entry?.exitCode !== 0);
+  if (uncommitted === true) return { ready: false, state: "UNCOMMITTED" };
+  return failed ? { ready: false, state: "NOT_READY" } : { ready: true, state: "READY" };
+}
+
+function buildHandoff(context, input, artifacts) {
+  const timestamp = context.now().toISOString();
+  const status = readiness(input.uncommitted, input.verification);
+  return {
+    schema_version: 1,
+    id: handoffId(context, input, timestamp),
+    from: input.from,
+    to: input.to,
+    task: input.task,
+    result: input.result,
+    branch: input.branch,
+    commit: input.commit,
+    base: input.base,
+    changed_paths: input.changedPaths,
+    verification: input.verification,
+    contracts: input.contracts,
+    follow_up: input.followUp,
+    artifacts,
+    limitations: input.limitations,
+    uncommitted: input.uncommitted,
+    ready_to_merge: status.ready,
+    state: status.state,
+    created_at: timestamp,
+  };
+}
+
+function verificationSummary(verification) {
+  return verification.map(entry => `- ${entry.command}: exit ${entry.exitCode} (${entry.summary})`)
+    .join("\n");
+}
+
+function limitationsSummary(limitations) {
+  return limitations.length === 0 ? "- none" : limitations.map(item => `- ${item}`).join("\n");
+}
+
+function handoffMessage(record) {
+  const commit = record.commit === null ? "none" : record.commit;
+  const commitState = record.uncommitted
+    ? `Commit state: ${record.state} (${commit}; never ready to merge)`
+    : `Commit state: ${record.state} (${commit})`;
+  return {
+    from: record.from,
+    to: record.to,
+    type: "handoff",
+    severity: "action",
+    subject: `Handoff ${record.task}: ${record.state}`,
+    body: [
+      `Handoff record: ${record.id}`,
+      `Result: ${record.result}`,
+      commitState,
+      `Base: ${record.base}`,
+      "Verification:",
+      verificationSummary(record.verification),
+      "Limitations:",
+      limitationsSummary(record.limitations),
+    ].join("\n"),
+    task: record.task,
+    requiresAck: true,
+    attachments: record.artifacts,
+  };
+}
+
+export async function createHandoff(context, input) {
+  const source = handoffInput(input);
+  const artifacts = await canonicalArtifacts(context, source.artifacts);
+  const record = validateHandoff(buildHandoff(context, source, artifacts));
+  await writeJsonAtomic(context.paths.handoffFile(record.id), record, {
+    tmpDir: context.paths.tmp,
+    exclusive: true,
+  });
+  const message = await sendMessage(context, handoffMessage(record));
+  return { record, message };
+}

--- a/prototype/integrated/tools/agents/lib/identity.mjs
+++ b/prototype/integrated/tools/agents/lib/identity.mjs
@@ -1,0 +1,176 @@
+import { createHash } from "node:crypto";
+import { realpath } from "node:fs/promises";
+import path from "node:path";
+
+import { readJsonStrict, writeJsonAtomic } from "./atomic-json.mjs";
+import { CommsError, EXIT } from "./errors.mjs";
+import { ensureBusLayout } from "./paths.mjs";
+import {
+  validateAgentId,
+  validatePresence,
+  validateProtocol,
+  validateRegistry,
+} from "./schema.mjs";
+
+const STALE_HEARTBEAT_MS = 45_000;
+
+async function readIfPresent(filePath, validate) {
+  try {
+    return await readJsonStrict(filePath, validate);
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+async function readRegistryIfPresent(paths, agentId) {
+  return readIfPresent(paths.registryFile(agentId), validateRegistry);
+}
+
+async function readPresenceIfPresent(paths, agentId) {
+  return readIfPresent(paths.presenceFile(agentId), validatePresence);
+}
+
+function inputAgentId(input) {
+  return validateAgentId(input.agentId ?? input.agent_id);
+}
+
+function presenceIsLive(presence, context) {
+  if (presence === null || presence.status !== "online") return false;
+  const heartbeatAt = Date.parse(presence.heartbeat_at);
+  return context.pidIsAlive(presence.pid)
+    && context.now().getTime() - heartbeatAt <= STALE_HEARTBEAT_MS;
+}
+
+function assertRegistrationAllowed(existing, input, presence, context) {
+  if (existing === null) {
+    if (input.resume) {
+      throw new CommsError("cannot resume an unregistered agent", EXIT.CONFLICT);
+    }
+    return;
+  }
+  if (presenceIsLive(presence, context)) {
+    throw new CommsError("agent id already has a live watcher", EXIT.CONFLICT);
+  }
+  if (input.resume && (existing.worktree !== input.worktree || existing.task !== input.task)) {
+    throw new CommsError("resume requires the registered worktree and task", EXIT.CONFLICT);
+  }
+}
+
+function makeRegistryRecord(input, agentId, git, timestamp) {
+  return validateRegistry({
+    schema_version: 1,
+    agent_id: agentId,
+    role: input.role,
+    task: input.task,
+    worktree: input.worktree,
+    branch: git.branch,
+    head: git.head,
+    ownership: input.ownership ?? [],
+    ...(input.client === undefined ? {} : { client: input.client }),
+    status: "open",
+    registered_at: timestamp,
+    updated_at: timestamp,
+  });
+}
+
+async function checkoutIdentity(paths) {
+  try {
+    const checkoutRoot = await realpath(path.dirname(paths.root));
+    const commonDir = await realpath(path.join(checkoutRoot, ".git"));
+    return {
+      checkoutRoot,
+      checkoutId: createHash("sha256").update(commonDir).digest("hex"),
+    };
+  } catch (error) {
+    throw new CommsError("cannot resolve checkout identity", EXIT.DATA, {
+      cause: error.message,
+    });
+  }
+}
+
+export async function initBus(context) {
+  await ensureBusLayout(context.paths);
+  const existing = await readIfPresent(context.paths.protocol, validateProtocol);
+  if (existing !== null) return existing;
+
+  const identity = await checkoutIdentity(context.paths);
+  const record = validateProtocol({
+    schema_version: 1,
+    protocol_version: 1,
+    checkout_id: identity.checkoutId,
+    checkout_root: identity.checkoutRoot,
+    initialized_at: context.now().toISOString(),
+  });
+  try {
+    await writeJsonAtomic(context.paths.protocol, record, {
+      tmpDir: context.paths.tmp,
+      exclusive: true,
+    });
+    return record;
+  } catch (error) {
+    if (!(error instanceof CommsError) || error.exitCode !== EXIT.CONFLICT) throw error;
+    return readJsonStrict(context.paths.protocol, validateProtocol);
+  }
+}
+
+export async function registerAgent(context, input) {
+  const agentId = inputAgentId(input);
+  const existing = await readRegistryIfPresent(context.paths, agentId);
+  const presence = await readPresenceIfPresent(context.paths, agentId);
+  assertRegistrationAllowed(existing, input, presence, context);
+  const git = await context.gitState(input.worktree);
+  const record = makeRegistryRecord(input, agentId, git, context.now().toISOString());
+  await writeJsonAtomic(context.paths.registryFile(agentId), record, {
+    tmpDir: context.paths.tmp,
+    exclusive: existing === null,
+  });
+  return record;
+}
+
+export async function requireOpenAgent(context, agentId) {
+  const validAgentId = validateAgentId(agentId);
+  const registry = await readRegistryIfPresent(context.paths, validAgentId);
+  if (registry === null || registry.status !== "open") {
+    throw new CommsError("agent is not registered and open", EXIT.CONFLICT, {
+      agentId: validAgentId,
+    });
+  }
+  return registry;
+}
+
+export async function closeAgent(context, agentId) {
+  const validAgentId = validateAgentId(agentId);
+  const registry = await readRegistryIfPresent(context.paths, validAgentId);
+  if (registry === null) {
+    throw new CommsError("agent is not registered", EXIT.DATA, { agentId: validAgentId });
+  }
+  const presence = await readPresenceIfPresent(context.paths, validAgentId);
+  if (presenceIsLive(presence, context)) {
+    throw new CommsError("cannot close an agent with a live watcher", EXIT.CONFLICT);
+  }
+  const timestamp = context.now().toISOString();
+  const closed = validateRegistry({
+    ...registry,
+    status: "closed",
+    updated_at: timestamp,
+    closed_at: timestamp,
+  });
+  const offline = validatePresence({
+    schema_version: 1,
+    agent_id: validAgentId,
+    pid: presence?.pid ?? process.pid,
+    status: "offline",
+    heartbeat_at: timestamp,
+  });
+  await writeJsonAtomic(context.paths.registryFile(validAgentId), closed, {
+    tmpDir: context.paths.tmp,
+    exclusive: false,
+  });
+  await writeJsonAtomic(context.paths.presenceFile(validAgentId), offline, {
+    tmpDir: context.paths.tmp,
+    exclusive: false,
+  });
+  await context.releaseOwnedClaims(validAgentId);
+  return closed;
+}

--- a/prototype/integrated/tools/agents/lib/identity.mjs
+++ b/prototype/integrated/tools/agents/lib/identity.mjs
@@ -14,9 +14,9 @@ import {
 
 const STALE_HEARTBEAT_MS = 45_000;
 
-async function readIfPresent(filePath, validate) {
+async function readIfPresent(paths, filePath, validate) {
   try {
-    return await readJsonStrict(filePath, validate);
+    return await readJsonStrict(filePath, validate, paths.root);
   } catch (error) {
     if (error.code === "ENOENT") return null;
     throw error;
@@ -24,11 +24,11 @@ async function readIfPresent(filePath, validate) {
 }
 
 async function readRegistryIfPresent(paths, agentId) {
-  return readIfPresent(paths.registryFile(agentId), validateRegistry);
+  return readIfPresent(paths, paths.registryFile(agentId), validateRegistry);
 }
 
 async function readPresenceIfPresent(paths, agentId) {
-  return readIfPresent(paths.presenceFile(agentId), validatePresence);
+  return readIfPresent(paths, paths.presenceFile(agentId), validatePresence);
 }
 
 function inputAgentId(input) {
@@ -91,7 +91,7 @@ async function checkoutIdentity(paths) {
 
 export async function initBus(context) {
   await ensureBusLayout(context.paths);
-  const existing = await readIfPresent(context.paths.protocol, validateProtocol);
+  const existing = await readIfPresent(context.paths, context.paths.protocol, validateProtocol);
   if (existing !== null) return existing;
 
   const identity = await checkoutIdentity(context.paths);
@@ -110,7 +110,7 @@ export async function initBus(context) {
     return record;
   } catch (error) {
     if (!(error instanceof CommsError) || error.exitCode !== EXIT.CONFLICT) throw error;
-    return readJsonStrict(context.paths.protocol, validateProtocol);
+    return readJsonStrict(context.paths.protocol, validateProtocol, context.paths.root);
   }
 }
 

--- a/prototype/integrated/tools/agents/lib/identity.mjs
+++ b/prototype/integrated/tools/agents/lib/identity.mjs
@@ -11,8 +11,7 @@ import {
   validateProtocol,
   validateRegistry,
 } from "./schema.mjs";
-
-const STALE_HEARTBEAT_MS = 45_000;
+import { inspectWatcherOwnership, withWatcherLifecycle } from "./watcher-ownership.mjs";
 
 async function readIfPresent(paths, filePath, validate) {
   try {
@@ -35,26 +34,30 @@ function inputAgentId(input) {
   return validateAgentId(input.agentId ?? input.agent_id);
 }
 
-function presenceIsLive(presence, context) {
-  if (presence === null || presence.status !== "online") return false;
-  const heartbeatAt = Date.parse(presence.heartbeat_at);
-  return context.pidIsAlive(presence.pid)
-    && context.now().getTime() - heartbeatAt <= STALE_HEARTBEAT_MS;
-}
-
-function assertRegistrationAllowed(existing, input, presence, context) {
+function assertRegistrationAllowed(existing, input) {
   if (existing === null) {
     if (input.resume) {
       throw new CommsError("cannot resume an unregistered agent", EXIT.CONFLICT);
     }
     return;
   }
-  if (presenceIsLive(presence, context)) {
-    throw new CommsError("agent id already has a live watcher", EXIT.CONFLICT);
+  if (existing.status === "closed") {
+    if (input.resume) throw new CommsError("cannot resume a closed agent", EXIT.CONFLICT);
+    return;
   }
-  if (input.resume && (existing.worktree !== input.worktree || existing.task !== input.task)) {
+  if (!input.resume) {
+    throw new CommsError("agent id is already open; use --resume or close it", EXIT.CONFLICT);
+  }
+  if (existing.worktree !== input.worktree || existing.task !== input.task) {
     throw new CommsError("resume requires the registered worktree and task", EXIT.CONFLICT);
   }
+}
+
+async function assertNoWatcherOwner(context, agentId, action) {
+  const ownership = await inspectWatcherOwnership(context, agentId);
+  if (ownership !== null) throw new CommsError(
+    `cannot ${action} while watcher ownership exists; stop or explicitly repair it`,
+    EXIT.CONFLICT, { agentId, owner: ownership.owner });
 }
 
 function makeRegistryRecord(input, agentId, git, timestamp) {
@@ -74,10 +77,13 @@ function makeRegistryRecord(input, agentId, git, timestamp) {
   });
 }
 
-async function checkoutIdentity(paths) {
+async function checkoutIdentity(context) {
   try {
-    const checkoutRoot = await realpath(path.dirname(paths.root));
-    const commonDir = await realpath(path.join(checkoutRoot, ".git"));
+    const commonDirInput = context.gitCommonDir === undefined
+      ? path.join(path.dirname(context.paths.root), ".git")
+      : await context.gitCommonDir();
+    const commonDir = await realpath(commonDirInput.trim());
+    const checkoutRoot = path.dirname(commonDir);
     return {
       checkoutRoot,
       checkoutId: createHash("sha256").update(commonDir).digest("hex"),
@@ -90,11 +96,15 @@ async function checkoutIdentity(paths) {
 }
 
 export async function initBus(context) {
-  await ensureBusLayout(context.paths);
+  const identity = await checkoutIdentity(context);
   const existing = await readIfPresent(context.paths, context.paths.protocol, validateProtocol);
-  if (existing !== null) return existing;
+  if (existing !== null) {
+    assertCheckoutIdentity(existing, identity);
+    await ensureBusLayout(context.paths);
+    return existing;
+  }
 
-  const identity = await checkoutIdentity(context.paths);
+  await ensureBusLayout(context.paths);
   const record = validateProtocol({
     schema_version: 1,
     protocol_version: 1,
@@ -110,22 +120,60 @@ export async function initBus(context) {
     return record;
   } catch (error) {
     if (!(error instanceof CommsError) || error.exitCode !== EXIT.CONFLICT) throw error;
-    return readJsonStrict(context.paths.protocol, validateProtocol, context.paths.root);
+    return assertCheckoutIdentity(await readJsonStrict(context.paths.protocol, validateProtocol,
+      context.paths.root), identity);
   }
+}
+
+function assertCheckoutIdentity(record, identity) {
+  if (record.checkout_id !== identity.checkoutId
+    || record.checkout_root !== identity.checkoutRoot) {
+    throw new CommsError("protocol belongs to a different checkout", EXIT.DATA, {
+      expectedCheckoutId: identity.checkoutId, actualCheckoutId: record.checkout_id,
+      expectedCheckoutRoot: identity.checkoutRoot, actualCheckoutRoot: record.checkout_root,
+    });
+  }
+  return record;
+}
+
+export async function requireCheckoutProtocol(context, options = {}) {
+  let record;
+  try {
+    record = await readJsonStrict(context.paths.protocol, validateProtocol, context.paths.root);
+  } catch (error) {
+    if (options.allowInvalid && (error.code === "ENOENT"
+      || error instanceof CommsError && error.exitCode === EXIT.DATA)) {
+      if (!options.repair) return null;
+      const identity = await checkoutIdentity(context);
+      const canonicalBus = path.join(identity.checkoutRoot, ".agents");
+      if (path.resolve(context.paths.root) === canonicalBus) return null;
+      throw new CommsError(
+        "cannot prove checkout identity for repair on a noncanonical bus",
+        EXIT.DATA,
+        { busRoot: context.paths.root, canonicalBus },
+      );
+    }
+    if (error.code === "ENOENT") throw new CommsError(
+      "agent bus protocol is not initialized; run init", EXIT.DATA);
+    throw error;
+  }
+  return assertCheckoutIdentity(record, await checkoutIdentity(context));
 }
 
 export async function registerAgent(context, input) {
   const agentId = inputAgentId(input);
-  const existing = await readRegistryIfPresent(context.paths, agentId);
-  const presence = await readPresenceIfPresent(context.paths, agentId);
-  assertRegistrationAllowed(existing, input, presence, context);
-  const git = await context.gitState(input.worktree);
-  const record = makeRegistryRecord(input, agentId, git, context.now().toISOString());
-  await writeJsonAtomic(context.paths.registryFile(agentId), record, {
-    tmpDir: context.paths.tmp,
-    exclusive: existing === null,
+  return withWatcherLifecycle(context, agentId, async () => {
+    const existing = await readRegistryIfPresent(context.paths, agentId);
+    assertRegistrationAllowed(existing, input);
+    await assertNoWatcherOwner(context, agentId, "register");
+    const git = await context.gitState(input.worktree);
+    const record = makeRegistryRecord(input, agentId, git, context.now().toISOString());
+    await writeJsonAtomic(context.paths.registryFile(agentId), record, {
+      tmpDir: context.paths.tmp,
+      exclusive: existing === null,
+    });
+    return record;
   });
-  return record;
 }
 
 export async function requireOpenAgent(context, agentId) {
@@ -141,36 +189,22 @@ export async function requireOpenAgent(context, agentId) {
 
 export async function closeAgent(context, agentId) {
   const validAgentId = validateAgentId(agentId);
-  const registry = await readRegistryIfPresent(context.paths, validAgentId);
-  if (registry === null) {
-    throw new CommsError("agent is not registered", EXIT.DATA, { agentId: validAgentId });
-  }
-  const presence = await readPresenceIfPresent(context.paths, validAgentId);
-  if (presenceIsLive(presence, context)) {
-    throw new CommsError("cannot close an agent with a live watcher", EXIT.CONFLICT);
-  }
-  const timestamp = context.now().toISOString();
-  const closed = validateRegistry({
-    ...registry,
-    status: "closed",
-    updated_at: timestamp,
-    closed_at: timestamp,
+  return withWatcherLifecycle(context, validAgentId, async () => {
+    const registry = await readRegistryIfPresent(context.paths, validAgentId);
+    if (registry === null) throw new CommsError(
+      "agent is not registered", EXIT.DATA, { agentId: validAgentId });
+    await assertNoWatcherOwner(context, validAgentId, "close");
+    const presence = await readPresenceIfPresent(context.paths, validAgentId);
+    const timestamp = context.now().toISOString();
+    const closed = validateRegistry({ ...registry, status: "closed",
+      updated_at: timestamp, closed_at: timestamp });
+    const offline = validatePresence({ schema_version: 1, agent_id: validAgentId,
+      pid: presence?.pid ?? process.pid, status: "offline", heartbeat_at: timestamp });
+    await writeJsonAtomic(context.paths.registryFile(validAgentId), closed, {
+      tmpDir: context.paths.tmp, exclusive: false });
+    await writeJsonAtomic(context.paths.presenceFile(validAgentId), offline, {
+      tmpDir: context.paths.tmp, exclusive: false });
+    await context.releaseOwnedClaims(validAgentId);
+    return closed;
   });
-  const offline = validatePresence({
-    schema_version: 1,
-    agent_id: validAgentId,
-    pid: presence?.pid ?? process.pid,
-    status: "offline",
-    heartbeat_at: timestamp,
-  });
-  await writeJsonAtomic(context.paths.registryFile(validAgentId), closed, {
-    tmpDir: context.paths.tmp,
-    exclusive: false,
-  });
-  await writeJsonAtomic(context.paths.presenceFile(validAgentId), offline, {
-    tmpDir: context.paths.tmp,
-    exclusive: false,
-  });
-  await context.releaseOwnedClaims(validAgentId);
-  return closed;
 }

--- a/prototype/integrated/tools/agents/lib/message-id.mjs
+++ b/prototype/integrated/tools/agents/lib/message-id.mjs
@@ -1,0 +1,12 @@
+import { CommsError, EXIT } from "./errors.mjs";
+
+const PORTABLE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$/;
+const WINDOWS_DEVICE = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i;
+
+export function validateMessageId(value, name = "message id") {
+  if (typeof value !== "string" || !PORTABLE_ID.test(value)
+    || value.endsWith(".") || WINDOWS_DEVICE.test(value)) {
+    throw new CommsError(`invalid ${name}`, EXIT.DATA, { value });
+  }
+  return value;
+}

--- a/prototype/integrated/tools/agents/lib/messages.mjs
+++ b/prototype/integrated/tools/agents/lib/messages.mjs
@@ -1,0 +1,280 @@
+import { randomUUID } from "node:crypto";
+import { access, readFile } from "node:fs/promises";
+import { isDeepStrictEqual } from "node:util";
+
+import { verifyAttachment } from "./attachments.mjs";
+import {
+  listJsonFiles,
+  moveFileAtomic,
+  readJsonStrict,
+  writeJsonAtomic,
+} from "./atomic-json.mjs";
+import { CommsError, EXIT } from "./errors.mjs";
+import { requireOpenAgent } from "./identity.mjs";
+import {
+  MESSAGE_TYPES,
+  SEVERITIES,
+  validateAcknowledgement,
+  validateMessage,
+  validateSeenReceipt,
+} from "./schema.mjs";
+
+async function exists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch (error) {
+    if (error.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function messageId(timestamp, sender, uuid) {
+  return `${timestamp.replaceAll("-", "").replaceAll(":", "")}-${sender}-${uuid}`;
+}
+
+async function bodyFrom(input) {
+  const sources = [input.body, input.bodyFile, input.stdin]
+    .filter(value => value !== undefined);
+  if (sources.length !== 1) {
+    throw new CommsError("message requires exactly one body source", EXIT.DATA);
+  }
+  if (input.body !== undefined) return input.body;
+  if (input.stdin !== undefined) return input.stdin;
+  try {
+    return await readFile(input.bodyFile, "utf8");
+  } catch (error) {
+    throw new CommsError("cannot read message body file", EXIT.DATA, {
+      filePath: input.bodyFile,
+      cause: error.message,
+    });
+  }
+}
+
+function buildMessage(context, input, sender, body) {
+  const createdAt = context.now().toISOString();
+  return {
+    schema_version: 1,
+    id: messageId(createdAt, input.from, (context.randomUUID ?? randomUUID)()),
+    from: input.from,
+    to: input.to,
+    type: input.type,
+    severity: input.severity,
+    subject: input.subject,
+    body,
+    task: input.task ?? sender.task,
+    reply_to: input.replyTo ?? null,
+    requires_ack: input.requiresAck ?? false,
+    created_at: createdAt,
+    sender_head: sender.head,
+    attachments: input.attachments ?? [],
+  };
+}
+
+function assertMessageId(value) {
+  if (typeof value !== "string" || value.length === 0
+    || value.includes("/") || value.includes("\\")) {
+    throw new CommsError("invalid message id", EXIT.DATA, { value });
+  }
+  return value;
+}
+
+function selected(value, allowed, name) {
+  if (value === undefined) return null;
+  if (!Array.isArray(value) || value.some(item => !allowed.includes(item))) {
+    throw new CommsError(`invalid ${name} filter`, EXIT.DATA, { value });
+  }
+  return new Set(value);
+}
+
+async function readMessageIfPresent(filePath) {
+  try {
+    return await readJsonStrict(filePath, validateMessage);
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+async function messageForRecipient(context, recipient, id) {
+  const inboxPath = context.paths.inboxFile(recipient, id);
+  const archivePath = context.paths.archiveFile(recipient, id);
+  const inboxMessage = await readMessageIfPresent(inboxPath);
+  if (inboxMessage !== null) return { message: inboxMessage, inboxPath, archivePath };
+  const archivedMessage = await readMessageIfPresent(archivePath);
+  if (archivedMessage !== null) return { message: archivedMessage, inboxPath, archivePath };
+  throw new CommsError("message does not exist for recipient", EXIT.DATA, {
+    messageId: id,
+    recipient,
+  });
+}
+
+export async function sendMessage(context, input) {
+  const sender = await requireOpenAgent(context, input.from);
+  await requireOpenAgent(context, input.to);
+  const body = await bodyFrom(input);
+  const message = validateMessage(buildMessage(context, input, sender, body));
+  await Promise.all(message.attachments.map(record => verifyAttachment(context, record)));
+  await writeJsonAtomic(context.paths.inboxFile(input.to, message.id), message, {
+    tmpDir: context.paths.tmp,
+    exclusive: true,
+  });
+  return message;
+}
+
+export async function listInbox(context, input) {
+  const recipient = (await requireOpenAgent(context, input.agentId)).agent_id;
+  const types = selected(input.types, MESSAGE_TYPES, "type");
+  const severities = selected(input.severities, SEVERITIES, "severity");
+  const files = await listJsonFiles(context.paths.inboxDir(recipient));
+  const items = [];
+  for (const filePath of files) {
+    const message = await readJsonStrict(filePath, validateMessage);
+    if (message.to !== recipient) {
+      throw new CommsError("inbox message has wrong recipient", EXIT.DATA, { filePath });
+    }
+    const acknowledgement = await receiptIfPresent(
+      context.paths.ackFile(message.id, recipient),
+      validateAcknowledgement,
+    );
+    if (acknowledgement !== null) {
+      assertReceiptBinding(acknowledgement, message.id, recipient, "acknowledgement");
+      continue;
+    }
+    if (types !== null && !types.has(message.type)) continue;
+    if (severities !== null && !severities.has(message.severity)) continue;
+    const seen = await receiptIfPresent(
+      context.paths.seenFile(message.id, recipient),
+      validateSeenReceipt,
+    );
+    if (seen !== null) assertReceiptBinding(seen, message.id, recipient, "seen receipt");
+    const state = seen === null ? "unseen" : "seen";
+    items.push({ message, state });
+  }
+  return items;
+}
+
+export async function markSeen(context, message, recipient) {
+  const validMessage = validateMessage(message);
+  const agent = await requireOpenAgent(context, recipient);
+  if (validMessage.to !== agent.agent_id) {
+    throw new CommsError("only the message recipient can mark it seen", EXIT.CONFLICT);
+  }
+  const persisted = await readMessageIfPresent(
+    context.paths.inboxFile(agent.agent_id, validMessage.id),
+  );
+  if (persisted === null || !isDeepStrictEqual(persisted, validMessage)) {
+    throw new CommsError("seen receipt requires the persisted inbox message", EXIT.DATA, {
+      messageId: validMessage.id,
+      recipient: agent.agent_id,
+    });
+  }
+  const receipt = validateSeenReceipt({
+    schema_version: 1,
+    message_id: validMessage.id,
+    recipient: agent.agent_id,
+    seen_at: context.now().toISOString(),
+  });
+  const filePath = context.paths.seenFile(validMessage.id, agent.agent_id);
+  try {
+    await writeJsonAtomic(filePath, receipt, {
+      tmpDir: context.paths.tmp,
+      exclusive: true,
+    });
+  } catch (error) {
+    if (!(error instanceof CommsError) || error.exitCode !== EXIT.CONFLICT) throw error;
+    const existing = await readJsonStrict(filePath, validateSeenReceipt);
+    assertReceiptBinding(existing, validMessage.id, agent.agent_id, "seen receipt");
+    return existing;
+  }
+  return receipt;
+}
+
+async function receiptIfPresent(filePath, validate) {
+  try {
+    return await readJsonStrict(filePath, validate);
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function assertReceiptBinding(receipt, messageId, recipient, name) {
+  if (receipt.message_id !== messageId || receipt.recipient !== recipient) {
+    throw new CommsError(`${name} does not match its message`, EXIT.DATA, {
+      messageId,
+      recipient,
+    });
+  }
+}
+
+export async function ackMessage(context, input) {
+  const recipient = (await requireOpenAgent(context, input.agentId)).agent_id;
+  const id = assertMessageId(input.messageId);
+  const stored = await messageForRecipient(context, recipient, id);
+  if (stored.message.to !== recipient) {
+    throw new CommsError("only the message recipient can acknowledge it", EXIT.CONFLICT);
+  }
+  let acknowledgement = await receiptIfPresent(
+    context.paths.ackFile(id, recipient),
+    validateAcknowledgement,
+  );
+  if (acknowledgement !== null) {
+    assertReceiptBinding(acknowledgement, id, recipient, "acknowledgement");
+  }
+  if (acknowledgement === null) {
+    acknowledgement = validateAcknowledgement({
+      schema_version: 1,
+      message_id: id,
+      recipient,
+      acknowledged_at: context.now().toISOString(),
+    });
+    try {
+      await writeJsonAtomic(context.paths.ackFile(id, recipient), acknowledgement, {
+        tmpDir: context.paths.tmp,
+        exclusive: true,
+      });
+    } catch (error) {
+      if (!(error instanceof CommsError) || error.exitCode !== EXIT.CONFLICT) throw error;
+      acknowledgement = await readJsonStrict(
+        context.paths.ackFile(id, recipient),
+        validateAcknowledgement,
+      );
+      assertReceiptBinding(acknowledgement, id, recipient, "acknowledgement");
+    }
+  }
+  if (await exists(stored.inboxPath)) {
+    try {
+      await moveFileAtomic(stored.inboxPath, stored.archivePath);
+    } catch (error) {
+      if (error.code !== "ENOENT" || !(await exists(stored.archivePath))) throw error;
+    }
+  }
+  return acknowledgement;
+}
+
+export async function replyToMessage(context, input) {
+  const sender = (await requireOpenAgent(context, input.from)).agent_id;
+  const original = (await messageForRecipient(
+    context,
+    sender,
+    assertMessageId(input.messageId),
+  )).message;
+  return sendMessage(context, {
+    ...input,
+    to: original.from,
+    replyTo: original.id,
+  });
+}
+
+export async function broadcastMessage(context, input) {
+  await requireOpenAgent(context, input.from);
+  const active = [...new Set(await context.listActiveAgentIds())]
+    .filter(agentId => agentId !== input.from)
+    .sort((left, right) => left.localeCompare(right));
+  return Promise.all(active.map(to => sendMessage(context, {
+    ...input,
+    to,
+    type: "broadcast",
+  })));
+}

--- a/prototype/integrated/tools/agents/lib/messages.mjs
+++ b/prototype/integrated/tools/agents/lib/messages.mjs
@@ -1,16 +1,19 @@
 import { randomUUID } from "node:crypto";
-import { access, readFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 
 import { verifyAttachment } from "./attachments.mjs";
 import {
+  archiveFileNoReplace,
   listJsonFiles,
-  moveFileAtomic,
   readJsonStrict,
   writeJsonAtomic,
 } from "./atomic-json.mjs";
 import { CommsError, EXIT } from "./errors.mjs";
 import { requireOpenAgent } from "./identity.mjs";
+import { validateMessageId } from "./message-id.mjs";
+import { readJsonRegularNoFollow } from "./safe-file.mjs";
 import {
   MESSAGE_TYPES,
   SEVERITIES,
@@ -18,16 +21,6 @@ import {
   validateMessage,
   validateSeenReceipt,
 } from "./schema.mjs";
-
-async function exists(filePath) {
-  try {
-    await access(filePath);
-    return true;
-  } catch (error) {
-    if (error.code === "ENOENT") return false;
-    throw error;
-  }
-}
 
 function messageId(timestamp, sender, uuid) {
   return `${timestamp.replaceAll("-", "").replaceAll(":", "")}-${sender}-${uuid}`;
@@ -71,14 +64,6 @@ function buildMessage(context, input, sender, body) {
   };
 }
 
-function assertMessageId(value) {
-  if (typeof value !== "string" || value.length === 0
-    || value.includes("/") || value.includes("\\")) {
-    throw new CommsError("invalid message id", EXIT.DATA, { value });
-  }
-  return value;
-}
-
 function selected(value, allowed, name) {
   if (value === undefined) return null;
   if (!Array.isArray(value) || value.some(item => !allowed.includes(item))) {
@@ -87,9 +72,23 @@ function selected(value, allowed, name) {
   return new Set(value);
 }
 
-async function readMessageIfPresent(filePath) {
+function assertMessageBinding(message, filePath, recipient) {
+  if (path.basename(filePath) !== `${message.id}.json`
+    || path.basename(path.dirname(filePath)) !== recipient
+    || message.to !== recipient) {
+    throw new CommsError("message does not match its recipient path", EXIT.DATA, {
+      filePath,
+      messageId: message.id,
+      recipient,
+    });
+  }
+}
+
+async function readMessageIfPresent(filePath, recipient, root) {
   try {
-    return await readJsonStrict(filePath, validateMessage);
+    const stored = await readJsonRegularNoFollow(filePath, validateMessage, root);
+    assertMessageBinding(stored.record, filePath, recipient);
+    return { message: stored.record, bytes: stored.bytes };
   } catch (error) {
     if (error.code === "ENOENT") return null;
     throw error;
@@ -97,12 +96,13 @@ async function readMessageIfPresent(filePath) {
 }
 
 async function messageForRecipient(context, recipient, id) {
-  const inboxPath = context.paths.inboxFile(recipient, id);
-  const archivePath = context.paths.archiveFile(recipient, id);
-  const inboxMessage = await readMessageIfPresent(inboxPath);
-  if (inboxMessage !== null) return { message: inboxMessage, inboxPath, archivePath };
-  const archivedMessage = await readMessageIfPresent(archivePath);
-  if (archivedMessage !== null) return { message: archivedMessage, inboxPath, archivePath };
+  const validId = validateMessageId(id);
+  const inboxPath = context.paths.inboxFile(recipient, validId);
+  const archivePath = context.paths.archiveFile(recipient, validId);
+  const inbox = await readMessageIfPresent(inboxPath, recipient, context.paths.root);
+  if (inbox !== null) return { ...inbox, inboxPath, archivePath };
+  const archived = await readMessageIfPresent(archivePath, recipient, context.paths.root);
+  if (archived !== null) return { ...archived, inboxPath, archivePath };
   throw new CommsError("message does not exist for recipient", EXIT.DATA, {
     messageId: id,
     recipient,
@@ -126,16 +126,18 @@ export async function listInbox(context, input) {
   const recipient = (await requireOpenAgent(context, input.agentId)).agent_id;
   const types = selected(input.types, MESSAGE_TYPES, "type");
   const severities = selected(input.severities, SEVERITIES, "severity");
-  const files = await listJsonFiles(context.paths.inboxDir(recipient));
+  const files = await listJsonFiles(context.paths.inboxDir(recipient), {
+    root: context.paths.root,
+  });
   const items = [];
   for (const filePath of files) {
-    const message = await readJsonStrict(filePath, validateMessage);
-    if (message.to !== recipient) {
-      throw new CommsError("inbox message has wrong recipient", EXIT.DATA, { filePath });
-    }
+    const stored = await readMessageIfPresent(filePath, recipient, context.paths.root);
+    if (stored === null) continue;
+    const message = stored.message;
     const acknowledgement = await receiptIfPresent(
       context.paths.ackFile(message.id, recipient),
       validateAcknowledgement,
+      context.paths.root,
     );
     if (acknowledgement !== null) {
       assertReceiptBinding(acknowledgement, message.id, recipient, "acknowledgement");
@@ -146,6 +148,7 @@ export async function listInbox(context, input) {
     const seen = await receiptIfPresent(
       context.paths.seenFile(message.id, recipient),
       validateSeenReceipt,
+      context.paths.root,
     );
     if (seen !== null) assertReceiptBinding(seen, message.id, recipient, "seen receipt");
     const state = seen === null ? "unseen" : "seen";
@@ -162,8 +165,10 @@ export async function markSeen(context, message, recipient) {
   }
   const persisted = await readMessageIfPresent(
     context.paths.inboxFile(agent.agent_id, validMessage.id),
+    agent.agent_id,
+    context.paths.root,
   );
-  if (persisted === null || !isDeepStrictEqual(persisted, validMessage)) {
+  if (persisted === null || !isDeepStrictEqual(persisted.message, validMessage)) {
     throw new CommsError("seen receipt requires the persisted inbox message", EXIT.DATA, {
       messageId: validMessage.id,
       recipient: agent.agent_id,
@@ -183,16 +188,16 @@ export async function markSeen(context, message, recipient) {
     });
   } catch (error) {
     if (!(error instanceof CommsError) || error.exitCode !== EXIT.CONFLICT) throw error;
-    const existing = await readJsonStrict(filePath, validateSeenReceipt);
+    const existing = await readJsonStrict(filePath, validateSeenReceipt, context.paths.root);
     assertReceiptBinding(existing, validMessage.id, agent.agent_id, "seen receipt");
     return existing;
   }
   return receipt;
 }
 
-async function receiptIfPresent(filePath, validate) {
+async function receiptIfPresent(filePath, validate, root) {
   try {
-    return await readJsonStrict(filePath, validate);
+    return await readJsonStrict(filePath, validate, root);
   } catch (error) {
     if (error.code === "ENOENT") return null;
     throw error;
@@ -210,7 +215,7 @@ function assertReceiptBinding(receipt, messageId, recipient, name) {
 
 export async function ackMessage(context, input) {
   const recipient = (await requireOpenAgent(context, input.agentId)).agent_id;
-  const id = assertMessageId(input.messageId);
+  const id = validateMessageId(input.messageId);
   const stored = await messageForRecipient(context, recipient, id);
   if (stored.message.to !== recipient) {
     throw new CommsError("only the message recipient can acknowledge it", EXIT.CONFLICT);
@@ -218,6 +223,7 @@ export async function ackMessage(context, input) {
   let acknowledgement = await receiptIfPresent(
     context.paths.ackFile(id, recipient),
     validateAcknowledgement,
+    context.paths.root,
   );
   if (acknowledgement !== null) {
     assertReceiptBinding(acknowledgement, id, recipient, "acknowledgement");
@@ -239,17 +245,15 @@ export async function ackMessage(context, input) {
       acknowledgement = await readJsonStrict(
         context.paths.ackFile(id, recipient),
         validateAcknowledgement,
+        context.paths.root,
       );
       assertReceiptBinding(acknowledgement, id, recipient, "acknowledgement");
     }
   }
-  if (await exists(stored.inboxPath)) {
-    try {
-      await moveFileAtomic(stored.inboxPath, stored.archivePath);
-    } catch (error) {
-      if (error.code !== "ENOENT" || !(await exists(stored.archivePath))) throw error;
-    }
-  }
+  await archiveFileNoReplace(stored.inboxPath, stored.archivePath, {
+    root: context.paths.root,
+    expectedBytes: stored.bytes,
+  });
   return acknowledgement;
 }
 
@@ -258,7 +262,7 @@ export async function replyToMessage(context, input) {
   const original = (await messageForRecipient(
     context,
     sender,
-    assertMessageId(input.messageId),
+    validateMessageId(input.messageId),
   )).message;
   return sendMessage(context, {
     ...input,

--- a/prototype/integrated/tools/agents/lib/paths.mjs
+++ b/prototype/integrated/tools/agents/lib/paths.mjs
@@ -1,0 +1,71 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+
+import { CommsError, EXIT } from "./errors.mjs";
+
+const DIRECTORY_NAMES = Object.freeze([
+  "registry",
+  "presence",
+  "inbox",
+  "seen",
+  "acknowledgements",
+  "claims",
+  "handoffs",
+  "archive",
+  "artifacts",
+  "locks",
+  "quarantine",
+  "tmp",
+]);
+
+export async function resolveBusDir({ cwd, env = process.env, runGit }) {
+  if (env.PW2_AGENT_BUS_DIR) return path.resolve(env.PW2_AGENT_BUS_DIR);
+  const commonDir = path.resolve(cwd, (await runGit(cwd)).trim());
+  if (path.basename(commonDir) !== ".git") {
+    throw new CommsError(
+      "cannot infer checkout root; set PW2_AGENT_BUS_DIR",
+      EXIT.DATA,
+    );
+  }
+  return path.join(path.dirname(commonDir), ".agents");
+}
+
+export function createBusPaths(busDir) {
+  const root = path.resolve(busDir);
+  const directories = Object.fromEntries(
+    DIRECTORY_NAMES.map(name => [name, path.join(root, name)]),
+  );
+
+  return Object.freeze({
+    root,
+    protocol: path.join(root, "protocol.json"),
+    ...directories,
+    registryFile: agentId => path.join(directories.registry, `${agentId}.json`),
+    presenceFile: agentId => path.join(directories.presence, `${agentId}.json`),
+    inboxDir: agentId => path.join(directories.inbox, agentId),
+    inboxFile: (agentId, messageId) => path.join(
+      directories.inbox,
+      agentId,
+      `${messageId}.json`,
+    ),
+    seenFile: (messageId, recipient) => path.join(
+      directories.seen,
+      `${messageId}--${recipient}.json`,
+    ),
+    ackFile: (messageId, recipient) => path.join(
+      directories.acknowledgements,
+      `${messageId}--${recipient}.json`,
+    ),
+    handoffFile: handoffId => path.join(directories.handoffs, `${handoffId}.json`),
+    archiveDir: agentId => path.join(directories.archive, agentId),
+    archiveFile: (agentId, messageId) => path.join(
+      directories.archive,
+      agentId,
+      `${messageId}.json`,
+    ),
+  });
+}
+
+export async function ensureBusLayout(paths) {
+  await Promise.all(DIRECTORY_NAMES.map(name => mkdir(paths[name], { recursive: true })));
+}

--- a/prototype/integrated/tools/agents/lib/paths.mjs
+++ b/prototype/integrated/tools/agents/lib/paths.mjs
@@ -1,7 +1,7 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 
 import { CommsError, EXIT } from "./errors.mjs";
+import { ensureManagedDirectory } from "./safe-directory.mjs";
 
 const DIRECTORY_NAMES = Object.freeze([
   "registry",
@@ -19,7 +19,14 @@ const DIRECTORY_NAMES = Object.freeze([
 ]);
 
 export async function resolveBusDir({ cwd, env = process.env, runGit }) {
-  if (env.PW2_AGENT_BUS_DIR) return path.resolve(env.PW2_AGENT_BUS_DIR);
+  if (env.PW2_AGENT_BUS_DIR !== undefined) {
+    if (typeof env.PW2_AGENT_BUS_DIR !== "string"
+      || !path.isAbsolute(env.PW2_AGENT_BUS_DIR)) {
+      throw new CommsError("PW2_AGENT_BUS_DIR must be absolute", EXIT.DATA,
+        { value: env.PW2_AGENT_BUS_DIR });
+    }
+    return path.resolve(env.PW2_AGENT_BUS_DIR);
+  }
   const commonDir = path.resolve(cwd, (await runGit(cwd)).trim());
   if (path.basename(commonDir) !== ".git") {
     throw new CommsError(
@@ -67,5 +74,8 @@ export function createBusPaths(busDir) {
 }
 
 export async function ensureBusLayout(paths) {
-  await Promise.all(DIRECTORY_NAMES.map(name => mkdir(paths[name], { recursive: true })));
+  await ensureManagedDirectory(paths.root, paths.root);
+  for (const name of DIRECTORY_NAMES) {
+    await ensureManagedDirectory(paths.root, paths[name]);
+  }
 }

--- a/prototype/integrated/tools/agents/lib/presence.mjs
+++ b/prototype/integrated/tools/agents/lib/presence.mjs
@@ -1,0 +1,203 @@
+import { watch as fsWatch } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { CommsError, EXIT } from "./errors.mjs";
+import { requireOpenAgent } from "./identity.mjs";
+import { listInbox, markSeen } from "./messages.mjs";
+import { validatePresence } from "./schema.mjs";
+import {
+  acquireWatcherOwnership, inspectWatcherOwnership, repairStaleWatcherOwnership,
+  writePresenceIfWatcherOwner,
+} from "./watcher-ownership.mjs";
+export { inspectWatcherOwnership, repairStaleWatcherOwnership };
+const STALE_HEARTBEAT_MS = 45_000;
+const DEFAULT_HEARTBEAT_MS = 15_000;
+const DEFAULT_SCAN_INTERVAL_MS = 2_000;
+const DEFAULT_WAIT_TIMEOUT_MS = 60_000;
+const DEFAULT_SCHEDULER = Object.freeze({
+  setInterval: (callback, delay) => setInterval(callback, delay),
+  setTimeout: (callback, delay) => setTimeout(callback, delay),
+  clearInterval: handle => clearInterval(handle),
+  clearTimeout: handle => clearTimeout(handle),
+});
+function duration(value, fallback, name, minimum = 1) {
+  const result = value ?? fallback;
+  if (!Number.isInteger(result) || result < minimum) {
+    throw new CommsError(`${name} must be an integer of at least ${minimum}`, EXIT.DATA);
+  }
+  return result;
+}
+function defaultOutput(event) {
+  return new Promise((resolve, reject) => {
+    process.stdout.write(`${JSON.stringify(event)}\n\u0007`, error => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+function messageEvent(message) {
+  return Object.freeze({ event: "message", message, state: "unseen" });
+}
+export function presenceState(record, now, pidIsAlive) {
+  const presence = validatePresence(record);
+  if (presence.status === "offline" || !pidIsAlive(presence.pid)) return "offline";
+  return now.getTime() - Date.parse(presence.heartbeat_at) > STALE_HEARTBEAT_MS
+    ? "stale"
+    : "online";
+}
+export async function startWatcher(context, input) {
+  const registry = await requireOpenAgent(context, input.agentId);
+  const agentId = registry.agent_id;
+  const pid = input.pid ?? context.pid ?? process.pid;
+  const scheduler = context.scheduler ?? DEFAULT_SCHEDULER;
+  const watchDirectory = context.watchDirectory ?? fsWatch;
+  const output = context.output ?? defaultOutput;
+  const heartbeatMs = duration(input.heartbeatMs, DEFAULT_HEARTBEAT_MS, "heartbeat");
+  const scanIntervalMs = duration(input.scanIntervalMs, DEFAULT_SCAN_INTERVAL_MS,
+    "scan interval");
+  const printed = new Set();
+  let stopped = false;
+  let fileWatcher = null;
+  let scanHandle = null;
+  let heartbeatHandle = null;
+  let scanTail = Promise.resolve();
+  let heartbeatTail = Promise.resolve();
+  let terminalPromise = null;
+  let resolveDone;
+  let rejectDone;
+  const done = new Promise((resolve, reject) => {
+    [resolveDone, rejectDone] = [resolve, reject];
+  });
+  done.catch(() => undefined);
+  let ownership = null;
+  async function scanInbox() {
+    const items = await listInbox(context, { agentId });
+    for (const item of items) {
+      if (item.state !== "unseen" || printed.has(item.message.id)) continue;
+      await output(messageEvent(item.message));
+      printed.add(item.message.id);
+      await markSeen(context, item.message, agentId);
+    }
+  }
+  async function heartbeat() {
+    if (!await writePresenceIfWatcherOwner(context, ownership, "online")) {
+      throw new CommsError("watcher ownership was lost", EXIT.CONFLICT, { agentId });
+    }
+    await context.extendOwnedClaims(agentId);
+  }
+  function queueScan() {
+    const task = scanTail.then(() => stopped ? undefined : scanInbox());
+    scanTail = task.catch(() => undefined);
+    task.catch(error => { void terminate(error); });
+    return task;
+  }
+  function queueHeartbeat() {
+    const task = heartbeatTail.then(() => stopped ? undefined : heartbeat());
+    heartbeatTail = task.catch(() => undefined);
+    task.catch(error => { void terminate(error); });
+    return task;
+  }
+  function closeEventSources() {
+    if (scanHandle !== null) scheduler.clearInterval(scanHandle);
+    if (heartbeatHandle !== null) scheduler.clearInterval(heartbeatHandle);
+    fileWatcher?.close();
+  }
+  function terminate(error = null) {
+    if (terminalPromise !== null) return terminalPromise;
+    stopped = true;
+    closeEventSources();
+    terminalPromise = (async () => {
+      await scanTail;
+      await heartbeatTail;
+      try {
+        await writePresenceIfWatcherOwner(context, ownership, "offline", true);
+      } catch (offlineError) {
+        rejectDone(error ?? offlineError);
+        throw offlineError;
+      }
+      if (error === null) resolveDone();
+      else rejectDone(error);
+    })();
+    return terminalPromise;
+  }
+  ownership = await acquireWatcherOwnership(context, agentId, pid);
+  heartbeatHandle = scheduler.setInterval(() => queueHeartbeat().catch(() => undefined),
+    heartbeatMs);
+  try {
+    await context.extendOwnedClaims(agentId);
+    await mkdir(context.paths.inboxDir(agentId), { recursive: true });
+    fileWatcher = watchDirectory(context.paths.inboxDir(agentId),
+      () => queueScan().catch(() => undefined));
+    if (typeof fileWatcher.once === "function") {
+      fileWatcher.once("error", error => { void terminate(error); });
+    }
+    await queueScan();
+  } catch (error) {
+    await terminate(error);
+    throw error;
+  }
+  scanHandle = scheduler.setInterval(() => queueScan().catch(() => undefined),
+    scanIntervalMs);
+  return Object.freeze({ stop: () => terminate(), done });
+}
+
+export async function waitForMessage(context, input) {
+  const agentId = (await requireOpenAgent(context, input.agentId)).agent_id;
+  const scheduler = context.scheduler ?? DEFAULT_SCHEDULER;
+  const watchDirectory = context.watchDirectory ?? fsWatch;
+  const readInbox = context.listInbox ?? (request => listInbox(context, request));
+  const timeoutMs = duration(input.timeoutMs, DEFAULT_WAIT_TIMEOUT_MS, "timeout", 0);
+  const scanIntervalMs = duration(input.scanIntervalMs, DEFAULT_SCAN_INTERVAL_MS,
+    "scan interval");
+  await mkdir(context.paths.inboxDir(agentId), { recursive: true });
+
+  let settled = false;
+  let fileWatcher = null;
+  let timeoutHandle = null;
+  let scanHandle = null;
+  let scanTail = Promise.resolve();
+  let resolveResult;
+  let rejectResult;
+  const result = new Promise((resolve, reject) => {
+    [resolveResult, rejectResult] = [resolve, reject];
+  });
+
+  function cleanup() {
+    fileWatcher?.close();
+    if (timeoutHandle !== null) scheduler.clearTimeout(timeoutHandle);
+    if (scanHandle !== null) scheduler.clearInterval(scanHandle);
+  }
+
+  function finish(value, error = null) {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    if (error === null) resolveResult(value);
+    else rejectResult(error);
+  }
+
+  async function scan() {
+    const unseen = (await readInbox({ agentId }))
+      .find(item => item.state === "unseen");
+    if (unseen !== undefined) finish(unseen.message);
+  }
+
+  function queueScan() {
+    const task = scanTail.then(() => settled ? undefined : scan());
+    scanTail = task.catch(() => undefined);
+    task.catch(error => finish(null, error));
+    return task;
+  }
+
+  fileWatcher = watchDirectory(context.paths.inboxDir(agentId),
+    () => queueScan().catch(() => undefined));
+  if (typeof fileWatcher.once === "function") {
+    fileWatcher.once("error", error => finish(null, error));
+  }
+  await queueScan().catch(() => undefined);
+  await scanTail;
+  if (settled) return result;
+  timeoutHandle = scheduler.setTimeout(() => finish(null), timeoutMs);
+  scanHandle = scheduler.setInterval(() => queueScan().catch(() => undefined),
+    scanIntervalMs);
+  return result;
+}

--- a/prototype/integrated/tools/agents/lib/presence.mjs
+++ b/prototype/integrated/tools/agents/lib/presence.mjs
@@ -119,7 +119,8 @@ export async function startWatcher(context, input) {
     })();
     return terminalPromise;
   }
-  ownership = await acquireWatcherOwnership(context, agentId, pid);
+  ownership = await acquireWatcherOwnership(context, agentId, pid,
+    () => requireOpenAgent(context, agentId));
   heartbeatHandle = scheduler.setInterval(() => queueHeartbeat().catch(() => undefined),
     heartbeatMs);
   try {

--- a/prototype/integrated/tools/agents/lib/prompt.mjs
+++ b/prototype/integrated/tools/agents/lib/prompt.mjs
@@ -9,6 +9,14 @@ function valueWithoutNul(value, name) {
   return value;
 }
 
+function shellQuote(value) {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function shellOwnership(value) {
+  return value.split(" --ownership ").map(shellQuote).join(" --ownership ");
+}
+
 export async function renderPrompt(input) {
   const templatePath = valueWithoutNul(input.templatePath, "template path");
   const agentId = validateAgentId(valueWithoutNul(input.agentId, "agent id"));
@@ -17,6 +25,10 @@ export async function renderPrompt(input) {
   const ownership = valueWithoutNul(input.ownership, "ownership");
   const template = await readFile(templatePath, "utf8");
   return template
+    .replaceAll("<AGENT_ID_SHELL>", shellQuote(agentId))
+    .replaceAll("<ROLE_SHELL>", shellQuote(role))
+    .replaceAll("<TASK_SHELL>", shellQuote(task))
+    .replaceAll("<OWNERSHIP_SHELL>", shellOwnership(ownership))
     .replaceAll("<AGENT_ID>", agentId)
     .replaceAll("<ROLE>", role)
     .replaceAll("<TASK>", task)

--- a/prototype/integrated/tools/agents/lib/prompt.mjs
+++ b/prototype/integrated/tools/agents/lib/prompt.mjs
@@ -1,0 +1,24 @@
+import { readFile } from "node:fs/promises";
+
+import { CommsError, EXIT } from "./errors.mjs";
+import { validateAgentId } from "./schema.mjs";
+
+function valueWithoutNul(value, name) {
+  if (typeof value !== "string") throw new CommsError(`${name} must be a string`, EXIT.DATA);
+  if (value.includes("\0")) throw new CommsError(`${name} must not contain a NUL byte`, EXIT.DATA);
+  return value;
+}
+
+export async function renderPrompt(input) {
+  const templatePath = valueWithoutNul(input.templatePath, "template path");
+  const agentId = validateAgentId(valueWithoutNul(input.agentId, "agent id"));
+  const role = valueWithoutNul(input.role, "role");
+  const task = valueWithoutNul(input.task, "task");
+  const ownership = valueWithoutNul(input.ownership, "ownership");
+  const template = await readFile(templatePath, "utf8");
+  return template
+    .replaceAll("<AGENT_ID>", agentId)
+    .replaceAll("<ROLE>", role)
+    .replaceAll("<TASK>", task)
+    .replaceAll("<OWNERSHIP>", ownership);
+}

--- a/prototype/integrated/tools/agents/lib/recovery-audits.mjs
+++ b/prototype/integrated/tools/agents/lib/recovery-audits.mjs
@@ -1,0 +1,121 @@
+import { lstat } from "node:fs/promises";
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+
+import { listDirectoryEntries } from "./atomic-json.mjs";
+import { CommsError, EXIT } from "./errors.mjs";
+import { claimLockDigest, validateClaimAudit } from "./claims-audit.mjs";
+import { claimFilePath } from "./claim-records.mjs";
+import { readJsonRegularNoFollow } from "./safe-file.mjs";
+import { validateLock, validatePresence } from "./schema.mjs";
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const DIGEST = /^[a-f0-9]{64}$/;
+const PREFIX = /^(claims-audit-|claims-lock-stale-|doctor-audit-|mutex-audit-|mutex-stale-|watcher-owner-stale-)/;
+function data(message) { throw new CommsError(message, EXIT.DATA); }
+function validateWatcherOwner(value) {
+  const keys = ["acquired_at", "agent_id", "pid", "schema_version", "token"];
+  if (value === null || typeof value !== "object" || Array.isArray(value)
+    || Object.keys(value).sort().join() !== keys.join() || value.schema_version !== 1
+    || !UUID_V4.test(value.token)) data("invalid quarantined watcher owner");
+  validatePresence({ schema_version: 1, agent_id: value.agent_id, pid: value.pid,
+    status: "online", heartbeat_at: value.acquired_at });
+  return value;
+}
+async function readLockGeneration(context, directory) {
+  const before = await lstat(directory);
+  if (!before.isDirectory() || before.isSymbolicLink()) data("unsafe stale claim lock path");
+  const snapshot = await readJsonRegularNoFollow(path.join(directory, "owner.json"), validateLock,
+    context.paths.root, context.openRecoveryOwner);
+  const after = await lstat(directory);
+  if (before.dev !== after.dev || before.ino !== after.ino) data("stale claim lock changed");
+  return snapshot.record;
+}
+function isClaimAudit(name) { return name.startsWith("claims-audit-"); }
+function isClaimLock(name) { return name.startsWith("claims-lock-stale-"); }
+function isWatcherOwner(name) { return name.startsWith("watcher-owner-stale-"); }
+export function isRecoveryArtifactPath(context, filePath) {
+  return path.dirname(filePath) === context.paths.quarantine && PREFIX.test(path.basename(filePath));
+}
+async function readClaimIfPresent(context, filePath) {
+  try { return (await readJsonRegularNoFollow(filePath, value => value,
+    context.paths.root, context.openRecoveryOwner)).record; }
+  catch (error) { if (error.code === "ENOENT") return null; throw error; }
+}
+export async function inspectRecoveryAudits(context) {
+  const entries = await listDirectoryEntries(context.paths.quarantine,
+    { root: context.paths.root, readDirectory: context.readRecoveryDirectory });
+  const corrupt = new Set(); const lockAudits = [], pendingForceReleases = [];
+  for (const entry of entries.filter(item => isClaimAudit(item.name))) {
+    const filePath = path.join(context.paths.quarantine, entry.name);
+    try {
+      const match = /^claims-audit-([0-9a-f-]+)\.json$/.exec(entry.name);
+      if (!UUID_V4.test(match?.[1] ?? "")) data("claims audit filename mismatch");
+      const { record } = await readJsonRegularNoFollow(filePath, validateClaimAudit,
+        context.paths.root, context.openRecoveryAudit);
+      if (record.action === "repair_stale_claim_lock") lockAudits.push({ filePath, record });
+      else {
+        const source = claimFilePath(context, record.target.scope);
+        const active = await readClaimIfPresent(context, source);
+        if (active !== null && !isDeepStrictEqual(active, record.target))
+          data("force release source generation mismatch");
+        if (active !== null) pendingForceReleases.push({ audit_path: filePath,
+          source_path: source, audit: record });
+      }
+    } catch { corrupt.add(filePath); }
+  }
+  const locks = new Map();
+  for (const entry of entries.filter(item => isClaimLock(item.name))) {
+    const filePath = path.join(context.paths.quarantine, entry.name);
+    try {
+      const match = /^claims-lock-stale-([a-f0-9]{64})$/.exec(entry.name);
+      if (match === null || !DIGEST.test(match[1])) data("claim lock filename mismatch");
+      const owner = await readLockGeneration(context, filePath);
+      if (claimLockDigest(owner) !== match[1]) data("claim lock digest mismatch");
+      locks.set(match[1], { filePath, owner });
+    } catch { corrupt.add(filePath); }
+  }
+  const matched = new Set(), pendingClaimLocks = [];
+  for (const audit of lockAudits) {
+    const digest = claimLockDigest(audit.record.target); const generation = locks.get(digest);
+    if (generation !== undefined && isDeepStrictEqual(generation.owner, audit.record.target))
+      matched.add(digest);
+    else if (generation === undefined) try {
+      const activePath = path.join(context.paths.locks, "claims.lock");
+      const active = await readLockGeneration(context, activePath);
+      const stale = context.now().getTime() - Date.parse(active.acquired_at) > 60_000
+        && !context.pidIsAlive(active.pid);
+      if (!stale || !isDeepStrictEqual(active, audit.record.target))
+        data("pending claim lock generation mismatch");
+      pendingClaimLocks.push({ audit_path: audit.filePath, source_path: activePath,
+        destination_path: path.join(context.paths.quarantine, `claims-lock-stale-${digest}`),
+        audit: audit.record });
+    } catch { corrupt.add(audit.filePath); }
+    else corrupt.add(audit.filePath);
+  }
+  for (const [digest, generation] of locks) if (!matched.has(digest))
+    corrupt.add(generation.filePath);
+  for (const entry of entries.filter(item => isWatcherOwner(item.name))) {
+    const filePath = path.join(context.paths.quarantine, entry.name);
+    try {
+      const match = /^watcher-owner-stale-([0-9a-f-]+)\.json$/.exec(entry.name);
+      if (!UUID_V4.test(match?.[1] ?? "")) data("watcher owner filename mismatch");
+      const { record } = await readJsonRegularNoFollow(filePath, validateWatcherOwner,
+        context.paths.root, context.openRecoveryOwner);
+      if (record.token !== match[1]) data("watcher owner token mismatch");
+    } catch { corrupt.add(filePath); }
+  }
+  return { corrupt: [...corrupt].sort(), pending_claim_locks: pendingClaimLocks,
+    pending_force_releases: pendingForceReleases };
+}
+export async function scanRecoveryAudits(context) {
+  return (await inspectRecoveryAudits(context)).corrupt;
+}
+export function recoveryIssues(recovery, issue) {
+  return [
+    ...recovery.pending_claim_locks.map(item => issue("PENDING_CLAIM_LOCK_REPAIR",
+      item.audit_path, "claim lock audit awaits its quarantine rename", "warning")),
+    ...recovery.pending_force_releases.map(item => issue("PENDING_FORCE_RELEASE",
+      item.audit_path, "force-release audit awaits claim removal", "warning")),
+  ];
+}

--- a/prototype/integrated/tools/agents/lib/repair-mutex.mjs
+++ b/prototype/integrated/tools/agents/lib/repair-mutex.mjs
@@ -3,7 +3,7 @@ import { lstat, mkdir, rename, rmdir, unlink } from "node:fs/promises";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 
-import { listDirectoryEntries, readJsonStrict, writeJsonAtomic } from "./atomic-json.mjs";
+import { listDirectoryEntries, writeJsonAtomic } from "./atomic-json.mjs";
 import { CommsError, EXIT } from "./errors.mjs";
 import { readJsonRegularNoFollow } from "./safe-file.mjs";
 import { validateAgentId } from "./schema.mjs";
@@ -135,9 +135,18 @@ export async function scanRepairMutexAudits(context) {
       const destination = path.join(context.paths.quarantine, `mutex-stale-${digest}`);
       if (match?.[1] !== digest || audit.quarantine_path !== destination)
         throw new Error("mutex audit binding mismatch");
-      const moved = await readOwnerSnapshot(context, destination);
-      if (!isDeepStrictEqual(moved.owner, audit.target)
-        || createHash("sha256").update(moved.bytes).digest("hex") !== audit.owner_sha256)
+      let snapshot, ownerSha;
+      try { snapshot = await readOwnerSnapshot(context, destination);
+        ownerSha = createHash("sha256").update(snapshot.bytes).digest("hex"); }
+      catch (error) {
+        if (error.code !== "ENOENT") throw error;
+        try { await lstat(destination); throw new Error("mutex quarantine owner is missing"); }
+        catch (missing) { if (missing.code !== "ENOENT") throw missing; }
+        const pending = await inspectRepairMutex(context, audit.target.kind, audit.target.agent_id);
+        if (pending?.state !== "stale") throw error;
+        snapshot = { owner: pending.owner }; ownerSha = pending.owner_sha256;
+      }
+      if (!isDeepStrictEqual(snapshot.owner, audit.target) || ownerSha !== audit.owner_sha256)
         throw new Error("mutex audit target mismatch");
     } catch { corrupt.push(auditPath); }
   }
@@ -158,7 +167,8 @@ export async function repairStaleRepairMutex(context, kind, agentId = null) {
   try { await writeJsonAtomic(paths.audit, audit, { tmpDir: context.paths.tmp, exclusive: true }); }
   catch (error) {
     if (!(error instanceof CommsError) || error.exitCode !== EXIT.CONFLICT) throw error;
-    const existing = await readJsonStrict(paths.audit, validateAudit, context.paths.root);
+    const { record: existing } = await readJsonRegularNoFollow(paths.audit, validateAudit,
+      context.paths.root, context.openMutexAudit);
     if (!isDeepStrictEqual(existing, { ...audit, recorded_at: existing.recorded_at })) throw error;
   }
   try { await (context.renameRepairMutex ?? rename)(inspected.path, paths.destination); }

--- a/prototype/integrated/tools/agents/lib/repair-mutex.mjs
+++ b/prototype/integrated/tools/agents/lib/repair-mutex.mjs
@@ -1,9 +1,9 @@
 import { createHash, randomUUID } from "node:crypto";
-import { lstat, mkdir, readdir, rename, rmdir, unlink } from "node:fs/promises";
+import { lstat, mkdir, rename, rmdir, unlink } from "node:fs/promises";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 
-import { readJsonStrict, writeJsonAtomic } from "./atomic-json.mjs";
+import { listDirectoryEntries, readJsonStrict, writeJsonAtomic } from "./atomic-json.mjs";
 import { CommsError, EXIT } from "./errors.mjs";
 import { readJsonRegularNoFollow } from "./safe-file.mjs";
 import { validateAgentId } from "./schema.mjs";
@@ -35,7 +35,7 @@ async function readOwnerSnapshot(context, directory) {
   const before = await lstat(directory);
   if (!before.isDirectory() || before.isSymbolicLink()) throw new Error("unsafe mutex path");
   const snapshot = await readJsonRegularNoFollow(ownerPath(directory), validateOwner,
-    context.openMutexOwner);
+    context.paths.root, context.openMutexOwner);
   const after = await lstat(directory);
   if (before.dev !== after.dev || before.ino !== after.ino) throw new Error("mutex changed");
   return { owner: snapshot.record, bytes: snapshot.bytes };
@@ -122,13 +122,14 @@ function validateAudit(value) {
 }
 export async function scanRepairMutexAudits(context) {
   const corrupt = [];
-  const entries = await readdir(context.paths.quarantine, { withFileTypes: true });
+  const entries = await listDirectoryEntries(context.paths.quarantine,
+    { root: context.paths.root });
   const names = new Set(entries.map(entry => entry.name));
   for (const entry of entries.filter(item => item.name.startsWith("mutex-audit-"))) {
     const auditPath = path.join(context.paths.quarantine, entry.name);
     try {
       const { record: audit } = await readJsonRegularNoFollow(auditPath, validateAudit,
-        context.openMutexAudit);
+        context.paths.root, context.openMutexAudit);
       const match = /^mutex-audit-([a-f0-9]{64})\.json$/.exec(entry.name);
       const digest = createHash("sha256").update(JSON.stringify(audit.target)).digest("hex");
       const destination = path.join(context.paths.quarantine, `mutex-stale-${digest}`);
@@ -157,7 +158,7 @@ export async function repairStaleRepairMutex(context, kind, agentId = null) {
   try { await writeJsonAtomic(paths.audit, audit, { tmpDir: context.paths.tmp, exclusive: true }); }
   catch (error) {
     if (!(error instanceof CommsError) || error.exitCode !== EXIT.CONFLICT) throw error;
-    const existing = await readJsonStrict(paths.audit, validateAudit);
+    const existing = await readJsonStrict(paths.audit, validateAudit, context.paths.root);
     if (!isDeepStrictEqual(existing, { ...audit, recorded_at: existing.recorded_at })) throw error;
   }
   try { await (context.renameRepairMutex ?? rename)(inspected.path, paths.destination); }

--- a/prototype/integrated/tools/agents/lib/repair-mutex.mjs
+++ b/prototype/integrated/tools/agents/lib/repair-mutex.mjs
@@ -1,0 +1,173 @@
+import { createHash, randomUUID } from "node:crypto";
+import { lstat, mkdir, readdir, rename, rmdir, unlink } from "node:fs/promises";
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+
+import { readJsonStrict, writeJsonAtomic } from "./atomic-json.mjs";
+import { CommsError, EXIT } from "./errors.mjs";
+import { readJsonRegularNoFollow } from "./safe-file.mjs";
+import { validateAgentId } from "./schema.mjs";
+
+const STALE_MS = 60_000;
+const ATTEMPTS = 10_000;
+function key(kind, agentId) { return kind === "doctor" ? "doctor" : `watcher-${agentId}`; }
+export function repairMutexPath(context, kind, agentId = null) {
+  if (kind !== "doctor" && kind !== "watcher") throw new TypeError("invalid mutex kind");
+  if (kind === "watcher") validateAgentId(agentId);
+  return path.join(context.paths.locks, `${key(kind, agentId)}.lock`);
+}
+function ownerPath(directory) { return path.join(directory, "owner.json"); }
+function validateOwner(value) {
+  const keys = ["acquired_at", "agent_id", "kind", "pid", "schema_version", "token"];
+  const timestamp = Date.parse(value?.acquired_at);
+  if (value === null || typeof value !== "object" || Array.isArray(value)
+    || Object.keys(value).sort().join() !== keys.join() || value.schema_version !== 1
+    || !["doctor", "watcher"].includes(value.kind)
+    || (value.kind === "doctor" ? value.agent_id !== null : !value.agent_id)
+    || !Number.isSafeInteger(value.pid) || value.pid < 1 || !Number.isFinite(timestamp)
+    || new Date(timestamp).toISOString() !== value.acquired_at
+    || !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(value.token))
+    throw new CommsError("invalid repair mutex owner", EXIT.DATA);
+  if (value.agent_id !== null) validateAgentId(value.agent_id);
+  return value;
+}
+async function readOwnerSnapshot(context, directory) {
+  const before = await lstat(directory);
+  if (!before.isDirectory() || before.isSymbolicLink()) throw new Error("unsafe mutex path");
+  const snapshot = await readJsonRegularNoFollow(ownerPath(directory), validateOwner,
+    context.openMutexOwner);
+  const after = await lstat(directory);
+  if (before.dev !== after.dev || before.ino !== after.ino) throw new Error("mutex changed");
+  return { owner: snapshot.record, bytes: snapshot.bytes };
+}
+function bound(owner, kind, agentId) {
+  return owner.kind === kind && owner.agent_id === (kind === "doctor" ? null : agentId);
+}
+export async function inspectRepairMutex(context, kind, agentId = null) {
+  const directory = repairMutexPath(context, kind, agentId);
+  try {
+    const { owner, bytes } = await readOwnerSnapshot(context, directory);
+    if (!bound(owner, kind, agentId)) throw new Error("mutex owner does not match path");
+    const age = context.now().getTime() - Date.parse(owner.acquired_at);
+    const state = context.pidIsAlive(owner.pid) ? "live" : age > STALE_MS ? "stale" : "young";
+    return { state, owner, owner_sha256: createHash("sha256").update(bytes).digest("hex"),
+      path: directory };
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      try { await lstat(directory); return { state: "corrupt", owner: null, path: directory }; }
+      catch (missing) { if (missing.code === "ENOENT") return null; throw missing; }
+    }
+    return { state: "corrupt", owner: null, path: directory };
+  }
+}
+async function wait(context, kind) {
+  if (context.waitRepairMutex !== undefined) return context.waitRepairMutex(kind);
+  return new Promise(resolve => setImmediate(resolve));
+}
+async function acquire(context, kind, agentId) {
+  const token = (context.randomMutexUUID ?? randomUUID)();
+  const active = repairMutexPath(context, kind, agentId);
+  const prepared = path.join(context.paths.tmp, `mutex-${token}`);
+  const owner = validateOwner({ schema_version: 1, kind,
+    agent_id: kind === "doctor" ? null : agentId, pid: context.pid ?? process.pid,
+    token, acquired_at: context.now().toISOString() });
+  await mkdir(prepared);
+  try {
+    await writeJsonAtomic(ownerPath(prepared), owner, { tmpDir: context.paths.tmp, exclusive: true });
+    for (let attempt = 0; attempt < ATTEMPTS; attempt += 1) try {
+      await rename(prepared, active); return { active, owner };
+    } catch (error) {
+      if (!["EEXIST", "ENOTEMPTY"].includes(error.code)) throw error;
+      await wait(context, kind);
+    }
+    throw new CommsError("repair mutex is unavailable", EXIT.CONFLICT, { path: active });
+  } catch (error) {
+    try { await unlink(ownerPath(prepared)); } catch {}
+    try { await rmdir(prepared); } catch {}
+    throw error;
+  }
+}
+async function release(context, acquired) {
+  let current;
+  try { current = (await readOwnerSnapshot(context, acquired.active)).owner; }
+  catch (error) { if (error.code === "ENOENT") return; throw error; }
+  if (current.token !== acquired.owner.token) return;
+  const retired = path.join(context.paths.tmp, `mutex-release-${current.token}`);
+  try { await rename(acquired.active, retired); }
+  catch (error) { if (["ENOENT", "EEXIST", "ENOTEMPTY"].includes(error.code)) return; throw error; }
+  await unlink(ownerPath(retired)); await rmdir(retired);
+}
+export async function withRepairMutex(context, kind, agentId, operation) {
+  const acquired = await acquire(context, kind, agentId);
+  try { return await operation(acquired.owner); }
+  finally { await release(context, acquired); }
+}
+function stalePaths(context, owner) {
+  const digest = createHash("sha256").update(JSON.stringify(owner)).digest("hex");
+  return { destination: path.join(context.paths.quarantine, `mutex-stale-${digest}`),
+    audit: path.join(context.paths.quarantine, `mutex-audit-${digest}.json`) };
+}
+function validateAudit(value) {
+  const keys = ["action", "owner_sha256", "quarantine_path", "recorded_at",
+    "schema_version", "target"];
+  const timestamp = Date.parse(value?.recorded_at);
+  if (value === null || typeof value !== "object" || Array.isArray(value)
+    || Object.keys(value).sort().join() !== keys.join() || value.schema_version !== 1
+    || value.action !== "repair_stale_mutex" || !path.isAbsolute(value.quarantine_path)
+    || !/^[a-f0-9]{64}$/.test(value.owner_sha256)
+    || !Number.isFinite(timestamp) || new Date(timestamp).toISOString() !== value.recorded_at)
+    throw new CommsError("invalid repair mutex audit", EXIT.DATA);
+  validateOwner(value.target);
+  return value;
+}
+export async function scanRepairMutexAudits(context) {
+  const corrupt = [];
+  const entries = await readdir(context.paths.quarantine, { withFileTypes: true });
+  const names = new Set(entries.map(entry => entry.name));
+  for (const entry of entries.filter(item => item.name.startsWith("mutex-audit-"))) {
+    const auditPath = path.join(context.paths.quarantine, entry.name);
+    try {
+      const { record: audit } = await readJsonRegularNoFollow(auditPath, validateAudit,
+        context.openMutexAudit);
+      const match = /^mutex-audit-([a-f0-9]{64})\.json$/.exec(entry.name);
+      const digest = createHash("sha256").update(JSON.stringify(audit.target)).digest("hex");
+      const destination = path.join(context.paths.quarantine, `mutex-stale-${digest}`);
+      if (match?.[1] !== digest || audit.quarantine_path !== destination)
+        throw new Error("mutex audit binding mismatch");
+      const moved = await readOwnerSnapshot(context, destination);
+      if (!isDeepStrictEqual(moved.owner, audit.target)
+        || createHash("sha256").update(moved.bytes).digest("hex") !== audit.owner_sha256)
+        throw new Error("mutex audit target mismatch");
+    } catch { corrupt.push(auditPath); }
+  }
+  for (const entry of entries.filter(item => item.name.startsWith("mutex-stale-"))) {
+    const match = /^mutex-stale-([a-f0-9]{64})$/.exec(entry.name);
+    if (match === null || !names.has(`mutex-audit-${match[1]}.json`)) corrupt.push(
+      path.join(context.paths.quarantine, entry.name));
+  }
+  return [...new Set(corrupt)].sort();
+}
+export async function repairStaleRepairMutex(context, kind, agentId = null) {
+  const inspected = await inspectRepairMutex(context, kind, agentId);
+  if (inspected?.state !== "stale") return false;
+  const paths = stalePaths(context, inspected.owner);
+  const audit = validateAudit({ schema_version: 1, action: "repair_stale_mutex",
+    recorded_at: context.now().toISOString(), target: inspected.owner,
+    owner_sha256: inspected.owner_sha256, quarantine_path: paths.destination });
+  try { await writeJsonAtomic(paths.audit, audit, { tmpDir: context.paths.tmp, exclusive: true }); }
+  catch (error) {
+    if (!(error instanceof CommsError) || error.exitCode !== EXIT.CONFLICT) throw error;
+    const existing = await readJsonStrict(paths.audit, validateAudit);
+    if (!isDeepStrictEqual(existing, { ...audit, recorded_at: existing.recorded_at })) throw error;
+  }
+  try { await (context.renameRepairMutex ?? rename)(inspected.path, paths.destination); }
+  catch (error) {
+    if (!["EEXIST", "ENOTEMPTY", "ENOENT"].includes(error.code)) throw error;
+    return false;
+  }
+  const moved = await readOwnerSnapshot(context, paths.destination);
+  if (!isDeepStrictEqual(moved.owner, inspected.owner)
+    || createHash("sha256").update(moved.bytes).digest("hex") !== inspected.owner_sha256)
+    throw new CommsError("repaired mutex generation changed", EXIT.DATA);
+  return true;
+}

--- a/prototype/integrated/tools/agents/lib/safe-directory.mjs
+++ b/prototype/integrated/tools/agents/lib/safe-directory.mjs
@@ -1,0 +1,77 @@
+import { lstat, mkdir, realpath } from "node:fs/promises";
+import path from "node:path";
+
+import { CommsError, EXIT } from "./errors.mjs";
+
+function invalidDirectory(message, directory, root, cause) {
+  return new CommsError(message, EXIT.DATA, {
+    directory,
+    root,
+    ...(cause === undefined ? {} : { cause }),
+  });
+}
+
+function relativeWithin(root, directory) {
+  const relative = path.relative(root, directory);
+  if (relative === "" || (!path.isAbsolute(relative)
+    && relative !== ".." && !relative.startsWith(`..${path.sep}`))) return relative;
+  throw invalidDirectory("managed directory escapes bus root", directory, root);
+}
+
+function absolutePath(value, name, root = value) {
+  if (typeof value !== "string" || !path.isAbsolute(value)) {
+    throw invalidDirectory(`${name} must be absolute`, value, root);
+  }
+  return path.normalize(value);
+}
+
+async function inspectRealDirectory(directory, root, create) {
+  let details;
+  try {
+    details = await lstat(directory);
+  } catch (error) {
+    if (error.code === "ENOENT" && !create) throw error;
+    if (error.code !== "ENOENT") {
+      throw invalidDirectory("cannot inspect managed directory", directory, root, error.message);
+    }
+    try {
+      await mkdir(directory);
+    } catch (mkdirError) {
+      if (mkdirError.code !== "EEXIST") {
+        throw invalidDirectory("cannot create managed directory", directory, root,
+          mkdirError.message);
+      }
+    }
+    details = await lstat(directory);
+  }
+  if (!details.isDirectory() || details.isSymbolicLink()) {
+    throw invalidDirectory("managed directory is not a real directory", directory, root);
+  }
+  return details;
+}
+
+async function inspectManagedDirectory(rootPath, directoryPath, create) {
+  const root = absolutePath(rootPath, "managed root");
+  const directory = absolutePath(directoryPath, "managed directory", root);
+  const relative = relativeWithin(root, directory);
+  let details = await inspectRealDirectory(root, root, create);
+  const canonicalRoot = await realpath(root);
+  let current = root;
+  for (const segment of relative.split(path.sep).filter(Boolean)) {
+    current = path.join(current, segment);
+    details = await inspectRealDirectory(current, root, create);
+    const expected = path.join(canonicalRoot, path.relative(root, current));
+    if (await realpath(current) !== expected) {
+      throw invalidDirectory("managed directory escapes canonical bus root", current, root);
+    }
+  }
+  return { directory, stat: details };
+}
+
+export async function assertManagedDirectory(rootPath, directoryPath) {
+  return inspectManagedDirectory(rootPath, directoryPath, false);
+}
+
+export async function ensureManagedDirectory(rootPath, directoryPath) {
+  return (await inspectManagedDirectory(rootPath, directoryPath, true)).directory;
+}

--- a/prototype/integrated/tools/agents/lib/safe-file.mjs
+++ b/prototype/integrated/tools/agents/lib/safe-file.mjs
@@ -1,20 +1,46 @@
 import { constants } from "node:fs";
 import { open } from "node:fs/promises";
+import path from "node:path";
 
 import { CommsError, EXIT } from "./errors.mjs";
+import { assertManagedDirectory } from "./safe-directory.mjs";
 
-export async function readRegularNoFollow(filePath, openFile = open) {
-  const handle = await openFile(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+function sameDirectory(left, right) {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+export async function readRegularNoFollow(filePath, root, openFile = open) {
+  const parent = path.dirname(filePath);
+  const before = await assertManagedDirectory(root, parent);
+  let handle;
+  try {
+    handle = await openFile(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+  } catch (error) {
+    if (error.code === "ENOENT") throw error;
+    throw new CommsError("cannot safely open regular file", EXIT.DATA,
+      { filePath, cause: error.message });
+  }
   try {
     const stat = await handle.stat();
     if (!stat.isFile()) throw new CommsError("record is not a regular file", EXIT.DATA,
       { filePath });
+    const after = await assertManagedDirectory(root, parent);
+    if (!sameDirectory(before.stat, after.stat)) {
+      throw new CommsError("record parent directory changed while opening", EXIT.DATA,
+        { filePath, root });
+    }
     return await handle.readFile();
-  } finally { await handle.close(); }
+  } catch (error) {
+    if (error instanceof CommsError || error.code === "ENOENT") throw error;
+    throw new CommsError("cannot safely read regular file", EXIT.DATA,
+      { filePath, cause: error.message });
+  } finally {
+    await handle.close();
+  }
 }
 
-export async function readJsonRegularNoFollow(filePath, validate, openFile = open) {
-  const bytes = await readRegularNoFollow(filePath, openFile);
+export async function readJsonRegularNoFollow(filePath, validate, root, openFile = open) {
+  const bytes = await readRegularNoFollow(filePath, root, openFile);
   try { return { record: validate(JSON.parse(bytes.toString("utf8"))), bytes }; }
   catch (error) {
     if (error instanceof CommsError) throw error;

--- a/prototype/integrated/tools/agents/lib/safe-file.mjs
+++ b/prototype/integrated/tools/agents/lib/safe-file.mjs
@@ -1,0 +1,24 @@
+import { constants } from "node:fs";
+import { open } from "node:fs/promises";
+
+import { CommsError, EXIT } from "./errors.mjs";
+
+export async function readRegularNoFollow(filePath, openFile = open) {
+  const handle = await openFile(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) throw new CommsError("record is not a regular file", EXIT.DATA,
+      { filePath });
+    return await handle.readFile();
+  } finally { await handle.close(); }
+}
+
+export async function readJsonRegularNoFollow(filePath, validate, openFile = open) {
+  const bytes = await readRegularNoFollow(filePath, openFile);
+  try { return { record: validate(JSON.parse(bytes.toString("utf8"))), bytes }; }
+  catch (error) {
+    if (error instanceof CommsError) throw error;
+    throw new CommsError("invalid JSON record", EXIT.DATA,
+      { filePath, cause: error.message });
+  }
+}

--- a/prototype/integrated/tools/agents/lib/schema.mjs
+++ b/prototype/integrated/tools/agents/lib/schema.mjs
@@ -1,0 +1,299 @@
+import path from "node:path";
+
+import { CommsError, EXIT } from "./errors.mjs";
+
+export const MESSAGE_TYPES = Object.freeze([
+  "status",
+  "question",
+  "contract_request",
+  "contract_response",
+  "blocker",
+  "handoff",
+  "broadcast",
+]);
+export const SEVERITIES = Object.freeze(["info", "action", "blocker"]);
+
+function invalid(message, details = null) {
+  throw new CommsError(message, EXIT.DATA, details);
+}
+
+function record(value, name, required, optional = []) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    invalid(`${name} must be an object`, { value });
+  }
+  const allowed = new Set([...required, ...optional]);
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) invalid(`${name} has unknown field`, { field: key });
+  }
+  for (const key of required) {
+    if (!Object.hasOwn(value, key)) invalid(`${name} is missing required field`, { field: key });
+  }
+  return value;
+}
+
+function version(value) {
+  if (value !== 1) invalid("unknown schema version", { value });
+}
+
+function string(value, name, { empty = false } = {}) {
+  if (typeof value !== "string" || (!empty && value.length === 0)) {
+    invalid(`${name} must be a string`, { value });
+  }
+  return value;
+}
+
+function oneOf(value, allowed, name) {
+  if (!allowed.includes(value)) invalid(`invalid ${name}`, { value });
+  return value;
+}
+
+function boolean(value, name) {
+  if (typeof value !== "boolean") invalid(`${name} must be a boolean`, { value });
+  return value;
+}
+
+function integer(value, name, minimum = Number.MIN_SAFE_INTEGER) {
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    invalid(`${name} must be an integer`, { value });
+  }
+  return value;
+}
+
+function array(value, name, validate) {
+  if (!Array.isArray(value)) invalid(`${name} must be an array`, { value });
+  value.forEach((item, index) => validate(item, `${name}[${index}]`));
+  return value;
+}
+
+function isoTimestamp(value, name) {
+  string(value, name);
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds) || new Date(milliseconds).toISOString() !== value) {
+    invalid(`${name} must be a canonical UTC timestamp`, { value });
+  }
+  return value;
+}
+
+export function validateAgentId(value) {
+  if (typeof value !== "string" || !/^[a-z0-9][a-z0-9_-]{1,31}$/.test(value)) {
+    throw new CommsError("invalid agent id", EXIT.DATA, { value });
+  }
+  return value;
+}
+
+export function validateSha256(value) {
+  if (typeof value !== "string" || !/^[a-f0-9]{64}$/.test(value)) {
+    invalid("invalid SHA-256", { value });
+  }
+  return value;
+}
+
+export function validateGitSha(value) {
+  if (typeof value !== "string" || !/^[a-f0-9]{40}$/.test(value)) {
+    invalid("invalid Git SHA", { value });
+  }
+  return value;
+}
+
+export function validateRepoPath(value, name = "path") {
+  string(value, name);
+  if (
+    value === "." || value === ".."
+    || value.includes("\\")
+    || path.posix.isAbsolute(value)
+    || path.posix.normalize(value) !== value
+    || value.startsWith("../")
+  ) {
+    invalid(`${name} must be a normalized repository-relative path`, { value });
+  }
+  return value;
+}
+
+export function validateScope(value, name = "scope") {
+  string(value, name);
+  if (value.startsWith("contract:")) {
+    if (!/^contract:[a-z0-9][a-z0-9._-]*$/.test(value)) invalid(`invalid ${name}`, { value });
+    return value;
+  }
+  return validateRepoPath(value, name);
+}
+
+export function validateAttachment(value) {
+  record(value, "attachment", ["path", "sha256", "size", "ephemeral"], ["commit"]);
+  validateRepoPath(value.path, "attachment.path");
+  validateSha256(value.sha256);
+  integer(value.size, "attachment.size", 0);
+  boolean(value.ephemeral, "attachment.ephemeral");
+  if (value.ephemeral && !value.path.startsWith(".agents/artifacts/")) {
+    invalid("ephemeral attachment must be inside .agents/artifacts", { path: value.path });
+  }
+  if (Object.hasOwn(value, "commit")) {
+    validateGitSha(value.commit);
+    if (value.ephemeral) invalid("ephemeral attachment cannot have a commit", { path: value.path });
+  }
+  return value;
+}
+
+export function validateProtocol(value) {
+  record(value, "protocol", [
+    "schema_version", "protocol_version", "checkout_id", "checkout_root", "initialized_at",
+  ]);
+  version(value.schema_version);
+  if (value.protocol_version !== 1) invalid("unknown protocol version", { value: value.protocol_version });
+  validateSha256(value.checkout_id);
+  if (typeof value.checkout_root !== "string" || !path.isAbsolute(value.checkout_root)) {
+    invalid("checkout_root must be absolute", { value: value.checkout_root });
+  }
+  isoTimestamp(value.initialized_at, "initialized_at");
+  return value;
+}
+
+export function validateRegistry(value) {
+  record(value, "registry", [
+    "schema_version", "agent_id", "role", "task", "worktree", "branch", "head",
+    "ownership", "status", "registered_at", "updated_at",
+  ], ["client", "closed_at"]);
+  version(value.schema_version);
+  validateAgentId(value.agent_id);
+  string(value.role, "role");
+  string(value.task, "task");
+  if (typeof value.worktree !== "string" || !path.isAbsolute(value.worktree)) {
+    invalid("worktree must be absolute", { value: value.worktree });
+  }
+  string(value.branch, "branch");
+  validateGitSha(value.head);
+  array(value.ownership, "ownership", validateScope);
+  oneOf(value.status, ["open", "closed"], "registry status");
+  isoTimestamp(value.registered_at, "registered_at");
+  isoTimestamp(value.updated_at, "updated_at");
+  if (Object.hasOwn(value, "client")) {
+    oneOf(value.client, ["codex", "claude-code", "cursor", "other"], "client");
+  }
+  if (Object.hasOwn(value, "closed_at")) isoTimestamp(value.closed_at, "closed_at");
+  if (value.status === "closed" && !Object.hasOwn(value, "closed_at")) {
+    invalid("closed registry requires closed_at");
+  }
+  return value;
+}
+
+export function validatePresence(value) {
+  record(value, "presence", ["schema_version", "agent_id", "pid", "status", "heartbeat_at"]);
+  version(value.schema_version);
+  validateAgentId(value.agent_id);
+  integer(value.pid, "pid", 1);
+  oneOf(value.status, ["online", "offline"], "presence status");
+  isoTimestamp(value.heartbeat_at, "heartbeat_at");
+  return value;
+}
+
+export function validateMessage(value) {
+  record(value, "message", [
+    "schema_version", "id", "from", "to", "type", "severity", "subject", "body",
+    "task", "reply_to", "requires_ack", "created_at", "sender_head", "attachments",
+  ]);
+  version(value.schema_version);
+  string(value.id, "message.id");
+  if (value.id.includes("/") || value.id.includes("\\")) invalid("invalid message id", { value: value.id });
+  validateAgentId(value.from);
+  validateAgentId(value.to);
+  oneOf(value.type, MESSAGE_TYPES, "message type");
+  oneOf(value.severity, SEVERITIES, "message severity");
+  string(value.subject, "subject");
+  string(value.body, "body", { empty: true });
+  string(value.task, "task");
+  if (value.reply_to !== null) string(value.reply_to, "reply_to");
+  boolean(value.requires_ack, "requires_ack");
+  isoTimestamp(value.created_at, "created_at");
+  validateGitSha(value.sender_head);
+  array(value.attachments, "attachments", validateAttachment);
+  return value;
+}
+
+function validateReceipt(value, timestampField, name) {
+  record(value, name, ["schema_version", "message_id", "recipient", timestampField]);
+  version(value.schema_version);
+  string(value.message_id, "message_id");
+  validateAgentId(value.recipient);
+  isoTimestamp(value[timestampField], timestampField);
+  return value;
+}
+
+export function validateSeenReceipt(value) {
+  return validateReceipt(value, "seen_at", "seen receipt");
+}
+
+export function validateAcknowledgement(value) {
+  return validateReceipt(value, "acknowledged_at", "acknowledgement");
+}
+
+export function validateClaim(value) {
+  record(value, "claim", [
+    "schema_version", "agent_id", "task", "scope", "reason",
+    "created_at", "updated_at", "expires_at",
+  ]);
+  version(value.schema_version);
+  validateAgentId(value.agent_id);
+  string(value.task, "task");
+  validateScope(value.scope);
+  string(value.reason, "reason");
+  for (const field of ["created_at", "updated_at", "expires_at"]) isoTimestamp(value[field], field);
+  return value;
+}
+
+function validateVerification(value) {
+  record(value, "verification", ["command", "exitCode", "summary"]);
+  string(value.command, "verification.command");
+  integer(value.exitCode, "verification.exitCode", 0);
+  string(value.summary, "verification.summary");
+}
+
+function validateContracts(value) {
+  record(value, "contracts", ["added", "changed", "consumed"]);
+  for (const field of ["added", "changed", "consumed"]) {
+    array(value[field], `contracts.${field}`, item => string(item, `contracts.${field}`));
+  }
+}
+
+export function validateHandoff(value) {
+  record(value, "handoff", [
+    "schema_version", "id", "from", "to", "task", "result", "branch", "commit", "base",
+    "changed_paths", "verification", "contracts", "follow_up", "artifacts", "limitations",
+    "uncommitted", "ready_to_merge", "state", "created_at",
+  ]);
+  version(value.schema_version);
+  string(value.id, "handoff.id");
+  validateAgentId(value.from);
+  validateAgentId(value.to);
+  for (const field of ["task", "result", "branch"]) string(value[field], field);
+  boolean(value.uncommitted, "uncommitted");
+  if (value.commit !== null) validateGitSha(value.commit);
+  validateGitSha(value.base);
+  if (!value.uncommitted && value.commit === null) invalid("committed handoff requires commit");
+  if (value.uncommitted && value.commit !== null) invalid("uncommitted handoff cannot have commit");
+  array(value.changed_paths, "changed_paths", validateRepoPath);
+  array(value.verification, "verification", validateVerification);
+  if (value.verification.length === 0) invalid("handoff requires verification evidence");
+  const verificationFailed = value.verification.some(item => item.exitCode !== 0);
+  validateContracts(value.contracts);
+  array(value.follow_up, "follow_up", validateAgentId);
+  array(value.artifacts, "artifacts", validateAttachment);
+  array(value.limitations, "limitations", item => string(item, "limitation"));
+  boolean(value.ready_to_merge, "ready_to_merge");
+  oneOf(value.state, ["READY", "NOT_READY", "UNCOMMITTED"], "handoff state");
+  const expectedState = value.uncommitted ? "UNCOMMITTED" : value.ready_to_merge ? "READY" : "NOT_READY";
+  if (value.state !== expectedState || (value.uncommitted && value.ready_to_merge)
+    || (!value.uncommitted && verificationFailed && value.ready_to_merge)) {
+    invalid("handoff readiness contradicts state or verification");
+  }
+  isoTimestamp(value.created_at, "created_at");
+  return value;
+}
+
+export function validateLock(value) {
+  record(value, "lock", ["schema_version", "owner_agent", "pid", "acquired_at"]);
+  version(value.schema_version);
+  validateAgentId(value.owner_agent);
+  integer(value.pid, "pid", 1);
+  isoTimestamp(value.acquired_at, "acquired_at");
+  return value;
+}

--- a/prototype/integrated/tools/agents/lib/schema.mjs
+++ b/prototype/integrated/tools/agents/lib/schema.mjs
@@ -1,6 +1,7 @@
 import path from "node:path";
 
 import { CommsError, EXIT } from "./errors.mjs";
+import { validateMessageId } from "./message-id.mjs";
 
 export const MESSAGE_TYPES = Object.freeze([
   "status",
@@ -192,8 +193,7 @@ export function validateMessage(value) {
     "task", "reply_to", "requires_ack", "created_at", "sender_head", "attachments",
   ]);
   version(value.schema_version);
-  string(value.id, "message.id");
-  if (value.id.includes("/") || value.id.includes("\\")) invalid("invalid message id", { value: value.id });
+  validateMessageId(value.id, "message id");
   validateAgentId(value.from);
   validateAgentId(value.to);
   oneOf(value.type, MESSAGE_TYPES, "message type");
@@ -201,7 +201,7 @@ export function validateMessage(value) {
   string(value.subject, "subject");
   string(value.body, "body", { empty: true });
   string(value.task, "task");
-  if (value.reply_to !== null) string(value.reply_to, "reply_to");
+  if (value.reply_to !== null) validateMessageId(value.reply_to, "reply_to");
   boolean(value.requires_ack, "requires_ack");
   isoTimestamp(value.created_at, "created_at");
   validateGitSha(value.sender_head);
@@ -212,7 +212,7 @@ export function validateMessage(value) {
 function validateReceipt(value, timestampField, name) {
   record(value, name, ["schema_version", "message_id", "recipient", timestampField]);
   version(value.schema_version);
-  string(value.message_id, "message_id");
+  validateMessageId(value.message_id, "message_id");
   validateAgentId(value.recipient);
   isoTimestamp(value[timestampField], timestampField);
   return value;

--- a/prototype/integrated/tools/agents/lib/signal-stop.mjs
+++ b/prototype/integrated/tools/agents/lib/signal-stop.mjs
@@ -1,0 +1,24 @@
+export async function withSignalStop(run, signals) {
+  let watcher = null;
+  let latched = false;
+  let stopping = Promise.resolve();
+  const stop = () => {
+    latched = true;
+    if (watcher !== null) stopping = stopping.then(() => watcher.stop());
+    return stopping;
+  };
+  const onSignal = () => { void stop(); };
+  signals.once("SIGINT", onSignal);
+  signals.once("SIGTERM", onSignal);
+  try {
+    const code = await run(value => {
+      watcher = value;
+      if (value !== null && latched) void stop();
+    });
+    await stopping;
+    return code;
+  } finally {
+    signals.removeListener("SIGINT", onSignal);
+    signals.removeListener("SIGTERM", onSignal);
+  }
+}

--- a/prototype/integrated/tools/agents/lib/status-locks.mjs
+++ b/prototype/integrated/tools/agents/lib/status-locks.mjs
@@ -1,0 +1,41 @@
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+import { inspectRepairMutex, repairStaleRepairMutex } from "./repair-mutex.mjs";
+
+async function watcherMutexIds(context) {
+  const entries = await readdir(context.paths.locks, { withFileTypes: true });
+  return entries.filter(entry => /^watcher-.+\.lock$/.test(entry.name))
+    .map(entry => entry.name.slice(8, -5)).sort();
+}
+export async function collectMutexStatus(context) {
+  const watcher = { live: [], young: [], stale: [], corrupt: [] };
+  for (const agentId of await watcherMutexIds(context)) {
+    let inspected;
+    try { inspected = await inspectRepairMutex(context, "watcher", agentId); }
+    catch { inspected = { state: "corrupt", owner: null,
+      path: path.join(context.paths.locks, `watcher-${agentId}.lock`) }; }
+    if (inspected !== null) watcher[inspected.state].push(inspected);
+  }
+  return { doctor: await inspectRepairMutex(context, "doctor"), watcher };
+}
+export function mutexIssues(locks, makeIssue) {
+  const issues = [];
+  if (locks.doctor !== null) issues.push(makeIssue(
+    `DOCTOR_MUTEX_${locks.doctor.state.toUpperCase()}`, locks.doctor.path,
+    `doctor mutex is ${locks.doctor.state}`, locks.doctor.state === "stale" ? "warning" : "error"));
+  for (const state of ["live", "young", "stale", "corrupt"])
+    for (const inspected of locks.watcher[state]) issues.push(makeIssue(
+      `WATCHER_MUTEX_${state.toUpperCase()}`, inspected.path,
+      `watcher mutex is ${state}`, state === "stale" ? "warning" : "error"));
+  return issues;
+}
+export async function repairStaleWatcherMutexes(context, locks) {
+  const repairs = [];
+  for (const inspected of locks.watcher.stale) {
+    const agentId = path.basename(inspected.path).slice(8, -5);
+    if (await repairStaleRepairMutex(context, "watcher", agentId)) repairs.push({
+      action: "repair_stale_watcher_mutex", path: inspected.path });
+  }
+  return repairs;
+}

--- a/prototype/integrated/tools/agents/lib/status-locks.mjs
+++ b/prototype/integrated/tools/agents/lib/status-locks.mjs
@@ -1,10 +1,11 @@
-import { readdir } from "node:fs/promises";
 import path from "node:path";
 
+import { listDirectoryEntries } from "./atomic-json.mjs";
 import { inspectRepairMutex, repairStaleRepairMutex } from "./repair-mutex.mjs";
 
 async function watcherMutexIds(context) {
-  const entries = await readdir(context.paths.locks, { withFileTypes: true });
+  const entries = await listDirectoryEntries(context.paths.locks,
+    { root: context.paths.root });
   return entries.filter(entry => /^watcher-.+\.lock$/.test(entry.name))
     .map(entry => entry.name.slice(8, -5)).sort();
 }

--- a/prototype/integrated/tools/agents/lib/status.mjs
+++ b/prototype/integrated/tools/agents/lib/status.mjs
@@ -1,6 +1,6 @@
-import { access, readdir } from "node:fs/promises";
+import { access } from "node:fs/promises";
 import path from "node:path";
-import { listJsonFiles, readJsonStrict } from "./atomic-json.mjs";
+import { listDirectoryEntries, listJsonFiles, readJsonStrict } from "./atomic-json.mjs";
 import { inspectClaimRecords } from "./claim-records.mjs";
 import { repairStaleClaimLock } from "./claims.mjs";
 import { archiveAcknowledged, quarantineCorrupt, scanDoctorAudits }
@@ -17,27 +17,25 @@ async function exists(filePath) { try { await access(filePath); return true; }
   catch (error) { if (error.code === "ENOENT") return false; throw error; }
 }
 function addCorrupt(state, filePath) { if (!state.corrupt.includes(filePath)) state.corrupt.push(filePath); }
-async function safeRead(filePath, validate, state) {
-  try { return await readJsonStrict(filePath, validate); }
+async function safeRead(context, filePath, validate, state) {
+  try { return await readJsonStrict(filePath, validate, context.paths.root); }
   catch (error) {
     if (error.code === "ENOENT") return null;
     addCorrupt(state, filePath);
     return null; }
 }
-async function nestedJsonFiles(root) {
-  let entries;
-  try { entries = await readdir(root, { withFileTypes: true }); }
-  catch (error) { if (error.code === "ENOENT") return []; throw error; }
+async function nestedJsonFiles(context, root) {
+  const entries = await listDirectoryEntries(root, { root: context.paths.root });
   const directories = entries.filter(entry => entry.isDirectory())
     .sort((a, b) => a.name.localeCompare(b.name));
   return (await Promise.all(directories.map(entry =>
-    listJsonFiles(path.join(root, entry.name))))).flat();
+    listJsonFiles(path.join(root, entry.name), { root: context.paths.root })))).flat();
 }
 function fileStem(filePath) { return path.basename(filePath, ".json"); }
 function sortRecords(records, field) { return records.sort(
   (a, b) => a[field].localeCompare(b[field])); }
 async function readProtocol(context, state) {
-  const record = await safeRead(context.paths.protocol, validateProtocol, state);
+  const record = await safeRead(context, context.paths.protocol, validateProtocol, state);
   if (record === null) {
     addCorrupt(state, context.paths.protocol);
     return { schema_version: null, protocol_version: null, checkout_id: null };
@@ -47,15 +45,15 @@ async function readProtocol(context, state) {
 }
 async function readAgents(context, state) {
   const presence = new Map();
-  for (const filePath of await listJsonFiles(context.paths.presence)) {
-    const record = await safeRead(filePath, validatePresence, state);
+  for (const filePath of await listJsonFiles(context.paths.presence, { root: context.paths.root })) {
+    const record = await safeRead(context, filePath, validatePresence, state);
     if (record === null) continue;
     if (fileStem(filePath) !== record.agent_id) { addCorrupt(state, filePath); continue; }
     presence.set(record.agent_id, record);
   }
   const agents = { live: [], stale: [], offline: [] };
-  for (const filePath of await listJsonFiles(context.paths.registry)) {
-    const registry = await safeRead(filePath, validateRegistry, state);
+  for (const filePath of await listJsonFiles(context.paths.registry, { root: context.paths.root })) {
+    const registry = await safeRead(context, filePath, validateRegistry, state);
     if (registry === null) continue;
     if (fileStem(filePath) !== registry.agent_id) { addCorrupt(state, filePath); continue; }
     const heartbeat = presence.get(registry.agent_id) ?? null;
@@ -77,8 +75,8 @@ async function readMessages(context, state) {
   const stored = new Map();
   for (const [location, root] of [["inbox", context.paths.inbox],
     ["archive", context.paths.archive]]) {
-    for (const filePath of await nestedJsonFiles(root)) {
-      const message = await safeRead(filePath, validateMessage, state);
+    for (const filePath of await nestedJsonFiles(context, root)) {
+      const message = await safeRead(context, filePath, validateMessage, state);
       if (message === null) continue;
       const recipient = path.basename(path.dirname(filePath));
       if (recipient !== message.to || fileStem(filePath) !== message.id
@@ -93,8 +91,8 @@ async function readReceipts(context, state, stored, kind) {
   const root = acknowledgements ? context.paths.acknowledgements : context.paths.seen;
   const validate = acknowledgements ? validateAcknowledgement : validateSeenReceipt;
   const records = new Map();
-  for (const filePath of await listJsonFiles(root)) {
-    const receipt = await safeRead(filePath, validate, state);
+  for (const filePath of await listJsonFiles(root, { root: context.paths.root })) {
+    const receipt = await safeRead(context, filePath, validate, state);
     if (receipt === null) continue;
     const expected = acknowledgements
       ? context.paths.ackFile(receipt.message_id, receipt.recipient)
@@ -140,8 +138,8 @@ async function readClaims(context, state) {
 }
 async function readHandoffs(context, state) {
   const records = [];
-  for (const filePath of await listJsonFiles(context.paths.handoffs)) {
-    const record = await safeRead(filePath, validateHandoff, state);
+  for (const filePath of await listJsonFiles(context.paths.handoffs, { root: context.paths.root })) {
+    const record = await safeRead(context, filePath, validateHandoff, state);
     if (record !== null && fileStem(filePath) === record.id) records.push(record);
     else if (record !== null) addCorrupt(state, filePath);
   }
@@ -159,7 +157,7 @@ function counts(report) {
 }
 async function readLockCorruption(context, state) {
   const ownerPath = path.join(context.paths.locks, "claims.lock", "owner.json");
-  if (await exists(ownerPath)) await safeRead(ownerPath, validateLock, state);
+  if (await exists(ownerPath)) await safeRead(context, ownerPath, validateLock, state);
   for (const agentId of await watcherIds(context)) try {
     await inspectWatcherOwnership(context, agentId);
   } catch { addCorrupt(state,
@@ -183,7 +181,7 @@ function issue(code, filePath, message, severity = "error") { return {
 function isRepairStoragePath(context, filePath) { return path.dirname(filePath) === context.paths.quarantine
   && /^(doctor-audit-|mutex-audit-|mutex-stale-)/.test(path.basename(filePath)); }
 async function watcherIds(context) {
-  const entries = await readdir(context.paths.locks, { withFileTypes: true });
+  const entries = await listDirectoryEntries(context.paths.locks, { root: context.paths.root });
   return entries.filter(entry => entry.isFile() && /^watcher-.+\.json$/.test(entry.name))
     .map(entry => entry.name.slice(8, -5)).sort();
 }
@@ -216,7 +214,7 @@ async function operationalIssues(context, report, input) {
   if (await exists(lockDir) && !await exists(lockOwner)) issues.push(issue(
     "CLAIM_LOCK_OWNER_MISSING", lockDir, "claim lock has no owner record"));
   else if (await exists(lockOwner)) {
-    const owner = await safeRead(lockOwner, validateLock, { corrupt: [] });
+    const owner = await safeRead(context, lockOwner, validateLock, { corrupt: [] });
     if (owner !== null && context.now().getTime() - Date.parse(owner.acquired_at) > 60_000
       && !context.pidIsAlive(owner.pid)) issues.push(issue("STALE_CLAIM_LOCK", lockOwner,
       "claim lock owner is dead and older than sixty seconds", "warning"));

--- a/prototype/integrated/tools/agents/lib/status.mjs
+++ b/prototype/integrated/tools/agents/lib/status.mjs
@@ -1,0 +1,299 @@
+import { access, readdir } from "node:fs/promises";
+import path from "node:path";
+import { listJsonFiles, readJsonStrict } from "./atomic-json.mjs";
+import { inspectClaimRecords } from "./claim-records.mjs";
+import { repairStaleClaimLock } from "./claims.mjs";
+import { archiveAcknowledged, quarantineCorrupt, scanDoctorAudits }
+  from "./doctor-storage.mjs";
+import { protocolCompatibilityIssue } from "./doctor-protocol.mjs";
+import { EXIT } from "./errors.mjs";
+import { inspectWatcherOwnership, presenceState, repairStaleWatcherOwnership } from "./presence.mjs";
+import { repairStaleRepairMutex, scanRepairMutexAudits, withRepairMutex } from "./repair-mutex.mjs";
+import { collectMutexStatus, mutexIssues, repairStaleWatcherMutexes } from "./status-locks.mjs";
+import { validateAcknowledgement, validateHandoff, validateLock,
+  validateMessage, validatePresence, validateProtocol, validateRegistry,
+  validateSeenReceipt } from "./schema.mjs";
+async function exists(filePath) { try { await access(filePath); return true; }
+  catch (error) { if (error.code === "ENOENT") return false; throw error; }
+}
+function addCorrupt(state, filePath) { if (!state.corrupt.includes(filePath)) state.corrupt.push(filePath); }
+async function safeRead(filePath, validate, state) {
+  try { return await readJsonStrict(filePath, validate); }
+  catch (error) {
+    if (error.code === "ENOENT") return null;
+    addCorrupt(state, filePath);
+    return null; }
+}
+async function nestedJsonFiles(root) {
+  let entries;
+  try { entries = await readdir(root, { withFileTypes: true }); }
+  catch (error) { if (error.code === "ENOENT") return []; throw error; }
+  const directories = entries.filter(entry => entry.isDirectory())
+    .sort((a, b) => a.name.localeCompare(b.name));
+  return (await Promise.all(directories.map(entry =>
+    listJsonFiles(path.join(root, entry.name))))).flat();
+}
+function fileStem(filePath) { return path.basename(filePath, ".json"); }
+function sortRecords(records, field) { return records.sort(
+  (a, b) => a[field].localeCompare(b[field])); }
+async function readProtocol(context, state) {
+  const record = await safeRead(context.paths.protocol, validateProtocol, state);
+  if (record === null) {
+    addCorrupt(state, context.paths.protocol);
+    return { schema_version: null, protocol_version: null, checkout_id: null };
+  }
+  return { schema_version: record.schema_version,
+    protocol_version: record.protocol_version, checkout_id: record.checkout_id };
+}
+async function readAgents(context, state) {
+  const presence = new Map();
+  for (const filePath of await listJsonFiles(context.paths.presence)) {
+    const record = await safeRead(filePath, validatePresence, state);
+    if (record === null) continue;
+    if (fileStem(filePath) !== record.agent_id) { addCorrupt(state, filePath); continue; }
+    presence.set(record.agent_id, record);
+  }
+  const agents = { live: [], stale: [], offline: [] };
+  for (const filePath of await listJsonFiles(context.paths.registry)) {
+    const registry = await safeRead(filePath, validateRegistry, state);
+    if (registry === null) continue;
+    if (fileStem(filePath) !== registry.agent_id) { addCorrupt(state, filePath); continue; }
+    const heartbeat = presence.get(registry.agent_id) ?? null;
+    presence.delete(registry.agent_id);
+    let status = "offline";
+    if (registry.status === "open" && heartbeat !== null)
+      status = presenceState(heartbeat, context.now(), context.pidIsAlive);
+    else if (registry.status === "open"
+      && context.now().getTime() - Date.parse(registry.updated_at) > 45_000) status = "stale";
+    agents[status === "online" ? "live" : status].push(registry);
+  }
+  for (const orphan of presence.values()) addCorrupt(state,
+    context.paths.presenceFile(orphan.agent_id));
+  for (const records of Object.values(agents)) sortRecords(records, "agent_id");
+  return agents;
+}
+function messageKey(message) { return `${message.to}/${message.id}`; }
+async function readMessages(context, state) {
+  const stored = new Map();
+  for (const [location, root] of [["inbox", context.paths.inbox],
+    ["archive", context.paths.archive]]) {
+    for (const filePath of await nestedJsonFiles(root)) {
+      const message = await safeRead(filePath, validateMessage, state);
+      if (message === null) continue;
+      const recipient = path.basename(path.dirname(filePath));
+      if (recipient !== message.to || fileStem(filePath) !== message.id
+        || stored.has(messageKey(message))) { addCorrupt(state, filePath); continue; }
+      stored.set(messageKey(message), { message, location, filePath });
+    }
+  }
+  return stored;
+}
+async function readReceipts(context, state, stored, kind) {
+  const acknowledgements = kind === "ack";
+  const root = acknowledgements ? context.paths.acknowledgements : context.paths.seen;
+  const validate = acknowledgements ? validateAcknowledgement : validateSeenReceipt;
+  const records = new Map();
+  for (const filePath of await listJsonFiles(root)) {
+    const receipt = await safeRead(filePath, validate, state);
+    if (receipt === null) continue;
+    const expected = acknowledgements
+      ? context.paths.ackFile(receipt.message_id, receipt.recipient)
+      : context.paths.seenFile(receipt.message_id, receipt.recipient);
+    const key = `${receipt.recipient}/${receipt.message_id}`;
+    if (filePath !== expected || !stored.has(key)) { addCorrupt(state, filePath); continue; }
+    records.set(key, receipt);
+  }
+  return records;
+}
+async function messageStatus(context, state) {
+  const stored = await readMessages(context, state);
+  const seen = await readReceipts(context, state, stored, "seen");
+  const acknowledged = await readReceipts(context, state, stored, "ack");
+  const messages = { unseen: [], seen_but_unacked: [], required_unacked: [],
+    blockers: [], acknowledgements: [] };
+  for (const [key, item] of stored) {
+    const acknowledgement = acknowledged.get(key);
+    if (acknowledgement !== undefined) {
+      messages.acknowledgements.push({ message: item.message, acknowledgement,
+        location: item.location });
+      continue;
+    }
+    if (item.location !== "inbox") { addCorrupt(state, item.filePath); continue; }
+    messages[seen.has(key) ? "seen_but_unacked" : "unseen"].push(item.message);
+    if (item.message.requires_ack) messages.required_unacked.push(item.message);
+    if (item.message.severity === "blocker") messages.blockers.push(item.message);
+  }
+  for (const name of ["unseen", "seen_but_unacked", "required_unacked", "blockers"])
+    sortRecords(messages[name], "id");
+  messages.acknowledgements.sort((a, b) => a.message.id.localeCompare(b.message.id));
+  return messages;
+}
+async function readClaims(context, state) {
+  const claims = { active: [], stale: [] };
+  const inspected = await inspectClaimRecords(context);
+  for (const filePath of inspected.corrupt) addCorrupt(state, filePath);
+  for (const item of inspected.records) claims[
+    Date.parse(item.record.expires_at) <= context.now().getTime() ? "stale" : "active"]
+    .push(item.record);
+  sortRecords(claims.active, "scope"); sortRecords(claims.stale, "scope");
+  return claims;
+}
+async function readHandoffs(context, state) {
+  const records = [];
+  for (const filePath of await listJsonFiles(context.paths.handoffs)) {
+    const record = await safeRead(filePath, validateHandoff, state);
+    if (record !== null && fileStem(filePath) === record.id) records.push(record);
+    else if (record !== null) addCorrupt(state, filePath);
+  }
+  return sortRecords(records, "id");
+}
+function counts(report) {
+  return {
+    live_agents: report.agents.live.length, stale_agents: report.agents.stale.length,
+    offline_agents: report.agents.offline.length, unseen: report.messages.unseen.length,
+    seen_but_unacked: report.messages.seen_but_unacked.length, required_unacked: report.messages.required_unacked.length,
+    blockers: report.messages.blockers.length, acknowledgements: report.messages.acknowledgements.length,
+    active_claims: report.claims.active.length, stale_claims: report.claims.stale.length,
+    handoffs: report.handoffs.length, corrupt: report.corrupt.length,
+  };
+}
+async function readLockCorruption(context, state) {
+  const ownerPath = path.join(context.paths.locks, "claims.lock", "owner.json");
+  if (await exists(ownerPath)) await safeRead(ownerPath, validateLock, state);
+  for (const agentId of await watcherIds(context)) try {
+    await inspectWatcherOwnership(context, agentId);
+  } catch { addCorrupt(state,
+    path.join(context.paths.locks, `watcher-${agentId}.json`)); }
+}
+export async function collectStatus(context) {
+  const state = { corrupt: [] };
+  await readLockCorruption(context, state);
+  for (const auditPath of [...await scanDoctorAudits(context),
+    ...await scanRepairMutexAudits(context)]) addCorrupt(state, auditPath);
+  const report = { protocol: await readProtocol(context, state),
+    agents: await readAgents(context, state),
+    messages: await messageStatus(context, state), claims: await readClaims(context, state),
+    handoffs: await readHandoffs(context, state), locks: await collectMutexStatus(context),
+    corrupt: state.corrupt.sort() };
+  report.counts = counts(report);
+  return report;
+}
+function issue(code, filePath, message, severity = "error") { return {
+  code, severity, path: filePath, message }; }
+function isRepairStoragePath(context, filePath) { return path.dirname(filePath) === context.paths.quarantine
+  && /^(doctor-audit-|mutex-audit-|mutex-stale-)/.test(path.basename(filePath)); }
+async function watcherIds(context) {
+  const entries = await readdir(context.paths.locks, { withFileTypes: true });
+  return entries.filter(entry => entry.isFile() && /^watcher-.+\.json$/.test(entry.name))
+    .map(entry => entry.name.slice(8, -5)).sort();
+}
+async function operationalIssues(context, report, input) {
+  const issues = [];
+  const protocolMissing = !await exists(context.paths.protocol);
+  const protectedProtocol = !protocolMissing && report.corrupt.includes(context.paths.protocol)
+    ? await protocolCompatibilityIssue(context) : null;
+  if (protocolMissing) issues.push(issue("PROTOCOL_MISSING", context.paths.protocol,
+    "protocol is not initialized"));
+  if (protectedProtocol !== null) issues.push(protectedProtocol);
+  issues.push(...mutexIssues(report.locks, issue).filter(item =>
+    !(input.doctorMutexHeld && item.code === "DOCTOR_MUTEX_LIVE")));
+  for (const filePath of report.corrupt) if (filePath !== context.paths.protocol
+    || (!protocolMissing && protectedProtocol === null)) issues.push(issue("CORRUPT_JSON", filePath,
+    "invalid or inconsistent protocol record"));
+  for (const item of report.messages.acknowledgements) if (item.location === "inbox")
+    issues.push(issue("ACKED_MESSAGE_NOT_ARCHIVED",
+      context.paths.inboxFile(item.message.to, item.message.id),
+      "acknowledged message remains in inbox"));
+  const required = [...new Set(input.requireLive ?? [])].sort();
+  for (const agentId of required) {
+    if (report.agents.live.some(agent => agent.agent_id === agentId)) continue;
+    const stale = report.agents.stale.some(agent => agent.agent_id === agentId);
+    issues.push(issue(stale ? "REQUIRED_AGENT_STALE" : "REQUIRED_AGENT_OFFLINE",
+      context.paths.presenceFile(agentId), `required agent ${agentId} is not live`));
+  }
+  const lockDir = path.join(context.paths.locks, "claims.lock");
+  const lockOwner = path.join(lockDir, "owner.json");
+  if (await exists(lockDir) && !await exists(lockOwner)) issues.push(issue(
+    "CLAIM_LOCK_OWNER_MISSING", lockDir, "claim lock has no owner record"));
+  else if (await exists(lockOwner)) {
+    const owner = await safeRead(lockOwner, validateLock, { corrupt: [] });
+    if (owner !== null && context.now().getTime() - Date.parse(owner.acquired_at) > 60_000
+      && !context.pidIsAlive(owner.pid)) issues.push(issue("STALE_CLAIM_LOCK", lockOwner,
+      "claim lock owner is dead and older than sixty seconds", "warning"));
+  }
+  for (const agentId of await watcherIds(context)) {
+    try {
+      const inspected = await inspectWatcherOwnership(context, agentId);
+      if (inspected?.repairable) issues.push(issue("STALE_WATCHER_OWNER",
+        path.join(context.paths.locks, `watcher-${agentId}.json`),
+        "watcher owner is dead and older than sixty seconds", "warning"));
+    } catch {}
+  }
+  return issues.sort((a, b) => a.path.localeCompare(b.path) || a.code.localeCompare(b.code));
+}
+async function performRepairs(context, issues) {
+  const repairs = [];
+  const corruptProtocol = issues.find(item => item.code === "CORRUPT_JSON"
+    && item.path === context.paths.protocol);
+  if (corruptProtocol !== undefined) {
+    const repaired = await quarantineCorrupt(context, corruptProtocol.path);
+    return repaired === null ? repairs : [repaired];
+  }
+  for (const item of issues.filter(entry => entry.code === "CORRUPT_JSON")) {
+    const repaired = await quarantineCorrupt(context, item.path);
+    if (repaired !== null) repairs.push(repaired);
+  }
+  let refreshed = await collectStatus(context);
+  repairs.push(...await repairStaleWatcherMutexes(context, refreshed.locks));
+  refreshed = await collectStatus(context);
+  for (const item of refreshed.messages.acknowledgements) {
+    if (item.location !== "inbox") continue;
+    const repaired = await archiveAcknowledged(context, item.message);
+    if (repaired !== null) repairs.push(repaired);
+  }
+  if (issues.some(item => item.code === "STALE_CLAIM_LOCK")
+    && await repairStaleClaimLock(context)) repairs.push({
+    action: "repair_stale_claim_lock", path: path.join(context.paths.locks, "claims.lock") });
+  for (const agentId of await watcherIds(context)) if (
+    await repairStaleWatcherOwnership(context, agentId)) repairs.push({
+    action: "repair_stale_watcher_owner",
+    path: path.join(context.paths.locks, `watcher-${agentId}.json`),
+  });
+  return repairs;
+}
+export async function runDoctor(context, input = {}) {
+  let report = await collectStatus(context);
+  let issues = await operationalIssues(context, report, input);
+  const incompatible = issues.some(item => ["PROTOCOL_MISSING", "UNKNOWN_PROTOCOL_VERSION",
+    "UNKNOWN_SCHEMA_VERSION"]
+    .includes(item.code));
+  const corruptAudit = report.corrupt.some(filePath => isRepairStoragePath(context, filePath));
+  let repairs = [];
+  if (input.repair && !incompatible && !corruptAudit) {
+    if (report.locks.doctor?.state === "stale"
+      && await repairStaleRepairMutex(context, "doctor")) repairs.push({
+      action: "repair_stale_doctor_mutex", path: report.locks.doctor.path });
+    if (!["young", "corrupt"].includes(report.locks.doctor?.state)) repairs =
+      repairs.concat(await withRepairMutex(context, "doctor", null, async () => {
+        const lockedReport = await collectStatus(context);
+        const lockedIssues = await operationalIssues(context, lockedReport,
+          { ...input, doctorMutexHeld: true });
+        const lockedIncompatible = lockedIssues.some(item => ["PROTOCOL_MISSING",
+          "UNKNOWN_PROTOCOL_VERSION", "UNKNOWN_SCHEMA_VERSION"].includes(item.code));
+        const lockedCorruptAudit = lockedReport.corrupt.some(filePath =>
+          isRepairStoragePath(context, filePath));
+        return lockedIncompatible || lockedCorruptAudit ? []
+          : performRepairs(context, lockedIssues);
+      }));
+  }
+  if (input.repair) { report = await collectStatus(context);
+    issues = await operationalIssues(context, report, input); }
+  return { ok: issues.length === 0, issues, repairs };
+}
+export function enforcementExit(report, options = {}) {
+  if (report.corrupt.length > 0 || report.locks.doctor?.state === "corrupt"
+    || report.locks.watcher.corrupt.length > 0) return EXIT.DATA;
+  if (options.failOnStale && report.agents.stale.length > 0) return EXIT.REQUIRED;
+  if (options.failOnPending && report.messages.required_unacked.length > 0) return EXIT.REQUIRED;
+  return EXIT.OK;
+}

--- a/prototype/integrated/tools/agents/lib/status.mjs
+++ b/prototype/integrated/tools/agents/lib/status.mjs
@@ -2,20 +2,21 @@ import { access } from "node:fs/promises";
 import path from "node:path";
 import { listDirectoryEntries, listJsonFiles, readJsonStrict } from "./atomic-json.mjs";
 import { inspectClaimRecords } from "./claim-records.mjs";
-import { repairStaleClaimLock } from "./claims.mjs";
+import { repairPendingForceReleases, repairStaleClaimLock } from "./claims.mjs";
 import { archiveAcknowledged, quarantineCorrupt, scanDoctorAudits }
   from "./doctor-storage.mjs";
 import { protocolCompatibilityIssue } from "./doctor-protocol.mjs";
 import { EXIT } from "./errors.mjs";
 import { inspectWatcherOwnership, presenceState, repairStaleWatcherOwnership } from "./presence.mjs";
+import { inspectRecoveryAudits, isRecoveryArtifactPath, recoveryIssues }
+  from "./recovery-audits.mjs";
 import { repairStaleRepairMutex, scanRepairMutexAudits, withRepairMutex } from "./repair-mutex.mjs";
 import { collectMutexStatus, mutexIssues, repairStaleWatcherMutexes } from "./status-locks.mjs";
 import { validateAcknowledgement, validateHandoff, validateLock,
   validateMessage, validatePresence, validateProtocol, validateRegistry,
   validateSeenReceipt } from "./schema.mjs";
-async function exists(filePath) { try { await access(filePath); return true; }
-  catch (error) { if (error.code === "ENOENT") return false; throw error; }
-}
+async function exists(filePath) { try { await access(filePath); return true; } catch (error) {
+  if (error.code === "ENOENT") return false; throw error; } }
 function addCorrupt(state, filePath) { if (!state.corrupt.includes(filePath)) state.corrupt.push(filePath); }
 async function safeRead(context, filePath, validate, state) {
   try { return await readJsonStrict(filePath, validate, context.paths.root); }
@@ -32,8 +33,7 @@ async function nestedJsonFiles(context, root) {
     listJsonFiles(path.join(root, entry.name), { root: context.paths.root })))).flat();
 }
 function fileStem(filePath) { return path.basename(filePath, ".json"); }
-function sortRecords(records, field) { return records.sort(
-  (a, b) => a[field].localeCompare(b[field])); }
+function sortRecords(records, field) { return records.sort((a, b) => a[field].localeCompare(b[field])); }
 async function readProtocol(context, state) {
   const record = await safeRead(context, context.paths.protocol, validateProtocol, state);
   if (record === null) {
@@ -164,22 +164,20 @@ async function readLockCorruption(context, state) {
     path.join(context.paths.locks, `watcher-${agentId}.json`)); }
 }
 export async function collectStatus(context) {
-  const state = { corrupt: [] };
+  const state = { corrupt: [] }, recovery = await inspectRecoveryAudits(context);
   await readLockCorruption(context, state);
-  for (const auditPath of [...await scanDoctorAudits(context),
-    ...await scanRepairMutexAudits(context)]) addCorrupt(state, auditPath);
+  for (const auditPath of [...await scanDoctorAudits(context), ...await scanRepairMutexAudits(context),
+    ...recovery.corrupt]) addCorrupt(state, auditPath);
   const report = { protocol: await readProtocol(context, state),
     agents: await readAgents(context, state),
     messages: await messageStatus(context, state), claims: await readClaims(context, state),
-    handoffs: await readHandoffs(context, state), locks: await collectMutexStatus(context),
+    handoffs: await readHandoffs(context, state), recovery, locks: await collectMutexStatus(context),
     corrupt: state.corrupt.sort() };
   report.counts = counts(report);
   return report;
 }
-function issue(code, filePath, message, severity = "error") { return {
-  code, severity, path: filePath, message }; }
-function isRepairStoragePath(context, filePath) { return path.dirname(filePath) === context.paths.quarantine
-  && /^(doctor-audit-|mutex-audit-|mutex-stale-)/.test(path.basename(filePath)); }
+function issue(code, filePath, message, severity = "error") {
+  return { code, severity, path: filePath, message }; }
 async function watcherIds(context) {
   const entries = await listDirectoryEntries(context.paths.locks, { root: context.paths.root });
   return entries.filter(entry => entry.isFile() && /^watcher-.+\.json$/.test(entry.name))
@@ -195,6 +193,7 @@ async function operationalIssues(context, report, input) {
   if (protectedProtocol !== null) issues.push(protectedProtocol);
   issues.push(...mutexIssues(report.locks, issue).filter(item =>
     !(input.doctorMutexHeld && item.code === "DOCTOR_MUTEX_LIVE")));
+  issues.push(...recoveryIssues(report.recovery, issue));
   for (const filePath of report.corrupt) if (filePath !== context.paths.protocol
     || (!protocolMissing && protectedProtocol === null)) issues.push(issue("CORRUPT_JSON", filePath,
     "invalid or inconsistent protocol record"));
@@ -252,6 +251,7 @@ async function performRepairs(context, issues) {
   if (issues.some(item => item.code === "STALE_CLAIM_LOCK")
     && await repairStaleClaimLock(context)) repairs.push({
     action: "repair_stale_claim_lock", path: path.join(context.paths.locks, "claims.lock") });
+  repairs.push(...await repairPendingForceReleases(context));
   for (const agentId of await watcherIds(context)) if (
     await repairStaleWatcherOwnership(context, agentId)) repairs.push({
     action: "repair_stale_watcher_owner",
@@ -265,7 +265,7 @@ export async function runDoctor(context, input = {}) {
   const incompatible = issues.some(item => ["PROTOCOL_MISSING", "UNKNOWN_PROTOCOL_VERSION",
     "UNKNOWN_SCHEMA_VERSION"]
     .includes(item.code));
-  const corruptAudit = report.corrupt.some(filePath => isRepairStoragePath(context, filePath));
+  const corruptAudit = report.corrupt.some(filePath => isRecoveryArtifactPath(context, filePath));
   let repairs = [];
   if (input.repair && !incompatible && !corruptAudit) {
     if (report.locks.doctor?.state === "stale"
@@ -279,7 +279,7 @@ export async function runDoctor(context, input = {}) {
         const lockedIncompatible = lockedIssues.some(item => ["PROTOCOL_MISSING",
           "UNKNOWN_PROTOCOL_VERSION", "UNKNOWN_SCHEMA_VERSION"].includes(item.code));
         const lockedCorruptAudit = lockedReport.corrupt.some(filePath =>
-          isRepairStoragePath(context, filePath));
+          isRecoveryArtifactPath(context, filePath));
         return lockedIncompatible || lockedCorruptAudit ? []
           : performRepairs(context, lockedIssues);
       }));

--- a/prototype/integrated/tools/agents/lib/watcher-ownership.mjs
+++ b/prototype/integrated/tools/agents/lib/watcher-ownership.mjs
@@ -1,0 +1,117 @@
+import { randomUUID } from "node:crypto";
+import { link, unlink } from "node:fs/promises";
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+
+import { readJsonStrict, writeJsonAtomic } from "./atomic-json.mjs";
+import { CommsError, EXIT } from "./errors.mjs";
+import { withRepairMutex } from "./repair-mutex.mjs";
+import { validatePresence } from "./schema.mjs";
+
+const STALE_OWNERSHIP_MS = 60_000;
+function ownershipPath(context, agentId) {
+  return path.join(context.paths.locks, `watcher-${agentId}.json`);
+}
+function staleOwnershipPath(context, owner) {
+  return path.join(context.paths.quarantine, `watcher-owner-stale-${owner.token}.json`);
+}
+function validateOwnership(value) {
+  const keys = ["acquired_at", "agent_id", "pid", "schema_version", "token"];
+  if (value === null || typeof value !== "object" || Array.isArray(value)
+    || Object.keys(value).sort().join() !== keys.join() || value.schema_version !== 1
+    || typeof value.token !== "string"
+    || !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(value.token)) {
+    throw new CommsError("invalid watcher ownership", EXIT.DATA);
+  }
+  validatePresence({ schema_version: 1, agent_id: value.agent_id, pid: value.pid,
+    status: "online", heartbeat_at: value.acquired_at });
+  return value;
+}
+async function readOwnership(context, agentId) {
+  try {
+    const owner = await readJsonStrict(ownershipPath(context, agentId), validateOwnership);
+    if (owner.agent_id !== agentId) {
+      throw new CommsError("watcher ownership agent does not match its path", EXIT.DATA,
+        { agentId, ownerAgentId: owner.agent_id });
+    }
+    return owner;
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+function withMutex(context, agentId, operation) {
+  return withRepairMutex(context, "watcher", agentId, operation);
+}
+async function writePresence(context, agentId, pid, status) {
+  const record = validatePresence({ schema_version: 1, agent_id: agentId, pid, status,
+    heartbeat_at: context.now().toISOString() });
+  await writeJsonAtomic(context.paths.presenceFile(agentId), record,
+    { tmpDir: context.paths.tmp, exclusive: false });
+}
+
+export async function inspectWatcherOwnership(context, agentId) {
+  const owner = await readOwnership(context, agentId);
+  if (owner === null) return null;
+  const age = context.now().getTime() - Date.parse(owner.acquired_at);
+  return Object.freeze({ owner,
+    repairable: age > STALE_OWNERSHIP_MS && !context.pidIsAlive(owner.pid) });
+}
+
+export async function acquireWatcherOwnership(context, agentId, pid) {
+  return withMutex(context, agentId, async () => {
+    const owner = validateOwnership({ schema_version: 1, agent_id: agentId, pid,
+      token: (context.randomUUID ?? randomUUID)(),
+      acquired_at: context.now().toISOString() });
+    try {
+      await writeJsonAtomic(ownershipPath(context, agentId), owner,
+        { tmpDir: context.paths.tmp, exclusive: true });
+    } catch (error) {
+      if (!(error instanceof CommsError) || error.exitCode !== EXIT.CONFLICT) throw error;
+      await readOwnership(context, agentId);
+      throw new CommsError("agent id already has a watcher owner", EXIT.CONFLICT, { agentId });
+    }
+    try { await writePresence(context, agentId, pid, "online"); }
+    catch (error) {
+      const current = await readOwnership(context, agentId);
+      if (current?.token === owner.token) await unlink(ownershipPath(context, agentId));
+      throw error;
+    }
+    return owner;
+  });
+}
+
+async function writeIfOwner(context, owner, status, release) {
+  const current = await readOwnership(context, owner.agent_id);
+  if (current === null || current.token !== owner.token) return false;
+  await writePresence(context, owner.agent_id, owner.pid, status);
+  if (release) await unlink(ownershipPath(context, owner.agent_id));
+  return true;
+}
+export async function writePresenceIfWatcherOwner(context, owner, status, release = false) {
+  if (!release) return writeIfOwner(context, owner, status, false);
+  return withMutex(context, owner.agent_id,
+    () => writeIfOwner(context, owner, status, true));
+}
+
+export async function repairStaleWatcherOwnership(context, agentId) {
+  return withMutex(context, agentId, async () => {
+    const inspected = await inspectWatcherOwnership(context, agentId);
+    if (inspected === null || !inspected.repairable) return false;
+    const active = ownershipPath(context, agentId);
+    const destination = staleOwnershipPath(context, inspected.owner);
+    try { await (context.linkWatcherOwner ?? link)(active, destination); }
+    catch (error) {
+      if (error.code === "ENOENT") return false;
+      if (error.code !== "EEXIST") throw error;
+      const quarantined = await readJsonStrict(destination, validateOwnership);
+      if (!isDeepStrictEqual(quarantined, inspected.owner)) return false;
+    }
+    const [current, quarantined] = await Promise.all([
+      readOwnership(context, agentId), readJsonStrict(destination, validateOwnership) ]);
+    if (current === null || !isDeepStrictEqual(current, inspected.owner)
+      || !isDeepStrictEqual(quarantined, inspected.owner)) return false;
+    await unlink(active);
+    return true;
+  });
+}

--- a/prototype/integrated/tools/agents/lib/watcher-ownership.mjs
+++ b/prototype/integrated/tools/agents/lib/watcher-ownership.mjs
@@ -29,7 +29,8 @@ function validateOwnership(value) {
 }
 async function readOwnership(context, agentId) {
   try {
-    const owner = await readJsonStrict(ownershipPath(context, agentId), validateOwnership);
+    const owner = await readJsonStrict(ownershipPath(context, agentId), validateOwnership,
+      context.paths.root);
     if (owner.agent_id !== agentId) {
       throw new CommsError("watcher ownership agent does not match its path", EXIT.DATA,
         { agentId, ownerAgentId: owner.agent_id });
@@ -104,11 +105,13 @@ export async function repairStaleWatcherOwnership(context, agentId) {
     catch (error) {
       if (error.code === "ENOENT") return false;
       if (error.code !== "EEXIST") throw error;
-      const quarantined = await readJsonStrict(destination, validateOwnership);
+      const quarantined = await readJsonStrict(destination, validateOwnership,
+        context.paths.root);
       if (!isDeepStrictEqual(quarantined, inspected.owner)) return false;
     }
     const [current, quarantined] = await Promise.all([
-      readOwnership(context, agentId), readJsonStrict(destination, validateOwnership) ]);
+      readOwnership(context, agentId),
+      readJsonStrict(destination, validateOwnership, context.paths.root) ]);
     if (current === null || !isDeepStrictEqual(current, inspected.owner)
       || !isDeepStrictEqual(quarantined, inspected.owner)) return false;
     await unlink(active);

--- a/prototype/integrated/tools/agents/lib/watcher-ownership.mjs
+++ b/prototype/integrated/tools/agents/lib/watcher-ownership.mjs
@@ -44,6 +44,9 @@ async function readOwnership(context, agentId) {
 function withMutex(context, agentId, operation) {
   return withRepairMutex(context, "watcher", agentId, operation);
 }
+export function withWatcherLifecycle(context, agentId, operation) {
+  return withMutex(context, agentId, operation);
+}
 async function writePresence(context, agentId, pid, status) {
   const record = validatePresence({ schema_version: 1, agent_id: agentId, pid, status,
     heartbeat_at: context.now().toISOString() });
@@ -59,8 +62,9 @@ export async function inspectWatcherOwnership(context, agentId) {
     repairable: age > STALE_OWNERSHIP_MS && !context.pidIsAlive(owner.pid) });
 }
 
-export async function acquireWatcherOwnership(context, agentId, pid) {
+export async function acquireWatcherOwnership(context, agentId, pid, assertAllowed) {
   return withMutex(context, agentId, async () => {
+    await assertAllowed?.();
     const owner = validateOwnership({ schema_version: 1, agent_id: agentId, pid,
       token: (context.randomUUID ?? randomUUID)(),
       acquired_at: context.now().toISOString() });


### PR DESCRIPTION
Executes `docs/superpowers/plans/2026-08-15-acc-prototype-reconciliation.md` end to end. Produces `prototype/integrated/`, a mutable snapshot of the preserved baseline with all four archived hardening sets reconciled and verified together, plus the certification evidence the core-extraction plan needs as its precondition.

The immutable artefacts are untouched: `prototype/papercut-agent-comms/` is unchanged, and all four patch checksums still match `migration/README.md`.

## Result

| Stage | Tests | Substance |
|---|---:|---|
| Task 1 snapshot | 181 | Mechanical copy; replaced the fixed 80 ms SIGTERM delay with condition-based readiness |
| Task 2 storage (0003) | 210 | Root-aware no-follow reads, record/filename binding, no-replace archives |
| Task 3 lifecycle (0002) | 232 | Protocol guard ported onto managed-root storage; 4 regressions added beyond the patch |
| Task 4 doctor (0004) | 251 | Recovery audit inventory and idempotent crash replay |
| Task 5 prompt (0001) | 252 | Shell-safe substitution of agent-controlled values |
| Task 6 certification | **271** | 12 cross-patch regressions from `docs/MIGRATION.md` plus mutation evidence |

`npm run test:integrated` passes 271/271. `node --check` is clean across all integrated `.mjs`, `git diff --check` is clean, and no production or test file reaches 300 lines.

## How the overlapping patches were reconciled

0002 and 0004 do not apply onto the storage-ported tree, exactly as `docs/MIGRATION.md` predicts. They were ported by three-way merge rather than retyped: the pre-image blobs are already in this repository because `prototype/papercut-agent-comms` is byte-identical to the patch base, and git addresses content rather than repositories. Conflicts landed precisely where MIGRATION.md says they would, and each was resolved by the plan's rule — storage's managed-root API wins, lifecycle and doctor semantics are ported onto it.

## Findings worth reviewer attention

**A silent defect in 0004.** The archived audit scanners pass their injected opener in the managed-root position. That was correct against the pre-storage signature, but managed reads reject a missing root with `EXIT.DATA`, and every scanner wraps its read in `catch { corrupt.add(filePath) }`. Ported verbatim, the reconciled tree would have declared *every* recovery artifact corrupt and blocked all repair — failing closed, but for an invented reason. Root is now threaded through every managed read, verified by a multi-line scan.

**No single predicate carries a protection group.** Mutation testing found 2–3 independent barriers per group, so a single-predicate mutation does not turn the combined tests red. The certification records which combinations are actually load-bearing rather than claiming a gate was proven by the first mutation that came to hand.

**One of my own assertions was wrong.** An acknowledgement receipt does outlive a failed archive move, deliberately — it is the evidence doctor requires to finish an interrupted move. The test now asserts the stronger true property instead of the production code being changed to satisfy it.

**Two arbitrary-timeout defects in the preserved harness.** The SIGTERM test terminated the watcher at a fixed 80 ms while ownership is published at ~103 ms, so the child died from the default signal disposition before installing its handler. Separately, a liveness property was encoded as a 300 ms latency budget. Both were measured before being changed, and the first fix's own regression — an uncleared `Promise.race` timer that made the suite four times slower — was caught by measurement rather than assumed away.

## Pre-push gate

Adds `.githooks/pre-push` (lint plus the protocol suite), enabled per clone with `git config core.hooksPath .githooks`.

Its first run rejected this very push and exposed a latent flaw in the preserved harness: git exports `GIT_DIR` into hook environments, and the fixtures spawned `git` without stripping it, so every fixture operated on the real repository. It flipped `core.bare`, created a stray branch, and stacked empty commits on the working branch. No content was lost and the repository was fully restored. Fixtures now build their environment through `hermeticEnv()`, the hook unsets the variables as a second barrier, and `harness-hermeticity.test.mjs` guards both.

## Scope held deliberately

No standalone renaming or package extraction. Papercut vocabulary (`PW2_AGENT_BUS_DIR`, checkout identity, `tools/agents/comms.mjs`) is retained by design; renaming belongs to the extraction plan. Production `defaultGitQuery` still inherits the ambient environment — recorded as a limitation for the extraction plan's injected `gitProbe` port, since ACC adapters are hook-driven by design.

`prototype/integrated/COMBINED_VERIFICATION.md` holds the full evidence: provenance, per-case coverage of all twelve required regressions, exact mutation outcomes, five corrections, and six remaining limitations — including that all evidence comes from a single macOS arm64 host.

`docs/PROGRESS.md` marks the integration checkbox complete and points the next action at the core-extraction plan. No other checkbox changed.