### PR TITLE
Drop the attention kind no rule ever produced

### DIFF
--- a/packages/adapter-sdk/test/context-projector.test.mjs
+++ b/packages/adapter-sdk/test/context-projector.test.mjs
@@ -33,7 +33,8 @@ test("direct requests and conflicts survive a budget that drops routine detail",
       { kind: "direct_request", priority: 1, sourceId: "message_a", summary: "Need slots" },
       { kind: "claim_conflict", priority: 2, sourceId: "claim_a",
         summary: "file:src/main.mjs is claimed by session_1" },
-      { kind: "nearby_intent", priority: 5, sourceId: "session_9", summary: "browsing" },
+      { kind: "coordinator_missing", priority: 4, sourceId: "workstream_a",
+        summary: "directed-visuals" },
     ],
   }), { budgetBytes: 400 });
 

--- a/packages/core/src/sync.mjs
+++ b/packages/core/src/sync.mjs
@@ -5,12 +5,15 @@ const DEFAULT_LIMIT = 100;
 
 // Attention is computed from explicit rules, never from a hidden classifier.
 // Lower priority sorts first.
-const PRIORITY = Object.freeze({
+//
+// Exported so a test can prove every kind listed here is reachable. A fifth
+// entry once sat here with no rule behind it, which read as a feature in review
+// and produced nothing at runtime.
+export const ATTENTION_PRIORITY = Object.freeze({
   direct_request: 1,
   claim_conflict: 2,
   task_unblocked: 3,
   coordinator_missing: 4,
-  nearby_intent: 5,
 });
 
 function directRequests(snapshot, participantId) {
@@ -20,7 +23,7 @@ function directRequests(snapshot, participantId) {
     if (receipt.state === "acknowledged" || receipt.state === "failed") continue;
     const message = (snapshot.messages ?? []).find(item => item.messageId === receipt.messageId);
     if (message === undefined || !message.requiresAck) continue;
-    items.push({ kind: "direct_request", priority: PRIORITY.direct_request,
+    items.push({ kind: "direct_request", priority: ATTENTION_PRIORITY.direct_request,
       sourceId: message.messageId, summary: message.subject });
   }
   return items;
@@ -33,7 +36,7 @@ function claimConflicts(snapshot, session, now) {
     .filter(claim => claim.ownerSessionId !== session.sessionId
       && Date.parse(claim.expiresAt) > Date.parse(now)
       && mine.resourceHints.some(hint => overlaps(hint, claim.resource)))
-    .map(claim => ({ kind: "claim_conflict", priority: PRIORITY.claim_conflict,
+    .map(claim => ({ kind: "claim_conflict", priority: ATTENTION_PRIORITY.claim_conflict,
       sourceId: claim.claimId,
       summary: `${claim.resource} is claimed by ${claim.ownerSessionId}` }));
 }
@@ -41,7 +44,7 @@ function claimConflicts(snapshot, session, now) {
 function unblockedTasks(snapshot, session) {
   return (snapshot.tasks ?? [])
     .filter(task => task.state === "pending" && task.assigneeSessionId === session?.sessionId)
-    .map(task => ({ kind: "task_unblocked", priority: PRIORITY.task_unblocked,
+    .map(task => ({ kind: "task_unblocked", priority: ATTENTION_PRIORITY.task_unblocked,
       sourceId: task.taskId, summary: task.title }));
 }
 
@@ -49,7 +52,8 @@ function coordinatorGaps(snapshot) {
   return (snapshot.workstreams ?? [])
     .filter(workstream => workstream.state === "open"
       && workstream.coordinatorSessionId === null)
-    .map(workstream => ({ kind: "coordinator_missing", priority: PRIORITY.coordinator_missing,
+    .map(workstream => ({ kind: "coordinator_missing",
+      priority: ATTENTION_PRIORITY.coordinator_missing,
       sourceId: workstream.workstreamId, summary: workstream.title }));
 }
 

--- a/packages/core/test/sync.test.mjs
+++ b/packages/core/test/sync.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { createCoordinationService } from "../src/service.mjs";
+import { ATTENTION_PRIORITY, computeAttention } from "../src/sync.mjs";
 import { createFakeClock, createFakeIds, createMemoryStore }
   from "../../../tests/helpers/memory-store.mjs";
 
@@ -131,4 +132,35 @@ test("a message that needs no acknowledgement is not an attention item", async (
   const result = await service.sync({ sessionId: second.sessionId });
 
   assert.deepEqual(result.attention.filter(item => item.kind === "direct_request"), []);
+});
+
+test("every attention kind in the priority table is one a rule can produce", () => {
+  // The guard for a specific failure: a kind listed here with nothing behind
+  // it. `nearby_intent` sat in this table with no rule, so it read as a shipped
+  // feature in review, was documented as one, and produced nothing at runtime.
+  //
+  // The snapshot below is built to trigger all four rules at once. Adding a
+  // fifth entry to the table without a rule fails this test; adding one with a
+  // rule fails it until the snapshot exercises it, which is the point.
+  const snapshot = {
+    messages: [{ messageId: "message_a", subject: "Need slots", requiresAck: true }],
+    receipts: [{ messageId: "message_a", recipientParticipantId: "participant_a",
+      state: "injected" }],
+    intents: [{ sessionId: "session_a", resourceHints: ["file:src/**"] }],
+    claims: [{ claimId: "claim_a", ownerSessionId: "session_b", resource: "file:src/main.mjs",
+      expiresAt: "2026-08-16T02:00:00.000Z" }],
+    tasks: [{ taskId: "task_a", state: "pending", assigneeSessionId: "session_a",
+      title: "port the store" }],
+    workstreams: [{ workstreamId: "workstream_a", state: "open",
+      coordinatorSessionId: null, title: "directed-visuals" }],
+  };
+
+  const produced = computeAttention(snapshot, { session: { sessionId: "session_a" },
+    participantId: "participant_a", now: NOW });
+
+  assert.deepEqual([...new Set(produced.map(item => item.kind))].sort(),
+    Object.keys(ATTENTION_PRIORITY).sort());
+  // Ordering is the table's, so a new kind cannot quietly outrank a conflict.
+  assert.deepEqual(produced.map(item => item.priority),
+    [...produced.map(item => item.priority)].sort((left, right) => left - right));
 });


### PR DESCRIPTION
`nearby_intent` sat in the attention priority table with nothing behind it.

```js
const PRIORITY = { direct_request: 1, claim_conflict: 2,
                   task_unblocked: 3, coordinator_missing: 4,
                   nearby_intent: 5 };        // ← nothing emits this
```

`computeAttention` assembles four lists. None produces that kind, so it read as a shipped feature in review, was documented as one, and produced nothing at runtime.

## Removed rather than implemented

The deciding fact came from reading the projector, not from taste. Attention lines are `required`; only the roster is `optional`:

```js
const required = [...attentionLines(attention), ...claimLines(claims), ...peerBlocks(messages)];
const optional = roster.map(...);
```

So attention is **never trimmed by the context budget**. A rule firing on mere intent overlap would add lines to every single turn and push real conflicts further down the projection — the flooding failure [THREAT_MODEL scenario 2](docs/THREAT_MODEL.md) guards against, caused by us rather than by a peer.

Intents overlap constantly and bind nobody. That separation between `Intent` (awareness) and `Claim` (enforcement) is the product's point, and a warning that fires on the first is a warning that stops being read.

If an earlier signal is wanted later, it has to be designed as `optional`, beside the roster. That is a feature with a design question, not a leftover constant.

## The guard

The table is now exported so a test can hold it to its own contents:

- a snapshot built to trigger all four rules at once must produce **exactly** the kinds the table lists;
- and in the table's order, so a future kind cannot quietly outrank a claim conflict.

Adding an entry without a rule fails it. Adding one *with* a rule fails it until the snapshot exercises that rule — which is the point.

Verified by mutation: putting `nearby_intent` back fails the test by name.

```
AssertionError: Expected values to be strictly deep-equal:
-   'nearby_intent',
```

## Also

A projector test used the dead kind as low-priority filler. It now names `coordinator_missing`, which exists.

## Verification

```
syntax ok in 132 file(s)
tests 594, pass 594, fail 0
```

No documentation change needed — `docs/ARCHITECTURE.md` already documents exactly the four rules that fire.
