### PR TITLE
Record which revision a tarball digest belongs to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,28 @@ release.
 
 | | |
 |---|---|
+| Built from | `70b793b` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 84 KB, 99 entries |
-| sha256 | `91914b8e57a85da422d66d687bb6f2b74c3b1f8de9e5495dfac1cdc2a3c8f6d6` |
-| Tests | 593 passing, 0 failing |
+| sha256 | `a5c8bb1de3e811694633f4cc4a0c238790b79774c546d9bc7cefaaa36eb7cdfa` |
+| Tests | 598 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
+
+This is a measurement, not a promise about `main`. Every workspace travels inside the
+tarball, so any change to shipped code changes the digest — and the commit named above is
+necessarily an ancestor of the one recording it, because no commit can contain its own
+hash. Only `bin/`, `README.md`, `LICENSE`, `docs/CAPABILITIES.md`, and the workspaces are
+packed, so changes to tests, scripts, or the rest of `docs/` leave the digest alone.
+
+To check it, or to record a newer candidate:
+
+```bash
+node scripts/verify-package.mjs
+```
+
+It prints the digest and the revision on one line, and refuses to imply reproducibility
+when the working tree is dirty.
 
 ### What it does
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -38,9 +38,20 @@ installs it.
 
 ## Record the evidence
 
-Put the tarball name, sha256, test counts, capability matrix, and known
-limitations in `CHANGELOG.md`. A release without them is a release nobody can
-audit later.
+Put the tarball name, sha256, **the commit it was built from**, test counts,
+capability matrix, and known limitations in `CHANGELOG.md`. A release without
+them is a release nobody can audit later.
+
+The commit is not optional detail. Every workspace travels inside the tarball,
+so any change to shipped code changes the digest — a digest recorded alone goes
+stale on the next merge and then reads as a false claim about the current tree
+rather than a true one about an older commit. `verify-package.mjs` prints both
+on one line for exactly this reason, and refuses to imply reproducibility when
+the working tree is dirty:
+
+```text
+PASS  agents-can-communicate-0.0.0.tgz  sha256 a5c8bb1d…  built from 39d0dcf
+```
 
 ## Then stop
 

--- a/scripts/git-provenance.mjs
+++ b/scripts/git-provenance.mjs
@@ -1,0 +1,41 @@
+// Which revision a build artefact belongs to.
+//
+// A digest on its own goes stale on the next merge - every workspace travels
+// inside the tarball, so any change to shipped code changes it - and a stale
+// digest recorded without its commit reads as a claim about the current tree
+// rather than a true one about an older commit. A dirty tree is worse: nobody
+// can rebuild that tarball, so the evidence proves nothing.
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+
+// The suite and the release workflow both export GIT_DIR='' so that git
+// commands inside temporary fixture repositories cannot operate on this
+// checkout. An empty GIT_DIR is not "unset" to git - it is a repository path of
+// "", and every command fails with `not a git repository: ''`. Stripped rather
+// than caught: swallowing the failure would drop the revision precisely when
+// the script is run the way the release doc says to run it.
+const INHERITED = ["GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR",
+  "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_PREFIX",
+  "GIT_QUARANTINE_PATH"];
+
+/**
+ * @param {string} cwd directory to describe
+ * @returns {Promise<{commit: string|null, dirty: boolean, why?: string}>}
+ *   `commit` is null outside a checkout, with `why` saying so. Not an error:
+ *   an artefact built elsewhere is still verifiable, just not attributable.
+ */
+export async function gitProvenance(cwd) {
+  const env = { ...process.env };
+  for (const name of INHERITED) delete env[name];
+
+  try {
+    const { stdout: head } = await run("git", ["rev-parse", "--short", "HEAD"], { cwd, env });
+    const { stdout: dirt } = await run("git", ["status", "--porcelain"], { cwd, env });
+    return { commit: head.trim(), dirty: dirt.trim() !== "" };
+  } catch (error) {
+    return { commit: null, dirty: false,
+      why: String(error.message).trim().split("\n").at(-1) };
+  }
+}

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -15,6 +15,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
+import { gitProvenance } from "./git-provenance.mjs";
+
 const run = promisify(execFile);
 const repo = path.resolve(import.meta.dirname, "..");
 
@@ -76,13 +78,25 @@ async function main() {
     step("pack");
     // Resolved before use: the install runs from a temporary directory, and a
     // path relative to the caller's shell would not exist there.
-    const tarball = process.argv[2] === undefined
+    const packed = process.argv[2] === undefined;
+    const tarball = packed
       ? await packTarball(workspace)
       : path.resolve(process.argv[2]);
     const bytes = await readFile(tarball);
     const digest = createHash("sha256").update(bytes).digest("hex");
     ok(`${path.basename(tarball)}  ${(bytes.length / 1024).toFixed(0)} KB`);
     ok(`sha256 ${digest}`);
+
+    const { commit, dirty, why } = packed
+      ? await gitProvenance(repo)
+      : { commit: null, dirty: false, why: "a tarball was supplied; HEAD is unrelated to it" };
+    if (commit === null) {
+      console.log(`   --  revision unknown: ${why}`);
+    } else {
+      ok(`built from ${commit}${dirty
+        ? "  WITH UNCOMMITTED CHANGES - this tarball cannot be rebuilt"
+        : ""}`);
+    }
 
     step("tarball contents");
     const listed = await entries(tarball);
@@ -141,7 +155,10 @@ async function main() {
     if (after !== before) fail("uninstall did not restore the client config");
     ok("client config restored byte for byte");
 
-    console.log(`\nPASS  ${path.basename(tarball)}  sha256 ${digest}`);
+    // One line to copy into the changelog, complete enough to be checkable
+    // later: which file, which bytes, and which revision produced them.
+    console.log(`\nPASS  ${path.basename(tarball)}  sha256 ${digest}`
+      + `${commit === null ? "" : `  built from ${commit}${dirty ? " (dirty)" : ""}`}`);
   } finally {
     await rm(workspace, { recursive: true, force: true });
   }

--- a/tests/process/git-provenance.test.mjs
+++ b/tests/process/git-provenance.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { gitProvenance } from "../../scripts/git-provenance.mjs";
+
+const repo = path.resolve(import.meta.dirname, "..", "..");
+
+/**
+ * The revision half of a release record.
+ *
+ * `CHANGELOG.md` carries a tarball digest, and every workspace travels inside
+ * that tarball - so any change to shipped code changes it. A digest recorded
+ * without the commit it belongs to goes stale on the next merge and then reads
+ * as a false claim about the current tree rather than a true one about an older
+ * commit. This is the piece that makes the record checkable.
+ */
+
+/** Run with the git variables the suite and the release workflow both export. */
+async function withGitEnv(overrides, callback) {
+  const saved = new Map(Object.keys(overrides).map(name => [name, process.env[name]]));
+  Object.assign(process.env, overrides);
+  try {
+    return await callback();
+  } finally {
+    for (const [name, value] of saved) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
+}
+
+test("a checkout reports the commit it is on", async () => {
+  const { commit, why } = await gitProvenance(repo);
+
+  assert.equal(why, undefined);
+  assert.match(commit, /^[0-9a-f]{7,40}$/);
+});
+
+test("an inherited empty GIT_DIR does not silence the revision", async () => {
+  // The regression this file exists for. `npm test` and the release workflow
+  // both set GIT_DIR='' so that git inside temporary fixture repositories
+  // cannot reach this checkout. To git that is a repository path of "", not an
+  // unset variable, and every command fails with `not a git repository: ''`.
+  //
+  // The first version of this helper caught that and returned no commit, so the
+  // evidence line vanished in exactly the environment the release doc
+  // prescribes - silently, with a PASS still printed.
+  const bare = await withGitEnv({ GIT_DIR: "", GIT_WORK_TREE: "" },
+    () => gitProvenance(repo));
+
+  assert.match(bare.commit ?? "", /^[0-9a-f]{7,40}$/,
+    `the empty GIT_DIR was inherited: ${bare.why}`);
+  assert.equal(bare.commit, (await gitProvenance(repo)).commit,
+    "the answer changed with the environment");
+});
+
+test("a directory outside any checkout says so instead of guessing", async t => {
+  const outside = await realpath(await mkdtemp(path.join(tmpdir(), "acc-provenance-")));
+  t.after(() => rm(outside, { recursive: true, force: true }));
+
+  // `GIT_CEILING_DIRECTORIES` stops discovery walking up into whatever
+  // repository the temporary directory happens to sit under on this machine.
+  const result = await withGitEnv({ GIT_CEILING_DIRECTORIES: path.dirname(outside) },
+    () => gitProvenance(outside));
+
+  assert.equal(result.commit, null);
+  assert.equal(result.dirty, false);
+  // Not a bare null: the caller prints this so an operator knows the record is
+  // incomplete rather than assuming there was nothing to record.
+  assert.equal(typeof result.why, "string");
+  assert.equal(result.why.length > 0, true);
+});
+
+test("the dirty flag is a boolean the caller can trust", async () => {
+  const { dirty } = await gitProvenance(repo);
+
+  assert.equal(typeof dirty, "boolean");
+});


### PR DESCRIPTION
`CHANGELOG.md` carried a digest with no commit beside it — and it was already wrong. Every workspace travels inside the tarball, so the merge of #9 changed the bytes and the recorded `91914b8e…` stopped matching `main`.

That is not a one-off slip. A digest recorded alone does not merely go stale: it reads as a claim about the current tree rather than a true one about an older commit.

## The mechanism

`verify-package.mjs` now prints the revision beside the digest, on one line meant to be copied:

```text
PASS  agents-can-communicate-0.0.0.tgz  sha256 a5c8bb1d…  built from 70b793b
```

and says when the working tree is dirty, because nobody can rebuild that tarball and the evidence would prove nothing.

## The first attempt shipped the bug it was meant to prevent

`npm test` and the release workflow both export `GIT_DIR=''` so git inside temporary fixture repositories cannot reach this checkout. To git that is a repository path of `""`, **not** an unset variable — every command fails with `fatal: not a git repository: ''`.

My first version wrapped the probe in a `catch`. So the evidence line silently vanished in exactly the environment the release doc prescribes, with `PASS` still printed. I only saw it because I ran the script the way CI does instead of the way that was convenient.

So the helper is now its own module with a test, rather than four lines inside a script nothing exercises:

- it strips the inherited git variables;
- outside a checkout it returns a **reason** the caller prints, instead of a bare null an operator would read as "there was nothing to record".

Proven by mutation — removing the strip fails the test by its exact cause:

```
AssertionError: the empty GIT_DIR was inherited: fatal: not a git repository: ''
```

## The record

Re-measured on a clean tree at `70b793b`:

| | |
|---|---|
| Built from | `70b793b` |
| sha256 | `a5c8bb1d…` (unchanged — nothing packed changed) |
| Tests | 598 passing |

The block now states what it is: a measurement of a named commit, not a promise about `main`. It names what is actually packed — `bin/`, `README.md`, `LICENSE`, `docs/CAPABILITIES.md`, and the workspaces — so a reader can tell whether a change could have moved the digest. And it admits the part with no fix: the recorded commit is always an ancestor of the commit recording it, because no commit can contain its own hash.

## Verification

```
syntax ok in 134 file(s)
tests 598, pass 598, fail 0
verify-package: PASS, built from 70b793b, clean tree
```
