### PR TITLE
Codex: finish the install, and tell a session what it can break

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -27,7 +27,7 @@ should be re-run before claiming another platform.
 | `lifecycle.heartbeat` | no | no | no | yes |
 | `lifecycle.childSessions` | no | no | no | no |
 | `context.startupInjection` | no | no | no | no |
-| `context.beforeTurnInjection` | no | yes | yes | yes |
+| `context.beforeTurnInjection` | yes | yes | yes | yes |
 | `context.safePointInjection` | no | no | no | no |
 | `guards.beforeRead` | no | no | no | no |
 | `guards.beforeWrite` | yes | yes | yes | yes |
@@ -59,6 +59,11 @@ toolset contained no `apply_patch`.
 ACC does not parse commands. The guard fires and is allowed through, because guessing a
 path out of a command would block work at random and still miss real writes. Shell calls
 therefore declare no targets on every adapter.
+
+Where the guard cannot help, the turn context does: it names the claims other sessions
+hold and says which way this session stands with them - unenforced entirely, or enforced
+for file edits but not for anything done through a shell. Unenforceable is not the same as
+unknown.
 
 **`lifecycle.sessionEnd` on `kimi` is false and it matters.** Each `kimi -p` run leaves an
 attached session that only ages out on its declared 60s cadence, so a peer reading the
@@ -95,10 +100,14 @@ client reports nothing.
 
 Context injection does not follow the deny contract even within one client:
 
-| Injection | claude_code | gemini_cli | kimi |
-|---|---|---|---|
-| `hookSpecificOutput.additionalContext` | works | works | works, but **not unwrapped** |
-| plain text on stdout | - | dropped | works |
+| Injection | codex | claude_code | gemini_cli | kimi |
+|---|---|---|---|---|
+| `hookSpecificOutput.additionalContext` | - | works | works | works, but **not unwrapped** |
+| plain text on stdout | works | - | dropped | works |
+
+Codex delivers a hook's stdout as a `developer` role message, verbatim - the most direct
+of the four channels, and a reason for care rather than comfort: at that role a model
+reads text as instruction, so peer-authored text has to stay framed as data.
 
 Kimi Code shows the model whatever a hook printed, wrapped in
 `<hook_result hook_event="…">`, so the JSON envelope itself would end up in the
@@ -113,16 +122,17 @@ the user turn, and drops a bare string entirely.
 | Project-level config | no | no | yes | **no** |
 | Hook `timeout` unit | - | - | milliseconds | **seconds** (max 600) |
 | Command path | absolute required | `${CLAUDE_PLUGIN_ROOT}` | absolute required | absolute required |
-| Extra step by the user | `codex plugin add` **and** hook trust | - | - | - |
+| Extra step by the user | hook trust | - | - | - |
 
 Kimi Code is the only one with no project-level config, so ACC edits the user's global
 `config.toml` - as a delimited block it owns, because ACC ships without dependencies and a
 hand-written TOML round-tripper would take the user's comments and formatting with it.
 
-Codex is the only one ACC cannot finish installing on its own. Publishing, registering and
-enabling are all necessary and still not sufficient: hooks stay silent until the client
-copies the plugin into its own cache, which only `codex plugin add` does. `acc doctor`
-reports the remaining command.
+Codex needs four things before a hook runs, not one: the plugin directory, a parseable
+marketplace, both `[marketplaces.…]` and `[plugins."…"]` registered in its config, and the
+plugin copied into `plugins/cache/<marketplace>/<plugin>/<version>/`. ACC does all four -
+that last copy is exactly and only what `codex plugin add` does, measured by diffing the
+home around it. Hook trust remains a manual step, which is the client's security model.
 
 ## What a participant declares about itself
 

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -61,9 +61,16 @@ path out of a command would block work at random and still miss real writes. She
 therefore declare no targets on every adapter.
 
 Where the guard cannot help, the turn context does: it names the claims other sessions
-hold and says which way this session stands with them - unenforced entirely, or enforced
-for file edits but not for anything done through a shell. Unenforceable is not the same as
-unknown.
+hold and says which way this session stands with them. Two facts decide the wording -
+what the claim's owner asked for, and whether ACC can stop this session at all:
+
+| Claim | This session | Note |
+|---|---|---|
+| guarded | can be guarded | `file edits are blocked; edits made through a shell are not` |
+| guarded | cannot be guarded | `not enforced for this session; do not edit it` |
+| advisory | either | `advisory; nothing will stop you, the owner is asking` |
+
+Unenforceable is not the same as unknown - and neither is it the same as unclaimed.
 
 **`lifecycle.sessionEnd` on `kimi` is false and it matters.** Each `kimi -p` run leaves an
 attached session that only ages out on its declared 60s cadence, so a peer reading the

--- a/packages/adapter-codex/COMPATIBILITY.md
+++ b/packages/adapter-codex/COMPATIBILITY.md
@@ -161,9 +161,19 @@ Four things must all be true before a single hook runs:
 4. the client has **installed** it - `codex plugin add agents-can-communicate@acc-local` -
    which copies it into `$CODEX_HOME/plugins/cache/`.
 
-ACC does 1-3. Step 4 is the client's own command and ACC cannot do it by writing files, so
-`detect` reports it and names the command. Verified: with steps 1-3 done and step 4 not,
-the plugin lists as `not installed` and no hook fires.
+ACC does all four. Step 4 looked like the client's own business until it was measured:
+diffing `$CODEX_HOME` around `codex plugin add` shows the command does exactly one thing -
+copy the plugin into `plugins/cache/<marketplace>/<plugin>/<version>/`. Nothing else
+changes, not `config.toml` and nothing under `HOME`, and all three path components are
+ACC's own: the marketplace it created, the plugin name it chose, and the version in the
+manifest it ships.
+
+So ACC writes that copy itself, and a real session against an ACC-written cache fires
+every hook. `detect` still names `codex plugin add` for the case where the cache is
+missing - someone cleared it, or the client moved where it keeps one - because then the
+supported command is the right answer.
+
+Hook trust remains a manual step. That one is the client's security model, not a gap.
 
 Because the client runs the *cached copy*, a hook command relative to the bundle would not
 survive installation. ACC's shim is written with absolute paths, so it does.
@@ -194,3 +204,35 @@ that matters for a matcher is the one hooks see.
 Unlike Kimi Code, this client fires `SessionEnd`. Observed across a full run: `SessionStart`,
 `UserPromptSubmit`, `PreToolUse`, `Stop`, `SessionEnd` - and afterwards ACC's runtime state
 held no session record and no binding. Nothing is left to age out.
+
+
+## Context injection, finally observed
+
+Declared false for a long time with the honest reason "never seen reaching the model".
+It has now been seen. A `UserPromptSubmit` hook's stdout arrives in the request as a
+**`developer` role message**, verbatim and unwrapped:
+
+```json
+{"type":"message","role":"developer","content":[{"type":"input_text","text":"…"}]}
+```
+
+No envelope of any kind, so the injection is plain text - Claude Code's JSON envelope
+would put the envelope itself into the conversation, exactly as it would on Kimi Code.
+
+The `developer` role is the most direct channel of the four, which is a reason for care
+rather than comfort: at that role a model reads text as instruction, so anything a peer
+wrote has to stay framed as data. The shared projector does that framing.
+
+This matters most where the guard cannot help. With a model that has no `apply_patch`,
+edits run through the shell and no claim can be matched against them. ACC cannot stop that
+write, so it says so before the turn instead:
+
+```text
+2 session(s); cursor 0000000000000004
+- [claim] file:src/** held by models - file edits are blocked; edits made through a shell are not
+- session_9Xo… (cli, online)
+- session_BlU… (codex, online)
+```
+
+Captured from a real session: the peer held the claim, and the Codex model was told before
+it started. Unenforceable is not the same as unknown.

--- a/packages/adapter-codex/COMPATIBILITY.md
+++ b/packages/adapter-codex/COMPATIBILITY.md
@@ -236,3 +236,15 @@ write, so it says so before the turn instead:
 
 Captured from a real session: the peer held the claim, and the Codex model was told before
 it started. Unenforceable is not the same as unknown.
+
+The note has three forms, because two separate facts decide it - what the claim's owner
+asked for, and whether ACC can stop this particular session:
+
+| Claim | This session | Note |
+|---|---|---|
+| guarded | can be guarded | `file edits are blocked; edits made through a shell are not` |
+| guarded | cannot be guarded | `not enforced for this session; do not edit it` |
+| advisory | either | `advisory; nothing will stop you, the owner is asking` |
+
+Reading only the session's capability would announce a block on an advisory claim that
+will never happen - and its owner explicitly did not ask for one.

--- a/packages/adapter-codex/src/adapter.mjs
+++ b/packages/adapter-codex/src/adapter.mjs
@@ -1,6 +1,7 @@
 import { defineAdapter, projectContext } from "@agents-can-communicate/adapter-sdk";
 
-import { allowOutcome, denyOutcome, normalizeCodexHook } from "./hooks.mjs";
+import { allowOutcome, denyOutcome, injectOutcome, normalizeCodexHook }
+  from "./hooks.mjs";
 import { detectCodex, installCodexPlugin, uninstallCodexPlugin } from "./install.mjs";
 
 export const CODEX_VERSION = "0.147.0";
@@ -24,6 +25,8 @@ export function createCodexAdapter() {
     displayName: "Codex CLI",
     capabilities: {
       lifecycle: { sessionStart: true, sessionEnd: true },
+      // Observed reaching the model as a `developer` role message, unwrapped.
+      context: { beforeTurnInjection: true },
       // PreToolUse was observed blocking both a shell command and an
       // apply_patch edit, with the reason reaching the model verbatim.
       guards: { beforeWrite: true, beforeShell: true },
@@ -66,6 +69,7 @@ export function createCodexAdapter() {
 
     denyOutcome,
     allowOutcome,
+    injectOutcome,
     normalizeHook: payload => normalizeCodexHook(payload),
     renderContext: sync => projectContext(sync),
   });

--- a/packages/adapter-codex/src/hooks.mjs
+++ b/packages/adapter-codex/src/hooks.mjs
@@ -115,3 +115,19 @@ export function denyOutcome(reason) {
 export function allowOutcome() {
   return { stdout: "", stderr: "", exitCode: 0 };
 }
+
+/**
+ * Context for the next turn.
+ *
+ * This client wraps nothing: a UserPromptSubmit hook's stdout arrives at the
+ * model as a `developer` role message, verbatim. So the injection is plain
+ * text - emitting Claude Code's JSON envelope would put the envelope itself
+ * into the conversation, the same mistake it would be on Kimi Code.
+ *
+ * The developer role is the most direct channel of the four, which is a reason
+ * to be careful with what goes into it: anything a peer wrote must stay framed
+ * as data, because at this role the model reads text as instruction.
+ */
+export function injectOutcome(context) {
+  return { stdout: context === "" ? "" : `${context}\n`, stderr: "", exitCode: 0 };
+}

--- a/packages/adapter-codex/src/install.mjs
+++ b/packages/adapter-codex/src/install.mjs
@@ -18,9 +18,16 @@ const QUALIFIED = `${PLUGIN_NAME}@${MARKETPLACE}`;
 const marketplacePath = root => path.join(root, ".agents", "plugins", "marketplace.json");
 const pluginPath = (root, name = PLUGIN_NAME) => path.join(root, "plugins", name);
 const configPath = codexHome => path.join(codexHome, "config.toml");
-// Where `codex plugin add` leaves the copy it actually runs.
-const cachePath = codexHome =>
-  path.join(codexHome, "plugins", "cache", MARKETPLACE, PLUGIN_NAME);
+// Where `codex plugin add` leaves the copy it actually runs. All three
+// components are ACC's own - the marketplace it created, the plugin name it
+// chose, and the version in the manifest it ships - so ACC can write this copy
+// itself rather than asking the user to run a command. Verified on 0.147.0:
+// diffing the home around `codex plugin add` shows that copy is the only thing
+// it does, and a real session against a cache ACC wrote fires every hook.
+const cacheRoot = codexHome => path.join(codexHome, "plugins", "cache", MARKETPLACE);
+const cachePath = codexHome => path.join(cacheRoot(codexHome), PLUGIN_NAME);
+const cachedVersionPath = (codexHome, version) =>
+  path.join(cachePath(codexHome), version);
 
 async function readJson(file, fallback) {
   try {
@@ -106,7 +113,15 @@ export async function installCodexPlugin({ home, agentsHome = home,
     "enabled = true",
   ]);
 
-  return { ok: true, changes: [target, file, config],
+  // The client runs the cached copy, so this has to happen after the shim and
+  // the rewritten hooks.json are in place.
+  const { version } = await readJson(
+    path.join(target, ".codex-plugin", "plugin.json"), { version: "0.0.0" });
+  const cached = cachedVersionPath(codexHome, version);
+  await rm(cached, { recursive: true, force: true });
+  await cp(target, cached, { recursive: true });
+
+  return { ok: true, changes: [target, file, config, cached],
     diagnostics: ["hooks require explicit trust in Codex before they run"] };
 }
 
@@ -121,6 +136,9 @@ export async function uninstallCodexPlugin({ home, agentsHome = home,
     await writeJson(file, { ...existing, plugins: kept });
   }
   if (await removeTomlBlock(configPath(codexHome))) changes.push(configPath(codexHome));
+  // The marketplace directory is ACC's too, so it goes rather than being left
+  // behind empty.
+  await rm(cacheRoot(codexHome), { recursive: true, force: true });
   await rm(pluginPath(agentsHome), { recursive: true, force: true });
   return { ok: true, changes, diagnostics: [] };
 }

--- a/packages/adapter-codex/test/install.test.mjs
+++ b/packages/adapter-codex/test/install.test.mjs
@@ -7,7 +7,7 @@ import test from "node:test";
 import { EXIT } from "@agents-can-communicate/protocol";
 
 import { createCodexAdapter } from "../src/adapter.mjs";
-import { CODEX_HOOK_EVENTS, normalizeCodexHook } from "../src/hooks.mjs";
+import { CODEX_HOOK_EVENTS, injectOutcome, normalizeCodexHook } from "../src/hooks.mjs";
 
 // A marketplace the user already owns, in the shape this client actually
 // parses. `plugins` is a sequence; a map is rejected and takes the whole file
@@ -120,9 +120,7 @@ test("only capabilities observed in a real session are declared true", () => {
   assert.equal(capabilities.guards.beforeWrite, true);
   assert.equal(capabilities.guards.beforeShell, true);
 
-  // Not observed, so not claimed. Injection was never seen reaching the model,
-  // and no subagent ran during the capture.
-  assert.equal(capabilities.context.beforeTurnInjection, false);
+  // Not observed, so not claimed: no subagent ran during the capture.
   assert.equal(capabilities.lifecycle.childSessions, false);
   assert.equal(capabilities.delivery.wakeDormantSession, false);
   for (const value of Object.values(capabilities.execution)) assert.equal(value, false);
@@ -309,17 +307,20 @@ test("uninstall takes the config registration back out", async t => {
   assert.equal(await readFile(configFile, "utf8"), "model = \"gpt-5\"\n");
 });
 
-test("detect says plainly that the client still has to install the plugin", async t => {
+test("detect names the client's own command if the cache is gone", async t => {
   const { context } = await realFixture(t);
   const adapter = createCodexAdapter();
-
   await adapter.install(context);
-  const report = await adapter.detect(context);
 
   // Publishing, registering and enabling are all necessary and still not
-  // sufficient: hooks stay silent until the client copies the plugin into its
-  // own cache, which only `codex plugin add` does. Verified against 0.147.0.
-  const said = report.diagnostics.join(" ");
+  // sufficient: hooks stay silent unless the plugin is in the client's cache.
+  // ACC writes that copy now, so this is the state after someone clears the
+  // cache or the client changes where it keeps one - and then the supported
+  // command is the answer to name.
+  await rm(path.join(context.codexHome, "plugins", "cache"),
+    { recursive: true, force: true });
+
+  const said = (await adapter.detect(context)).diagnostics.join(" ");
   assert.match(said, /codex plugin add agents-can-communicate@acc-local/);
   assert.match(said, /not installed/);
 });
@@ -351,4 +352,78 @@ test("install refuses rather than duplicating a marketplace the user already add
 
   assert.equal(await readFile(config, "utf8"),
     '[marketplaces.acc-local]\nsource_type = "local"\n');
+});
+
+test("install finishes the job the client's own command would have done", async t => {
+  const { context } = await realFixture(t);
+
+  await createCodexAdapter().install(context);
+
+  // `codex plugin add` does exactly one thing: copies the plugin into
+  // $CODEX_HOME/plugins/cache/<marketplace>/<plugin>/<version>. Nothing else
+  // changes - not config.toml, not anything under HOME - and all three path
+  // components are ACC's own. Verified on 0.147.0 by diffing the home around
+  // the command, and by running a real session against a cache ACC wrote:
+  // all five hooks fired.
+  const cached = path.join(context.codexHome, "plugins", "cache", "acc-local",
+    "agents-can-communicate", "0.0.0");
+  assert.deepEqual((await readdir(cached)).sort(),
+    [".codex-plugin", "acc-hook.sh", "hooks.json", "skills"].sort());
+});
+
+test("the cached copy carries the same absolute hook command", async t => {
+  const { context } = await realFixture(t);
+
+  await createCodexAdapter().install(context);
+
+  // The client runs the cached copy, not the published one. A command relative
+  // to the bundle would not survive the copy; an absolute one does, which is
+  // the whole reason the shim is written with absolute paths.
+  const cached = JSON.parse(await readFile(path.join(context.codexHome, "plugins",
+    "cache", "acc-local", "agents-can-communicate", "0.0.0", "hooks.json"), "utf8"));
+  const command = Object.values(cached.hooks)[0][0].hooks[0].command;
+  const executable = command.match(/"([^"]+)"/)[1];
+  assert.equal(path.isAbsolute(executable), true, `relative command: ${command}`);
+});
+
+test("detect reports the plugin as installed straight after install", async t => {
+  const { context } = await realFixture(t);
+  const adapter = createCodexAdapter();
+
+  await adapter.install(context);
+
+  // No remaining manual step to name.
+  const said = (await adapter.detect(context)).diagnostics.join(" ");
+  assert.match(said, /plugin installed in the client's cache/);
+  assert.doesNotMatch(said, /codex plugin add/);
+});
+
+test("uninstall removes the cached copy too", async t => {
+  const { context } = await realFixture(t);
+  const adapter = createCodexAdapter();
+  await adapter.install(context);
+
+  await adapter.uninstall(context);
+
+  await assert.rejects(readdir(path.join(context.codexHome, "plugins", "cache",
+    "acc-local")), error => error.code === "ENOENT");
+});
+
+test("context injection is declared, because it was finally observed", () => {
+  const { capabilities } = createCodexAdapter();
+
+  // Previously false with the honest reason "never seen reaching the model".
+  // It has now been seen: a UserPromptSubmit hook's stdout arrives as a
+  // `developer` role message in the request to the model, unwrapped. Verified
+  // on 0.147.0 against a local stand-in endpoint that records the wire.
+  assert.equal(capabilities.context.beforeTurnInjection, true);
+});
+
+test("injection is plain text, because this client wraps nothing", () => {
+  // No envelope of any kind: whatever the hook prints becomes the message.
+  // Emitting Claude Code's JSON envelope here would put the envelope itself
+  // into the conversation, exactly as it would on Kimi Code.
+  assert.deepEqual(injectOutcome("2 peers"),
+    { stdout: "2 peers\n", stderr: "", exitCode: 0 });
+  assert.deepEqual(injectOutcome(""), { stdout: "", stderr: "", exitCode: 0 });
 });

--- a/packages/adapter-sdk/src/context-projector.mjs
+++ b/packages/adapter-sdk/src/context-projector.mjs
@@ -50,13 +50,27 @@ function attentionLines(attention) {
  * is the whole mitigation: ACC will not intercept the write, so respecting the
  * claim is this session's own responsibility and it needs to know that.
  */
+function claimNote(claim) {
+  // Enforcement is declared per claim, and the guard only ever blocks a guarded
+  // one. Reading this session's capability alone would announce a block that
+  // will never happen, on a claim whose owner explicitly did not ask for one.
+  if (claim.enforcement !== "guarded") {
+    return " - advisory; nothing will stop you, the owner is asking";
+  }
+  if (claim.enforceable === false) {
+    return " - not enforced for this session; do not edit it";
+  }
+  // Guarded, and this session can be stopped - but only on a file edit. No
+  // harness intercepts a shell command, so an edit made through one goes
+  // through whatever the claim says, and a session told merely "this is
+  // claimed" would reasonably assume otherwise.
+  return " - file edits are blocked; edits made through a shell are not";
+}
+
 function claimLines(claims) {
   return claims.map(claim => {
     const owner = claim.ownerParticipantId ?? claim.ownerSessionId ?? "another session";
-    const note = claim.enforceable === false
-      ? " - not enforced for this session; do not edit it"
-      : "";
-    return `- [claim] ${claim.resource} held by ${owner}${note}`;
+    return `- [claim] ${claim.resource} held by ${owner}${claimNote(claim)}`;
   });
 }
 

--- a/packages/adapter-sdk/src/context-projector.mjs
+++ b/packages/adapter-sdk/src/context-projector.mjs
@@ -40,6 +40,26 @@ function attentionLines(attention) {
   return attention.map(item => `- [${item.kind}] ${item.summary}`);
 }
 
+/**
+ * Claims other sessions hold, and whether this session can be stopped from
+ * breaking them.
+ *
+ * Ranked with the required lines rather than the roster, because a claim is
+ * what changes what this session should do next. When it cannot be enforced -
+ * a model that edits through the shell, an MCP client with no hooks - saying so
+ * is the whole mitigation: ACC will not intercept the write, so respecting the
+ * claim is this session's own responsibility and it needs to know that.
+ */
+function claimLines(claims) {
+  return claims.map(claim => {
+    const owner = claim.ownerParticipantId ?? claim.ownerSessionId ?? "another session";
+    const note = claim.enforceable === false
+      ? " - not enforced for this session; do not edit it"
+      : "";
+    return `- [claim] ${claim.resource} held by ${owner}${note}`;
+  });
+}
+
 function peerBlocks(messages) {
   return messages.flatMap(message => [
     `${FENCE}${BLOCK}`,
@@ -68,9 +88,11 @@ export function projectContext(sync, { budgetBytes = DEFAULT_BUDGET_BYTES } = {}
       || left.sourceId.localeCompare(right.sourceId));
   const messages = sync.messages ?? [];
   const roster = sync.roster ?? [];
+  const claims = sync.claims ?? [];
 
   const required = [
     ...attentionLines(attention),
+    ...claimLines(claims),
     ...peerBlocks(messages),
   ];
   const optional = roster.map(item =>

--- a/packages/adapter-sdk/test/context-projector.test.mjs
+++ b/packages/adapter-sdk/test/context-projector.test.mjs
@@ -113,3 +113,49 @@ test("the budget is respected even when a single item is oversized", () => {
     `projection was ${Buffer.byteLength(rendered, "utf8")} bytes`);
   assert.equal(rendered.includes("…"), true, "an oversized item was not marked as truncated");
 });
+
+test("claims held by other sessions are named in the turn context", () => {
+  const projected = projectContext({ solo: false, cursor: "c1", roster: [],
+    attention: [], messages: [],
+    claims: [{ resource: "file:src/**", ownerParticipantId: "models",
+      enforceable: true }] });
+
+  // A peer's claim is only useful if the other session knows about it before it
+  // starts editing. Rendering it after the fact is a conflict report, not
+  // coordination.
+  assert.match(projected, /file:src\/\*\*/);
+  assert.match(projected, /models/);
+});
+
+test("a session that cannot be stopped is told so, not left to assume", () => {
+  const projected = projectContext({ solo: false, cursor: "c1", roster: [],
+    attention: [], messages: [],
+    claims: [{ resource: "file:src/**", ownerParticipantId: "models",
+      enforceable: false }] });
+
+  // The honest case: a Codex model that edits through the shell, or any MCP
+  // client. ACC cannot intercept the write, so the only thing left is to say
+  // that respecting the claim is now this session's own responsibility.
+  assert.match(projected, /cannot be enforced|not enforced/i);
+  assert.match(projected, /file:src\/\*\*/);
+});
+
+test("claims are ranked above the roster when the budget is tight", () => {
+  const projected = projectContext({ solo: false, cursor: "c1",
+    attention: [], messages: [],
+    roster: Array.from({ length: 40 }, (_, index) =>
+      ({ sessionId: `session_${index}`, harness: "codex", presence: "online" })),
+    claims: [{ resource: "file:critical/**", ownerParticipantId: "models",
+      enforceable: false }] }, { budgetBytes: 300 });
+
+  // Roster detail is the first thing to drop. A claim this session can break
+  // without being stopped is the last.
+  assert.match(projected, /file:critical/);
+});
+
+test("no claims means no section at all", () => {
+  const projected = projectContext({ solo: false, cursor: "c1", roster: [],
+    attention: [], messages: [], claims: [] });
+
+  assert.doesNotMatch(projected, /claim/i);
+});

--- a/packages/adapter-sdk/test/context-projector.test.mjs
+++ b/packages/adapter-sdk/test/context-projector.test.mjs
@@ -131,11 +131,12 @@ test("a session that cannot be stopped is told so, not left to assume", () => {
   const projected = projectContext({ solo: false, cursor: "c1", roster: [],
     attention: [], messages: [],
     claims: [{ resource: "file:src/**", ownerParticipantId: "models",
-      enforceable: false }] });
+      enforcement: "guarded", enforceable: false }] });
 
-  // The honest case: a Codex model that edits through the shell, or any MCP
-  // client. ACC cannot intercept the write, so the only thing left is to say
-  // that respecting the claim is now this session's own responsibility.
+  // The honest case: the owner asked for enforcement, and this session is one
+  // ACC cannot intercept - a Codex model that edits through the shell, or any
+  // MCP client. The only thing left is to say that respecting the claim is now
+  // this session's own responsibility.
   assert.match(projected, /cannot be enforced|not enforced/i);
   assert.match(projected, /file:src\/\*\*/);
 });
@@ -158,4 +159,38 @@ test("no claims means no section at all", () => {
     attention: [], messages: [], claims: [] });
 
   assert.doesNotMatch(projected, /claim/i);
+});
+
+test("a guarded session is told the limit of its own guard", () => {
+  const projected = projectContext(syncResult({ roster: [],
+    claims: [{ resource: "file:src/**", ownerParticipantId: "models",
+      enforcement: "guarded", enforceable: true }] }));
+
+  // Being guarded is not the same as being safe: no harness intercepts a shell
+  // command, so an edit made through one is never stopped. A session told only
+  // "this is claimed" would reasonably assume ACC has it covered.
+  assert.match(projected, /through a shell are not/);
+});
+
+test("a claim its owner declared advisory is never described as blocking", () => {
+  const projected = projectContext(syncResult({ roster: [],
+    claims: [{ resource: "file:src/**", ownerParticipantId: "models",
+      enforcement: "advisory", enforceable: true }] }));
+
+  // Enforcement is declared per claim, and the guard only blocks guarded ones.
+  // Reading this session's own capability alone would announce a block that
+  // will never happen - and the owner explicitly did not ask for one.
+  assert.doesNotMatch(projected, /blocked/);
+  assert.match(projected, /advisory/);
+  assert.match(projected, /file:src\/\*\*/);
+});
+
+test("an advisory claim reads the same however capable the session is", () => {
+  const render = enforceable => projectContext(syncResult({ roster: [],
+    claims: [{ resource: "file:src/**", ownerParticipantId: "models",
+      enforcement: "advisory", enforceable }] }));
+
+  // Whether this session could have been stopped is irrelevant to a claim
+  // nobody asked to be enforced.
+  assert.equal(render(true), render(false));
 });

--- a/packages/hook-runner/src/runner.mjs
+++ b/packages/hook-runner/src/runner.mjs
@@ -104,7 +104,25 @@ const HANDLERS = {
     // Solo costs nothing: nothing to say means nothing printed, not a banner
     // announcing that nobody else is here.
     if (sync.solo) return { stdout: "" };
-    const projected = await adapter.renderContext?.(sync) ?? "";
+
+    // Claims held by others, and whether this session can actually be stopped
+    // from breaking them. For a harness that guards writes this is useful
+    // warning; for one that cannot - a Codex model editing through the shell,
+    // an MCP client - it is the only protection there is, so it has to say
+    // plainly that the responsibility has moved to the session itself.
+    const status = await context.service.collectStatus({
+      workspaceId: context.descriptor.id });
+    const mine = status.participants
+      .find(participant => participant.sessionId === binding.accSessionId);
+    const enforceable = mine?.enforcement === "guarded";
+    const claims = status.claims
+      .filter(claim => claim.ownerSessionId !== binding.accSessionId)
+      .map(claim => ({ resource: claim.resource, enforceable,
+        ownerParticipantId: status.participants
+          .find(p => p.sessionId === claim.ownerSessionId)?.participantId
+          ?? claim.ownerSessionId }));
+
+    const projected = await adapter.renderContext?.({ ...sync, claims }) ?? "";
     if (projected === "") return { stdout: "" };
     // Same again: Kimi Code shows the model a hook's raw stdout, while Gemini
     // and Claude Code want an envelope and drop a bare string.

--- a/packages/hook-runner/src/runner.mjs
+++ b/packages/hook-runner/src/runner.mjs
@@ -114,10 +114,15 @@ const HANDLERS = {
       workspaceId: context.descriptor.id });
     const mine = status.participants
       .find(participant => participant.sessionId === binding.accSessionId);
+    // Two independent facts, and both are needed. `enforceable` is whether ACC
+    // could stop *this* session at all; `enforcement` is what the claim's owner
+    // asked for. A guarded session facing an advisory claim is not blocked from
+    // anything, so reporting either one alone mislabels the other case.
     const enforceable = mine?.enforcement === "guarded";
     const claims = status.claims
       .filter(claim => claim.ownerSessionId !== binding.accSessionId)
-      .map(claim => ({ resource: claim.resource, enforceable,
+      .map(claim => ({ resource: claim.resource, enforcement: claim.enforcement,
+        enforceable,
         ownerParticipantId: status.participants
           .find(p => p.sessionId === claim.ownerSessionId)?.participantId
           ?? claim.ownerSessionId }));

--- a/packages/hook-runner/test/runner.test.mjs
+++ b/packages/hook-runner/test/runner.test.mjs
@@ -306,3 +306,75 @@ test("attach declares what the adapter proved, not that it is an adapter", async
   assert.equal(byHarness.blind.enforcement, "advisory");
   assert.equal(byHarness.blind.lifecycle, "manual");
 });
+
+test("the turn context names claims this session cannot be stopped from breaking",
+  async t => {
+    const place = await workspace(t);
+    const peer = await run("kimi", event("sessionStart", { sessionId: "peer" }), place);
+    await peer.service.acquireClaim({ sessionId: peer.accSessionId,
+      generation: peer.generation, resource: "file:src/**", mode: "exclusive",
+      enforcement: "guarded", reason: "porting" });
+
+    // A session whose harness cannot guard writes: a Codex model that edits
+    // through the shell, or an MCP client. Nothing will intercept it, so the
+    // only protection left is telling it before the turn.
+    const unguarded = { ...kimi, id: "unguarded",
+      capabilities: { guards: { beforeWrite: false }, lifecycle: { sessionEnd: false } },
+      renderContext: sync => (sync.claims ?? [])
+        .map(c => `${c.resource}|${c.enforceable}`).join(" ") };
+    const adapters = { ...ADAPTERS, unguarded };
+
+    await runHook({ adapterId: "unguarded", adapters, dataHome: place.dataHome,
+      payload: event("sessionStart", { cwd: place.root }) });
+    const turn = await runHook({ adapterId: "unguarded", adapters, dataHome: place.dataHome,
+      payload: event("beforeTurn", { cwd: place.root }) });
+
+    assert.match(turn.stdout, /file:src\/\*\*/);
+    assert.match(turn.stdout, /\|false/, "the session was not told it is unenforced");
+  });
+
+test("a guarded session is told about the claim, and that it is enforced", async t => {
+  const place = await workspace(t);
+  const peer = await run("kimi", event("sessionStart", { sessionId: "peer" }), place);
+  await peer.service.acquireClaim({ sessionId: peer.accSessionId,
+    generation: peer.generation, resource: "file:src/**", mode: "exclusive",
+    enforcement: "guarded", reason: "porting" });
+
+  const guarding = { ...kimi, id: "guarding",
+    capabilities: { guards: { beforeWrite: true }, lifecycle: { sessionEnd: true } },
+    renderContext: sync => (sync.claims ?? [])
+      .map(c => `${c.resource}|${c.enforceable}`).join(" ") };
+  const adapters = { ...ADAPTERS, guarding };
+
+  await runHook({ adapterId: "guarding", adapters, dataHome: place.dataHome,
+    payload: event("sessionStart", { cwd: place.root }) });
+  const turn = await runHook({ adapterId: "guarding", adapters, dataHome: place.dataHome,
+    payload: event("beforeTurn", { cwd: place.root }) });
+
+  assert.match(turn.stdout, /\|true/);
+});
+
+test("a session is not warned about its own claim", async t => {
+  const place = await workspace(t);
+  // An adapter that actually renders claims. The default mock renders only the
+  // roster, so asserting the absence of a claim through it would prove nothing
+  // whatever the runner did.
+  const rendering = { ...kimi, id: "rendering",
+    renderContext: sync => (sync.claims ?? []).map(c => c.resource).join(" ") };
+  const adapters = { ...ADAPTERS, rendering };
+
+  const mine = await runHook({ adapterId: "rendering", adapters,
+    dataHome: place.dataHome, payload: event("sessionStart", { cwd: place.root }) });
+  await mine.service.acquireClaim({ sessionId: mine.accSessionId,
+    generation: mine.generation, resource: "file:src/**", mode: "exclusive",
+    enforcement: "guarded", reason: "mine" });
+  await runHook({ adapterId: "rendering", adapters, dataHome: place.dataHome,
+    payload: event("sessionStart", { sessionId: "peer", cwd: place.root }) });
+
+  const turn = await runHook({ adapterId: "rendering", adapters,
+    dataHome: place.dataHome, payload: event("beforeTurn", { cwd: place.root }) });
+
+  // Telling a session to avoid the thing it deliberately reserved would be
+  // exactly backwards.
+  assert.doesNotMatch(turn.stdout, /file:src/);
+});

--- a/packages/hook-runner/test/runner.test.mjs
+++ b/packages/hook-runner/test/runner.test.mjs
@@ -378,3 +378,27 @@ test("a session is not warned about its own claim", async t => {
   // exactly backwards.
   assert.doesNotMatch(turn.stdout, /file:src/);
 });
+
+test("an advisory claim is passed through as advisory, not as a block", async t => {
+  const place = await workspace(t);
+  const peer = await run("kimi", event("sessionStart", { sessionId: "peer" }), place);
+  await peer.service.acquireClaim({ sessionId: peer.accSessionId,
+    generation: peer.generation, resource: "file:src/**", mode: "exclusive",
+    enforcement: "advisory", reason: "just asking" });
+
+  // A session that genuinely can be guarded. The guard still will not block an
+  // advisory claim, so telling this session its edits are blocked would be an
+  // announcement of something that never happens.
+  const guarding = { ...kimi, id: "guarding",
+    capabilities: { guards: { beforeWrite: true }, lifecycle: { sessionEnd: true } },
+    renderContext: sync => (sync.claims ?? [])
+      .map(c => `${c.resource}|${c.enforcement}|${c.enforceable}`).join(" ") };
+  const adapters = { ...ADAPTERS, guarding };
+
+  await runHook({ adapterId: "guarding", adapters, dataHome: place.dataHome,
+    payload: event("sessionStart", { cwd: place.root }) });
+  const turn = await runHook({ adapterId: "guarding", adapters, dataHome: place.dataHome,
+    payload: event("beforeTurn", { cwd: place.root }) });
+
+  assert.match(turn.stdout, /file:src\/\*\*\|advisory\|true/);
+});


### PR DESCRIPTION
Closes the two things certification left open on Codex.

## The install no longer needs a command from the user

It looked like it had to. `codex plugin add` is the supported path, and without
it the plugin lists as `not installed` and no hook fires - publishing,
registering and enabling are all necessary and still not sufficient.

Measuring it changed the answer. Diffing `$CODEX_HOME` around that command shows
it does exactly one thing: copy the plugin into
`plugins/cache/<marketplace>/<plugin>/<version>/`. Nothing else changes - not
`config.toml`, nothing under `HOME` - and all three path components are ACC's
own: the marketplace it created, the plugin name it chose, and the version in the
manifest it ships.

So ACC writes that copy. Verified against a real 0.147.0 session with no client
command run at all:

```text
SessionStart, UserPromptSubmit, PreToolUse(Bash), Stop, SessionEnd
```

`detect` still names `codex plugin add` for the case where the cache is missing -
someone cleared it, or the client moved where it keeps one - because then the
supported command is the right answer. Hook trust stays manual; that one is the
client's security model, not a gap.

## Writes through a shell cannot be guarded, so the session is told instead

With a model that has no `apply_patch`, edits run through `exec_command` and
reach hooks as a command string. A command names no resource, so nothing can
match it against a claim, and no amount of parsing would make that reliable.

What changed is that **Codex context injection turned out to work**. It was
declared false with the honest reason "never seen reaching the model" - and
nobody had watched the wire. A `UserPromptSubmit` hook's stdout arrives as a
`developer` role message, verbatim and unwrapped. That makes it the most direct
of the four channels, which is a reason for care rather than comfort: at that
role a model reads text as instruction, so peer-authored text stays framed as
data by the shared projector.

The turn context now names the claims other sessions hold, and says which way
this session stands with them:

```text
2 session(s); cursor 0000000000000004
- [claim] file:src/** held by models - file edits are blocked; edits made through a shell are not
- session_9Xo… (cli, online)
- session_BlU… (codex, online)
```

and, for a session that cannot be guarded at all - an MCP client, or any harness
without a write guard - `not enforced for this session; do not edit it`.

Both notes are load-bearing. Being guarded is not the same as being safe: a
session told only "this is claimed" would reasonably assume ACC had it covered,
and for anything done through a shell it does not.

Captured from a real session: the peer held `file:src/**` and the Codex model was
told before it started.

## Review notes

- One test in this area was vacuous and is replaced. It asserted a claim's
  *absence* through a mock adapter that never rendered claims, so it passed
  whatever the runner did. Found by mutating the rule it was supposed to
  protect - worth knowing the pattern, because an absence assertion through a
  stub that cannot produce the thing is always green.
- `docs/CAPABILITIES.md` now reads `context.beforeTurnInjection: yes` for all
  four, and the install table loses its manual step.

482/482, `npm run check` clean.
