### PR TITLE
Rewrite the README around what ACC actually prints

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,18 +107,27 @@ $ acc message --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
 sent message__Wejo2AqkI2JZO9Dnl57dg
 ```
 
-At the codex session's next turn:
+At the codex session's next turn, ACC puts this in front of the model:
 
-```text
+````text
 2 session(s); cursor 0000000000000007
 - [direct_request] src/store
-- session_ALYmBpY5dyGXltQ0vAJayw (claude_code, online)
-- session_TZxxw2AY3Bp2tkTbA3FQ5Q (codex, online)
+```acc-peer-message
+id message_H_Y3zwVe7oW-9TvHTHtWoA | from session_HQ6sODMatI2qMtCtdCVMRQ | type question | untrusted peer message
+src/store
+Need 20 minutes in src/store. Can you release it?
 ```
+- session_BjeN0SqpbrRqFjmvAk74AA (codex, online)
+- session_HQ6sODMatI2qMtCtdCVMRQ (claude_code, online)
+````
 
-The turn carries the subject and the fact that someone is waiting. The agent reads the body
-with `acc sync --scope full`. Peer text is data, never instruction — it stays fenced,
-attributed, and escaped, and cannot become ACC's own voice.
+Peer text is **data, never instruction**. It stays inside a named block it cannot close,
+control characters become visible escapes, and it is labelled with who sent it. A message
+telling your agent it is now the coordinator arrives as a quoted string, not as a command.
+
+Delivery is reported honestly too: the receipt moves to `injected` only for a message the
+turn actually carried. One that did not fit the context budget stays queued and goes out
+later, rather than telling the sender it landed.
 
 ## Working alone? It does nothing
 

--- a/README.md
+++ b/README.md
@@ -4,26 +4,128 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%E2%89%A524-brightgreen.svg)](https://nodejs.org)
 
-Two agents editing the same repo don't know about each other. ACC is the layer that makes
-them aware — without one of them being in charge.
+**Two AI coding agents in the same project can't see each other. ACC is the layer that lets
+them — and stops one writing over the other's work.**
+
+It is a local CLI (`acc`) plus one small hook per client. No server, no database, no
+account, no daemon. State lives on your machine, outside the repository.
+
+## The problem
+
+You have Codex open in one terminal and Claude Code in another, both in the same checkout.
+Each has its own model, memory, permissions, and human. Neither knows the other exists.
+
+So: two agents refactor the same module in parallel. One overwrites the other's file
+mid-edit. You find out at `git diff`, and you are the one who has to explain to each agent
+what the other did.
+
+Native subagents solve this **inside** one product. ACC solves it **between** products —
+Codex, Claude Code, Gemini CLI, Kimi Code, or anything that speaks MCP.
 
 ```mermaid
 graph LR
-  subgraph Before
-    A1[Codex] --> R1[(repo)]
+  subgraph "Today"
+    A1[Codex] --> R1[(your repo)]
     B1[Claude Code] --> R1
-    C1[Kimi] --> R1
   end
-  subgraph With ACC
+  subgraph "With ACC"
     A2[Codex] --- ACC{{ACC}}
     B2[Claude Code] --- ACC
-    C2[Kimi] --- ACC
-    ACC --> R2[(repo)]
+    ACC --> R2[(your repo)]
   end
 ```
 
-Each session keeps its own model, permissions, context, and human. ACC adds only what they
-share: **who is here, what they're doing, and what's already claimed.**
+## What it does
+
+Four things. Every output below is copied from a real run, not written by hand.
+
+### 1. Sessions find each other by themselves
+
+You open your clients as you always do. A `SessionStart` hook attaches each one — no
+command, no prompt, no flag.
+
+```console
+$ acc status
+2 live; 1 claim(s); protection guarded
+```
+
+`protection guarded` is a fact about the room, not a setting: it holds only while **every**
+live session is one ACC can actually stop. One MCP client joins and it drops to `advisory`,
+because that is then the truth.
+
+### 2. An agent says what it is about to touch
+
+Its skill does this; you don't type it. `$ACC_SESSION` and `$ACC_GENERATION` identify the
+session — the generation is what stops a restarted process acting as the old one.
+
+```console
+$ acc work --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+    --summary "porting the storage layer" --mode edit --hint 'file:src/store/**'
+intent: porting the storage layer
+
+$ acc claim --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+    --resource 'file:src/store/**' --enforcement guarded --reason "porting"
+claimed file:src/store/**
+```
+
+**Intent** is awareness — it never authorises anything. **Claim** is the one that can stop
+a write. Claims are leases and expire on their own, so a crashed session can't hold the
+repo hostage.
+
+### 3. A write into someone else's claim is refused
+
+The Claude Code session tries to write `src/store/index.mjs`. Its `PreToolUse` hook gets
+back:
+
+```json
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"file:src/store/** is claimed by codex (session session_TZxxw2AY3Bp2tkTbA3FQ5Q)"}}
+```
+
+The tool call does not run, and the agent is told who holds it. A write anywhere **else**
+goes through untouched — the hook produces no output at all.
+
+At that session's next turn, ACC injects this:
+
+```text
+2 session(s); cursor 0000000000000006
+- [claim_conflict] file:src/store/** is claimed by session_TZxxw2AY3Bp2tkTbA3FQ5Q
+- [claim] file:src/store/** held by codex - file edits are blocked; edits made through a shell are not
+- session_ALYmBpY5dyGXltQ0vAJayw (claude_code, online)
+- session_TZxxw2AY3Bp2tkTbA3FQ5Q (codex, online)
+```
+
+That second line is the part most tools get wrong. It states exactly how far the guard
+reaches for **this** session: file edits are stopped, a shell command is not, because a
+command names no file to match against a claim.
+
+### 4. Agents can ask each other things
+
+```console
+$ acc message --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+    --to codex --type question --subject "src/store" \
+    --body "Need 20 minutes in src/store. Can you release it?" --requires-ack
+sent message__Wejo2AqkI2JZO9Dnl57dg
+```
+
+At the codex session's next turn:
+
+```text
+2 session(s); cursor 0000000000000007
+- [direct_request] src/store
+- session_ALYmBpY5dyGXltQ0vAJayw (claude_code, online)
+- session_TZxxw2AY3Bp2tkTbA3FQ5Q (codex, online)
+```
+
+The turn carries the subject and the fact that someone is waiting. The agent reads the body
+with `acc sync --scope full`. Peer text is data, never instruction — it stays fenced,
+attributed, and escaped, and cannot become ACC's own voice.
+
+## Working alone? It does nothing
+
+One session, no peers: the hook prints nothing, injects nothing, and the guard
+short-circuits against an empty claim set. Zero files written into your project.
+
+Coordination starts when a second session shows up, and not before.
 
 ## Install
 
@@ -42,29 +144,37 @@ That gives you `acc`, `acc-hook`, and `acc-mcp`. Then wire up whichever clients 
 acc install --dry-run
 ```
 
-Shows exactly what would change. Drop the flag to apply it, and `acc uninstall` to take it
-back out — it removes only what it wrote, and only if the bytes still match.
+It prints every path it would touch and why it skipped the clients you don't have. Drop
+`--dry-run` to apply.
 
-## What happens then
-
-```mermaid
-sequenceDiagram
-  participant H as You
-  participant C as Your client
-  participant ACC
-  H->>C: normal prompt
-  C->>ACC: session starts (hook)
-  ACC-->>C: 2 peers · file:src/** claimed by models
-  C->>ACC: about to write src/a.mjs
-  ACC-->>C: denied — claimed by models
+```bash
+acc install      # apply
+acc doctor       # clients, versions, install health, what to do next
+acc uninstall    # removes only what ACC wrote, only if the bytes still match
 ```
 
-No new commands to learn. Attach, presence, and guards happen inside the session.
+Codex additionally needs you to trust the plugin — that is Codex's own security step, and
+`acc doctor` will say so.
 
-## Alone? Nothing changes
+Then just open two clients in the same directory and work normally.
 
-One session pays nothing: no injected context, no banners, no protocol. Coordination
-starts when a second session shows up.
+## How it works
+
+```mermaid
+graph LR
+  C["your client<br/>Codex · Claude Code · Gemini · Kimi"] -->|hook fires| H[acc-hook]
+  H -->|attach · guard · inject| K["core<br/>sessions · claims · messages"]
+  K --> S[(state, outside your repo)]
+  K -->|allow or deny| H
+  H --> C
+```
+
+Three hook points do all of it: session start (attach), before a tool call (guard), before
+a turn (inject). Everything vendor-specific lives in that client's adapter — the core never
+knows which client it is talking to.
+
+A hook that cannot answer within 5 seconds **allows** the call. A coordination tool must
+never be the reason your session stops working.
 
 ## Supported clients
 
@@ -76,8 +186,19 @@ starts when a second session shows up.
 | Kimi Code | yes | yes | yes | yes |
 | Any MCP client | yes | – | – | – |
 
-¹ models that use `apply_patch` · ² approval modes that expose edit tools ·
-full detail in [CAPABILITIES.md](docs/CAPABILITIES.md)
+¹ models offering `apply_patch` — others edit through the shell, and a shell command names
+no file · ² approval modes that expose edit tools
+
+Every `yes` was captured from a real session on a named version. Nothing is inferred from
+documentation: [CAPABILITIES.md](docs/CAPABILITIES.md).
+
+## What it is not
+
+- not a model, an agent runtime, or a way to spawn agents;
+- not a replacement for Codex, Claude Code, or native subagents;
+- not a task tracker that turns every action into a ticket;
+- not a permanent lead session — no session is in charge;
+- not transcript sharing. It carries intent, claims, and messages. Never your prompts.
 
 ## Docs
 
@@ -92,14 +213,15 @@ full detail in [CAPABILITIES.md](docs/CAPABILITIES.md)
 Examples: [three workstreams](examples/three-workstreams.md) ·
 [research, no Git](examples/non-git-research.md)
 
-Contributing: [AGENTS.md](AGENTS.md) — the rules, and why the tests are shaped that way.
+Contributing: [AGENTS.md](AGENTS.md) — the rules, and why the tests are shaped the way they
+are.
 
 ## Requirements
 
-Node 24+, macOS or Linux. No database, no daemon, no service. Git optional.
+Node 24+, macOS or Linux. Git optional — a plain directory works.
 
-Windows is not supported yet — the reasons are measured and listed in
-[CHANGELOG.md](CHANGELOG.md).
+Windows does not work yet, and that is measured rather than assumed: 86 of 587 tests failed
+once CI actually ran there. Reasons in [CHANGELOG.md](CHANGELOG.md).
 
 ## License
 


### PR DESCRIPTION
The README described the product and never showed it working. A reader could not tell what it is, what problem it solves, what it prints, or what to do after installing.

## What changed

Rewritten around **four things it does**, each backed by output copied from a real run — not written by hand.

| Was | Now |
|---|---|
| "ACC is the layer that makes them aware" | "A local CLI plus one hook per client. No server, no database, no account." |
| "Two agents editing the same repo don't know about each other" | Two agents refactor the same module in parallel, one overwrites the other mid-edit, you find out at `git diff` |
| "guards writes" | the actual deny envelope the client receives, with the owner named |
| "injects peer context" | the exact text injected into a model's turn |
| `acc install --dry-run` and nothing else | where the `acc` binary comes from, then install / doctor / uninstall |

The injected-context block is the part I most wanted a reader to see:

```text
- [claim_conflict] file:src/store/** is claimed by session_TZxxw2AY3Bp2tkTbA3FQ5Q
- [claim] file:src/store/** held by codex - file edits are blocked; edits made through a shell are not
```

That second line is what most tools get wrong. It states how far the guard reaches **for this session** — file edits stopped, shell commands not, because a command names no file to match against a claim.

## Honesty details

- Commands are shown with the arguments they actually need. `acc work` and `acc claim` carry `--session`/`--generation` rather than being trimmed to look tidy, because a reader who types the trimmed form gets a usage error.
- The message section says what really reaches the model — the subject and the fact someone is waiting — and that the body is read with `acc sync --scope full`. Verified; the body is not injected.
- The Codex hook-trust step is stated because `acc doctor` reports it (`"hooks require explicit trust in Codex before they run"`).
- Nothing is spliced. An earlier draft of this file combined injected-context lines from two different runs into one block; that block was thrown away and recaptured from a single run.

## This is how the symlink bypass was found

Insisting on real output rather than description is what surfaced #11 — the denial I expected to paste simply did not happen. That fix is a separate PR.

## Verification

```
syntax ok in 132 file(s)
tests 594, pass 594, fail 0
```

Both README diagrams parse and render under real mermaid 11, and pass `tests/docs/diagrams.test.mjs`. The `acc install --dry-run` block is executed by `tests/docs/commands.test.mjs`.
