### PR TITLE
Enforce claims however the workspace path is spelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,28 @@ release.
 
 | | |
 |---|---|
+| Built from | `70b793b` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 84 KB, 99 entries |
-| sha256 | `91914b8e57a85da422d66d687bb6f2b74c3b1f8de9e5495dfac1cdc2a3c8f6d6` |
-| Tests | 593 passing, 0 failing |
+| sha256 | `a5c8bb1de3e811694633f4cc4a0c238790b79774c546d9bc7cefaaa36eb7cdfa` |
+| Tests | 598 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
+
+This is a measurement, not a promise about `main`. Every workspace travels inside the
+tarball, so any change to shipped code changes the digest — and the commit named above is
+necessarily an ancestor of the one recording it, because no commit can contain its own
+hash. Only `bin/`, `README.md`, `LICENSE`, `docs/CAPABILITIES.md`, and the workspaces are
+packed, so changes to tests, scripts, or the rest of `docs/` leave the digest alone.
+
+To check it, or to record a newer candidate:
+
+```bash
+node scripts/verify-package.mjs
+```
+
+It prints the digest and the revision on one line, and refuses to imply reproducibility
+when the working tree is dirty.
 
 ### What it does
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -38,9 +38,20 @@ installs it.
 
 ## Record the evidence
 
-Put the tarball name, sha256, test counts, capability matrix, and known
-limitations in `CHANGELOG.md`. A release without them is a release nobody can
-audit later.
+Put the tarball name, sha256, **the commit it was built from**, test counts,
+capability matrix, and known limitations in `CHANGELOG.md`. A release without
+them is a release nobody can audit later.
+
+The commit is not optional detail. Every workspace travels inside the tarball,
+so any change to shipped code changes the digest — a digest recorded alone goes
+stale on the next merge and then reads as a false claim about the current tree
+rather than a true one about an older commit. `verify-package.mjs` prints both
+on one line for exactly this reason, and refuses to imply reproducibility when
+the working tree is dirty:
+
+```text
+PASS  agents-can-communicate-0.0.0.tgz  sha256 a5c8bb1d…  built from 39d0dcf
+```
 
 ## Then stop
 

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -100,6 +100,7 @@ gate runs. Each rule is written as an attack rather than a description:
 | Peer text cannot repaint the terminal | `peer-injection.test.mjs` |
 | Flooding cannot bury a conflict warning | `peer-injection.test.mjs` |
 | No path escapes the managed root | `storage-boundary.test.mjs` |
+| A claim holds however the path is spelled | `symlinked-workspace.test.mjs` |
 | A workspace id cannot traverse | `storage-boundary.test.mjs` |
 | A config cannot point roots outside itself | `storage-boundary.test.mjs` |
 | A symlinked config is refused, not followed | `storage-boundary.test.mjs` |

--- a/packages/hook-runner/src/runner.mjs
+++ b/packages/hook-runner/src/runner.mjs
@@ -1,4 +1,5 @@
 import { randomBytes } from "node:crypto";
+import { realpath } from "node:fs/promises";
 import path from "node:path";
 
 import { clearSessionBinding, loadSessionBinding, storeSessionBinding }
@@ -21,6 +22,9 @@ const CADENCE_MS = 60_000;
 const defaultRuntime = () => ({
   clock: { now: () => new Date().toISOString() },
   ids: { next: kind => createId(kind, randomBytes) },
+  // Injected rather than imported at the call site so a test can drive the
+  // resolution without needing a real symlink on the filesystem it runs on.
+  realpath,
 });
 
 /**
@@ -35,6 +39,40 @@ export function resourceFor(root, target) {
   const relative = path.relative(root, absolute);
   if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) return null;
   return `file:${relative.split(path.sep).join("/")}`;
+}
+
+/**
+ * The same path, spelled the way the workspace root is spelled.
+ *
+ * Discovery resolves its root through `realpath`, so the descriptor is always
+ * canonical. A hook payload is not: it carries whatever the client had, and a
+ * client's cwd is whatever the human typed. When the two differ only by a
+ * symlinked ancestor - `/tmp` and `/var` on macOS, a symlinked checkout
+ * anywhere - `resourceFor` relativised to `../..`, the target list emptied, and
+ * every write was allowed while `acc status` still said `protection guarded`.
+ *
+ * The leaf usually does not exist yet, because the tool call being guarded is
+ * what would create it. So the deepest existing ancestor is resolved and the
+ * remainder appended, which is also what keeps this from following a symlink
+ * the write itself would replace.
+ */
+export async function canonicalTarget(realpath, target) {
+  let current = path.resolve(target);
+  const trailing = [];
+  for (;;) {
+    try {
+      return path.join(await realpath(current), ...trailing);
+    } catch (error) {
+      if (error.code !== "ENOENT" && error.code !== "ENOTDIR") return path.resolve(target);
+      const parent = path.dirname(current);
+      // Reached the filesystem root without finding anything that exists. The
+      // unresolved path is the best answer available, and `resourceFor` will
+      // reject it if it is outside the workspace.
+      if (parent === current) return path.resolve(target);
+      trailing.unshift(path.basename(current));
+      current = parent;
+    }
+  }
 }
 
 // Same rule as the core's claim overlap, applied to a concrete path: a claim on
@@ -56,7 +94,7 @@ async function openContext({ cwd, dataHome, runtime, env }) {
   });
   const store = await openFilesystemStore({ root: paths.root, clock: runtime.clock,
     ids: runtime.ids, workspaceId: descriptor.id });
-  return { descriptor, paths,
+  return { descriptor, paths, realpath: runtime.realpath ?? realpath,
     service: createCoordinationService({ store, clock: runtime.clock, ids: runtime.ids }) };
 }
 
@@ -145,7 +183,9 @@ const HANDLERS = {
     const status = await context.service.collectStatus({
       workspaceId: context.descriptor.id });
     const root = context.descriptor.roots[0];
-    const wanted = event.targets
+    const resolved = await Promise.all(event.targets
+      .map(target => canonicalTarget(context.realpath, target)));
+    const wanted = resolved
       .map(target => resourceFor(root, target))
       .filter(resource => resource !== null);
 

--- a/packages/hook-runner/test/runner.test.mjs
+++ b/packages/hook-runner/test/runner.test.mjs
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { covers, resourceFor, runHook } from "../src/runner.mjs";
+import { canonicalTarget, covers, resourceFor, runHook } from "../src/runner.mjs";
 
 // Two adapters whose deny shapes disagree, because that disagreement is the
 // point: the runner must speak each client's own contract, and a shape borrowed
@@ -401,4 +401,50 @@ test("an advisory claim is passed through as advisory, not as a block", async t 
     payload: event("beforeTurn", { cwd: place.root }) });
 
   assert.match(turn.stdout, /file:src\/\*\*\|advisory\|true/);
+});
+
+/**
+ * The leaf of a guarded path is usually the file the tool call is about to
+ * create, so resolution has to work on a path that does not exist yet. These
+ * drive an injected realpath rather than the filesystem, because the branch
+ * that matters - how far up the walk goes - is otherwise invisible.
+ */
+const fakeRealpath = existing => async target => {
+  if (existing.has(target)) return existing.get(target);
+  const error = new Error(`ENOENT: ${target}`);
+  error.code = "ENOENT";
+  throw error;
+};
+
+test("a path whose leaf does not exist resolves through its deepest real parent", async () => {
+  const resolve = fakeRealpath(new Map([["/link/project", "/real/project"]]));
+
+  assert.equal(await canonicalTarget(resolve, "/link/project/src/store/index.mjs"),
+    "/real/project/src/store/index.mjs");
+});
+
+test("an existing path resolves outright", async () => {
+  const resolve = fakeRealpath(new Map([["/link/a.mjs", "/real/a.mjs"]]));
+
+  assert.equal(await canonicalTarget(resolve, "/link/a.mjs"), "/real/a.mjs");
+});
+
+test("nothing resolvable leaves the path as given rather than inventing one", async () => {
+  // Not a silent empty string: `resourceFor` still gets a real path to judge,
+  // and rejects it if it is outside the workspace.
+  assert.equal(await canonicalTarget(fakeRealpath(new Map()), "/nowhere/at/all.mjs"),
+    "/nowhere/at/all.mjs");
+});
+
+test("an error that is not absence stops the walk instead of climbing past it", async () => {
+  // EACCES on a parent means the answer is unknown, not "keep going until
+  // something answers" - climbing would resolve some unrelated ancestor and
+  // graft the rest onto it.
+  const resolve = async () => {
+    const error = new Error("EACCES");
+    error.code = "EACCES";
+    throw error;
+  };
+
+  assert.equal(await canonicalTarget(resolve, "/guarded/src/a.mjs"), "/guarded/src/a.mjs");
 });

--- a/scripts/git-provenance.mjs
+++ b/scripts/git-provenance.mjs
@@ -1,0 +1,41 @@
+// Which revision a build artefact belongs to.
+//
+// A digest on its own goes stale on the next merge - every workspace travels
+// inside the tarball, so any change to shipped code changes it - and a stale
+// digest recorded without its commit reads as a claim about the current tree
+// rather than a true one about an older commit. A dirty tree is worse: nobody
+// can rebuild that tarball, so the evidence proves nothing.
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+
+// The suite and the release workflow both export GIT_DIR='' so that git
+// commands inside temporary fixture repositories cannot operate on this
+// checkout. An empty GIT_DIR is not "unset" to git - it is a repository path of
+// "", and every command fails with `not a git repository: ''`. Stripped rather
+// than caught: swallowing the failure would drop the revision precisely when
+// the script is run the way the release doc says to run it.
+const INHERITED = ["GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR",
+  "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_PREFIX",
+  "GIT_QUARANTINE_PATH"];
+
+/**
+ * @param {string} cwd directory to describe
+ * @returns {Promise<{commit: string|null, dirty: boolean, why?: string}>}
+ *   `commit` is null outside a checkout, with `why` saying so. Not an error:
+ *   an artefact built elsewhere is still verifiable, just not attributable.
+ */
+export async function gitProvenance(cwd) {
+  const env = { ...process.env };
+  for (const name of INHERITED) delete env[name];
+
+  try {
+    const { stdout: head } = await run("git", ["rev-parse", "--short", "HEAD"], { cwd, env });
+    const { stdout: dirt } = await run("git", ["status", "--porcelain"], { cwd, env });
+    return { commit: head.trim(), dirty: dirt.trim() !== "" };
+  } catch (error) {
+    return { commit: null, dirty: false,
+      why: String(error.message).trim().split("\n").at(-1) };
+  }
+}

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -15,6 +15,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
+import { gitProvenance } from "./git-provenance.mjs";
+
 const run = promisify(execFile);
 const repo = path.resolve(import.meta.dirname, "..");
 
@@ -76,13 +78,25 @@ async function main() {
     step("pack");
     // Resolved before use: the install runs from a temporary directory, and a
     // path relative to the caller's shell would not exist there.
-    const tarball = process.argv[2] === undefined
+    const packed = process.argv[2] === undefined;
+    const tarball = packed
       ? await packTarball(workspace)
       : path.resolve(process.argv[2]);
     const bytes = await readFile(tarball);
     const digest = createHash("sha256").update(bytes).digest("hex");
     ok(`${path.basename(tarball)}  ${(bytes.length / 1024).toFixed(0)} KB`);
     ok(`sha256 ${digest}`);
+
+    const { commit, dirty, why } = packed
+      ? await gitProvenance(repo)
+      : { commit: null, dirty: false, why: "a tarball was supplied; HEAD is unrelated to it" };
+    if (commit === null) {
+      console.log(`   --  revision unknown: ${why}`);
+    } else {
+      ok(`built from ${commit}${dirty
+        ? "  WITH UNCOMMITTED CHANGES - this tarball cannot be rebuilt"
+        : ""}`);
+    }
 
     step("tarball contents");
     const listed = await entries(tarball);
@@ -141,7 +155,10 @@ async function main() {
     if (after !== before) fail("uninstall did not restore the client config");
     ok("client config restored byte for byte");
 
-    console.log(`\nPASS  ${path.basename(tarball)}  sha256 ${digest}`);
+    // One line to copy into the changelog, complete enough to be checkable
+    // later: which file, which bytes, and which revision produced them.
+    console.log(`\nPASS  ${path.basename(tarball)}  sha256 ${digest}`
+      + `${commit === null ? "" : `  built from ${commit}${dirty ? " (dirty)" : ""}`}`);
   } finally {
     await rm(workspace, { recursive: true, force: true });
   }

--- a/tests/process/git-provenance.test.mjs
+++ b/tests/process/git-provenance.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { gitProvenance } from "../../scripts/git-provenance.mjs";
+
+const repo = path.resolve(import.meta.dirname, "..", "..");
+
+/**
+ * The revision half of a release record.
+ *
+ * `CHANGELOG.md` carries a tarball digest, and every workspace travels inside
+ * that tarball - so any change to shipped code changes it. A digest recorded
+ * without the commit it belongs to goes stale on the next merge and then reads
+ * as a false claim about the current tree rather than a true one about an older
+ * commit. This is the piece that makes the record checkable.
+ */
+
+/** Run with the git variables the suite and the release workflow both export. */
+async function withGitEnv(overrides, callback) {
+  const saved = new Map(Object.keys(overrides).map(name => [name, process.env[name]]));
+  Object.assign(process.env, overrides);
+  try {
+    return await callback();
+  } finally {
+    for (const [name, value] of saved) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
+}
+
+test("a checkout reports the commit it is on", async () => {
+  const { commit, why } = await gitProvenance(repo);
+
+  assert.equal(why, undefined);
+  assert.match(commit, /^[0-9a-f]{7,40}$/);
+});
+
+test("an inherited empty GIT_DIR does not silence the revision", async () => {
+  // The regression this file exists for. `npm test` and the release workflow
+  // both set GIT_DIR='' so that git inside temporary fixture repositories
+  // cannot reach this checkout. To git that is a repository path of "", not an
+  // unset variable, and every command fails with `not a git repository: ''`.
+  //
+  // The first version of this helper caught that and returned no commit, so the
+  // evidence line vanished in exactly the environment the release doc
+  // prescribes - silently, with a PASS still printed.
+  const bare = await withGitEnv({ GIT_DIR: "", GIT_WORK_TREE: "" },
+    () => gitProvenance(repo));
+
+  assert.match(bare.commit ?? "", /^[0-9a-f]{7,40}$/,
+    `the empty GIT_DIR was inherited: ${bare.why}`);
+  assert.equal(bare.commit, (await gitProvenance(repo)).commit,
+    "the answer changed with the environment");
+});
+
+test("a directory outside any checkout says so instead of guessing", async t => {
+  const outside = await realpath(await mkdtemp(path.join(tmpdir(), "acc-provenance-")));
+  t.after(() => rm(outside, { recursive: true, force: true }));
+
+  // `GIT_CEILING_DIRECTORIES` stops discovery walking up into whatever
+  // repository the temporary directory happens to sit under on this machine.
+  const result = await withGitEnv({ GIT_CEILING_DIRECTORIES: path.dirname(outside) },
+    () => gitProvenance(outside));
+
+  assert.equal(result.commit, null);
+  assert.equal(result.dirty, false);
+  // Not a bare null: the caller prints this so an operator knows the record is
+  // incomplete rather than assuming there was nothing to record.
+  assert.equal(typeof result.why, "string");
+  assert.equal(result.why.length > 0, true);
+});
+
+test("the dirty flag is a boolean the caller can trust", async () => {
+  const { dirty } = await gitProvenance(repo);
+
+  assert.equal(typeof dirty, "boolean");
+});

--- a/tests/security/symlinked-workspace.test.mjs
+++ b/tests/security/symlinked-workspace.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, realpath, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import { loadSessionBinding } from "@agents-can-communicate/adapter-sdk";
+
+const run = promisify(execFile);
+const repo = path.resolve(import.meta.dirname, "..", "..");
+const acc = path.join(repo, "bin", "acc.mjs");
+const hook = path.join(repo, "bin", "acc-hook.mjs");
+
+/**
+ * A guard that only holds when the path is spelled one particular way is not a
+ * guard.
+ *
+ * Workspace discovery resolves its root through `realpath`, so the descriptor
+ * always carries a canonical path. A hook payload carries whatever the client
+ * had - and a client's cwd is whatever the human typed. When those disagree
+ * only by a symlinked ancestor, the relative path came out as `../..`, the
+ * target list emptied, and every write was allowed. Silently: exit 0, no
+ * message, and `acc status` still reporting `protection guarded`.
+ *
+ * This is not exotic. On macOS `/tmp` and `/var` are symlinks, and a checkout
+ * reached through any symlinked parent behaves the same way on every platform.
+ */
+async function workspace(t, { throughSymlink }) {
+  const base = await realpath(await mkdtemp(path.join(tmpdir(), "acc-symlink-")));
+  t.after(() => rm(base, { recursive: true, force: true }));
+
+  const real = path.join(base, "real");
+  await mkdir(path.join(real, "src", "store"), { recursive: true });
+  const link = path.join(base, "link");
+  await symlink(real, link);
+
+  // The only difference between the two runs. Both name the same directory.
+  const project = throughSymlink ? link : real;
+  const env = { ...process.env, ACC_DATA_HOME: path.join(base, "data"),
+    GIT_DIR: "", GIT_WORK_TREE: "" };
+
+  const start = (adapter, clientSessionId) => {
+    const child = run(process.execPath, [hook, adapter, "sessionStart"], { env });
+    child.child.stdin.end(JSON.stringify({ hook_event_name: "SessionStart",
+      session_id: clientSessionId, cwd: project, source: "startup" }));
+    return child;
+  };
+  await start("codex", "owner-1");
+  await start("claude_code", "writer-1");
+
+  const { stdout: reported } = await run(process.execPath,
+    [acc, "doctor", "--cwd", project, "--json"], { env });
+  const runtimeDir = JSON.parse(reported).data.runtimeRoot;
+  const owner = await loadSessionBinding({ runtimeDir, harnessSessionId: "owner-1" });
+
+  await run(process.execPath, [acc, "claim", "--session", owner.accSessionId,
+    "--generation", owner.generation, "--cwd", project,
+    "--resource", "file:src/store/**", "--enforcement", "guarded",
+    "--reason", "porting"], { env });
+
+  return { project, env };
+}
+
+/** What the writer's client is told when it tries to write into the claim. */
+async function attemptWrite({ project, env }) {
+  const child = run(process.execPath, [hook, "claude_code", "preToolUse"], { env });
+  child.child.stdin.end(JSON.stringify({ hook_event_name: "PreToolUse",
+    session_id: "writer-1", cwd: project, tool_name: "Write",
+    tool_input: { file_path: path.join(project, "src", "store", "index.mjs") } }));
+  const { stdout } = await child;
+  return stdout;
+}
+
+test("a claim is enforced when the workspace is reached through a symlink", async t => {
+  const place = await workspace(t, { throughSymlink: true });
+
+  const stdout = await attemptWrite(place);
+
+  assert.match(stdout, /"permissionDecision"\s*:\s*"deny"/,
+    "the write was allowed through a symlinked path while status reported guarded");
+  assert.match(stdout, /file:src\/store\/\*\*/);
+});
+
+test("the same claim is enforced when the workspace is reached directly", async t => {
+  // The control. Without it a broken guard could pass the test above by
+  // denying everything, and a broken *test* could pass by asserting nothing.
+  const place = await workspace(t, { throughSymlink: false });
+
+  const stdout = await attemptWrite(place);
+
+  assert.match(stdout, /"permissionDecision"\s*:\s*"deny"/);
+});
+
+test("a write outside the claim is still allowed through a symlink", async t => {
+  // The guard must not become "deny everything" as a way of passing the first
+  // test. A path the claim does not cover has to go through untouched.
+  const place = await workspace(t, { throughSymlink: true });
+
+  const child = run(process.execPath, [hook, "claude_code", "preToolUse"], { env: place.env });
+  child.child.stdin.end(JSON.stringify({ hook_event_name: "PreToolUse",
+    session_id: "writer-1", cwd: place.project, tool_name: "Write",
+    tool_input: { file_path: path.join(place.project, "src", "cli", "args.mjs") } }));
+  const { stdout } = await child;
+
+  assert.equal(stdout, "", `an unrelated write was interfered with: ${stdout}`);
+});


### PR DESCRIPTION
**The write guard silently did nothing whenever the project was reached through a symlink.**

Found while producing real terminal output for a README rewrite. The denial I expected to paste simply did not happen.

## What went wrong

Workspace discovery resolves its root through `realpath`, so `descriptor.roots[0]` is always canonical. A hook payload is not — it carries whatever the client had, and a client's `cwd` is whatever the human typed.

```
root   (canonical)   /private/var/…/warehouse
target (as given)    /var/…/warehouse/src/store/index.mjs
path.relative()      ../../../../var/…      → resourceFor returns null
wanted               []                     → no claim to break → allow
```

## Why nobody would notice

| What the user sees | |
|---|---|
| hook exit code | `0` |
| hook output | nothing |
| `acc status` | `2 live; 1 claim(s); protection guarded` |
| the claim | still listed, still `guarded` |
| the write | **goes through** |

`protection guarded` is computed from session capabilities and claim modes. Neither changed. The guard was the only thing that stopped working, and it is the only thing with no visible output when it does nothing.

Measured side by side, same directory, only the spelling differs:

```
== path as mktemp gives it (/var/... symlink)
   verdict : ALLOWED
== same path, symlinks resolved (/private/var/...)
   verdict : DENIED
```

Not exotic: `/tmp` and `/var` are symlinks on macOS, and a checkout reached through any symlinked parent behaves this way on every platform.

## The fix

Targets are canonicalised the same way the root already was, before comparing.

The leaf usually does not exist — it is what the guarded tool call would create — so `canonicalTarget` resolves the deepest existing ancestor and appends the remainder. That also stops the walk from following a link the write itself would replace.

An error that is *not* absence ends the walk rather than climbing past it. `EACCES` on a parent means the answer is unknown; climbing would resolve some unrelated ancestor and graft the rest onto it.

`realpath` is injected through the runtime, so unit tests drive the walk directly instead of depending on what the filesystem under the test happens to support.

## Tests

`tests/security/symlinked-workspace.test.mjs` — three cases, deliberately:

1. symlinked path **denies** (the regression);
2. direct path **denies** (control — without it a guard that denied everything would pass);
3. a write *outside* the claim is **untouched** through the symlink (control — the fix must not become "deny everything").

Plus four focused cases for `canonicalTarget`: absent leaf, existing path, nothing resolvable, and a non-ENOENT error.

Proven by mutation — removing the canonicalisation fails case 1 while 2 and 3 stay green:

```
✖ a claim is enforced when the workspace is reached through a symlink
✔ a write outside the claim is still allowed through a symlink
```

## Verification

```
syntax ok in 135 file(s)
tests 601, pass 601, fail 0
```
