### PR TITLE
Deliver peer messages, and report only what actually landed

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -126,6 +126,12 @@ recorded -> queued -> injected -> seen -> acknowledged
 
 States are monotonic. One recipient's receipt cannot alter another recipient's state. `seen` means exposed to the receiving session or explicitly marked, not that the model obeyed it.
 
+`sendMessage` leaves a receipt at `queued`. It advances to `injected` when a recipient's
+turn context actually carried the message — and only then. A message the context budget
+could not fit stays `queued` and goes out on a later turn, because a receipt claiming
+delivery for text nobody was shown tells the sender something untrue. Whatever the budget
+left out is stated in the projection rather than dropped in silence.
+
 ## Decisions
 
 Decisions are separate durable objects rather than ordinary chat messages:

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -99,6 +99,8 @@ gate runs. Each rule is written as an attack rather than a description:
 | Peer text cannot forge or close the fence | `peer-injection.test.mjs` |
 | Peer text cannot repaint the terminal | `peer-injection.test.mjs` |
 | Flooding cannot bury a conflict warning | `peer-injection.test.mjs` |
+| The budget never cuts a peer block in half | `context-projector.test.mjs` |
+| A message nobody was shown is never reported delivered | `message-delivery.test.mjs` |
 | No path escapes the managed root | `storage-boundary.test.mjs` |
 | A workspace id cannot traverse | `storage-boundary.test.mjs` |
 | A config cannot point roots outside itself | `storage-boundary.test.mjs` |

--- a/packages/adapter-claude-code/src/adapter.mjs
+++ b/packages/adapter-claude-code/src/adapter.mjs
@@ -55,6 +55,6 @@ export function createClaudeCodeAdapter() {
     denyOutcome,
     injectOutcome,
     normalizeHook: payload => normalizeClaudeHook(payload),
-    renderContext: sync => projectContext(sync),
+    renderContext: (sync, options) => projectContext(sync, options),
   });
 }

--- a/packages/adapter-codex/src/adapter.mjs
+++ b/packages/adapter-codex/src/adapter.mjs
@@ -72,6 +72,6 @@ export function createCodexAdapter() {
     allowOutcome,
     injectOutcome,
     normalizeHook: payload => normalizeCodexHook(payload),
-    renderContext: sync => projectContext(sync),
+    renderContext: (sync, options) => projectContext(sync, options),
   });
 }

--- a/packages/adapter-gemini-cli/src/adapter.mjs
+++ b/packages/adapter-gemini-cli/src/adapter.mjs
@@ -65,6 +65,6 @@ export function createGeminiCliAdapter() {
     denyOutcome,
     injectOutcome,
     normalizeHook: payload => normalizeGeminiHook(payload),
-    renderContext: sync => projectContext(sync),
+    renderContext: (sync, options) => projectContext(sync, options),
   });
 }

--- a/packages/adapter-kimi/src/adapter.mjs
+++ b/packages/adapter-kimi/src/adapter.mjs
@@ -57,6 +57,6 @@ export function createKimiAdapter() {
     denyOutcome,
     injectOutcome,
     normalizeHook: payload => normalizeKimiHook(payload),
-    renderContext: sync => projectContext(sync),
+    renderContext: (sync, options) => projectContext(sync, options),
   });
 }

--- a/packages/adapter-sdk/src/context-projector.mjs
+++ b/packages/adapter-sdk/src/context-projector.mjs
@@ -1,4 +1,8 @@
 const DEFAULT_BUDGET_BYTES = 6_000;
+// Held back from the required lines so the "not shown" note can always be
+// written. A projection that silently drops what it could not fit is how an
+// agent ends up confidently unaware.
+const NOTE_RESERVE = 48;
 const FENCE = "```";
 // A peer cannot close a block it cannot name. The fence carries a marker that
 // is stripped from peer content, so forged delimiters stay inside the block.
@@ -74,10 +78,24 @@ function claimLines(claims) {
   });
 }
 
+/**
+ * One group per message, never a flat list of lines.
+ *
+ * A block that the budget cuts in half is worse than a block that was left out:
+ * the fence never closes, and everything after it reads as ACC's own words
+ * rather than as a peer's. So a message is included whole or not at all.
+ *
+ * The id is carried because the reader needs it to acknowledge the message, and
+ * because the caller needs it to tell which messages actually reached the model
+ * before recording any of them as delivered. Ids, session ids and types are
+ * generated or schema-validated; only the subject and body are peer-authored,
+ * and only those are escaped.
+ */
 function peerBlocks(messages) {
-  return messages.flatMap(message => [
+  return messages.map(message => [
     `${FENCE}${BLOCK}`,
-    `from ${message.fromSessionId} | type ${message.type} | untrusted peer message`,
+    `id ${message.messageId} | from ${message.fromSessionId} | type ${message.type}`
+    + " | untrusted peer message",
     escapePeerText(message.subject),
     escapePeerText(message.body),
     FENCE,
@@ -104,9 +122,11 @@ export function projectContext(sync, { budgetBytes = DEFAULT_BUDGET_BYTES } = {}
   const roster = sync.roster ?? [];
   const claims = sync.claims ?? [];
 
+  // Every entry is a group that appears whole or not at all. Single-line groups
+  // may still be truncated - there is no fence in them to leave open.
   const required = [
-    ...attentionLines(attention),
-    ...claimLines(claims),
+    ...attentionLines(attention).map(line => [line]),
+    ...claimLines(claims).map(line => [line]),
     ...peerBlocks(messages),
   ];
   const optional = roster.map(item =>
@@ -116,11 +136,29 @@ export function projectContext(sync, { budgetBytes = DEFAULT_BUDGET_BYTES } = {}
   const lines = [header];
   let used = bytes(header);
 
-  for (const line of required) {
-    const candidate = truncate(line, Math.max(0, budgetBytes - used - 1));
-    if (candidate === "" || used + bytes(candidate) + 1 > budgetBytes) break;
-    lines.push(candidate);
-    used += bytes(candidate) + 1;
+  // Reserved so the note below always fits. Without it the projection could run
+  // out of room to say that it ran out of room.
+  const ceiling = budgetBytes - NOTE_RESERVE;
+  let dropped = 0;
+  for (const group of required) {
+    if (group.length === 1) {
+      const candidate = truncate(group[0], Math.max(0, ceiling - used - 1));
+      if (candidate === "" || used + bytes(candidate) + 1 > ceiling) { dropped += 1; continue; }
+      lines.push(candidate);
+      used += bytes(candidate) + 1;
+      continue;
+    }
+    const size = group.reduce((total, line) => total + bytes(line) + 1, 0);
+    // Skipped rather than stopped at: the groups are ordered by priority, and a
+    // large message must not hide the shorter ones behind it.
+    if (used + size > ceiling) { dropped += 1; continue; }
+    lines.push(...group);
+    used += size;
+  }
+  if (dropped > 0) {
+    const note = `- +${dropped} not shown, over budget`;
+    lines.push(note);
+    used += bytes(note) + 1;
   }
 
   let shown = 0;

--- a/packages/adapter-sdk/test/context-projector.test.mjs
+++ b/packages/adapter-sdk/test/context-projector.test.mjs
@@ -195,3 +195,71 @@ test("an advisory claim reads the same however capable the session is", () => {
   // nobody asked to be enforced.
   assert.equal(render(true), render(false));
 });
+
+const peerMessage = (overrides = {}) => ({ messageId: "message_a",
+  fromSessionId: "session_peer", type: "question", subject: "src/store",
+  body: "Need 20 minutes.", ...overrides });
+
+test("a peer message reaches the projection whole, with the id needed to answer it", () => {
+  const rendered = projectContext(syncResult({ messages: [peerMessage()] }));
+
+  assert.match(rendered, /id message_a \| from session_peer \| type question/);
+  assert.match(rendered, /Need 20 minutes\./);
+});
+
+test("a message that does not fit is left out rather than cut in half", () => {
+  // Half a block is worse than no block: the fence never closes, and everything
+  // after it reads as ACC's own words. Before peer messages were ever delivered
+  // this could not happen, because the projector never received any.
+  const rendered = projectContext(syncResult({
+    roster: [],
+    messages: [peerMessage({ body: "x".repeat(4_000) })],
+  }), { budgetBytes: 300 });
+
+  const fences = rendered.split("\n").filter(line => line.startsWith("```")).length;
+  assert.equal(fences, 0, `a partial block was emitted:\n${rendered}`);
+  assert.equal(rendered.includes("xxxx"), false, "peer text leaked without its fence");
+});
+
+test("what the budget leaves out is stated, not silently dropped", () => {
+  const rendered = projectContext(syncResult({
+    roster: [],
+    messages: [peerMessage({ body: "x".repeat(4_000) })],
+  }), { budgetBytes: 300 });
+
+  assert.match(rendered, /- \+1 not shown, over budget/);
+});
+
+test("a large message does not hide the shorter ones queued behind it", () => {
+  // The loop skips what does not fit instead of stopping at it. Stopping would
+  // let one oversized message silence every message after it.
+  const rendered = projectContext(syncResult({
+    roster: [],
+    messages: [
+      peerMessage({ messageId: "message_big", body: "x".repeat(4_000) }),
+      peerMessage({ messageId: "message_small", body: "short" }),
+    ],
+  }), { budgetBytes: 400 });
+
+  assert.match(rendered, /id message_small/);
+  assert.equal(rendered.includes("message_big"), false);
+  assert.match(rendered, /- \+1 not shown, over budget/);
+});
+
+test("every emitted block is closed, whatever the budget", () => {
+  // Swept rather than spot-checked: the failure is a fence count that goes odd
+  // at one particular budget, and a single size would miss it.
+  for (let budgetBytes = 120; budgetBytes <= 1_200; budgetBytes += 20) {
+    const rendered = projectContext(syncResult({
+      roster: [],
+      messages: [peerMessage({ messageId: "message_a", body: "a".repeat(200) }),
+        peerMessage({ messageId: "message_b", body: "b".repeat(600) })],
+    }), { budgetBytes });
+
+    const fences = rendered.split("\n").filter(line => line === "```"
+      || line === "```acc-peer-message").length;
+    assert.equal(fences % 2, 0, `unbalanced fences at ${budgetBytes} bytes:\n${rendered}`);
+    assert.equal(Buffer.byteLength(rendered, "utf8") <= budgetBytes, true,
+      `projection overran ${budgetBytes} bytes`);
+  }
+});

--- a/packages/core/src/communication.mjs
+++ b/packages/core/src/communication.mjs
@@ -174,5 +174,34 @@ export function createCommunicationService(ports, sessions, claims) {
     return record;
   }
 
-  return { sendMessage, markDelivery, recordDecision, finishSession };
+  /**
+   * Messages addressed to this participant that nothing has shown a model yet.
+   *
+   * `queued` is where `sendMessage` leaves a receipt. Anything further along has
+   * already been put in front of the recipient, and delivery states only move
+   * forward - so re-injecting would misreport what happened rather than repeat
+   * harmlessly.
+   *
+   * A session never receives its own message back. Another session of the same
+   * participant does, because it is a different reader.
+   */
+  async function pendingMessages(input = {}) {
+    const participantId = input.participantId;
+    if (typeof participantId !== "string" || participantId === "") return [];
+    const workspaceId = input.workspaceId ?? store.workspaceId;
+    const snapshot = await store.snapshot(workspaceId);
+    const waiting = new Set((snapshot.receipts ?? [])
+      .filter(receipt => receipt.recipientParticipantId === participantId
+        && (receipt.state === "queued" || receipt.state === "recorded"))
+      .map(receipt => receipt.messageId));
+    return (snapshot.messages ?? [])
+      .filter(message => waiting.has(message.messageId)
+        && message.fromSessionId !== input.exceptSessionId)
+      // Oldest first, and the id breaks ties so two messages sent in the same
+      // millisecond still project in a stable order.
+      .sort((left, right) => left.sentAt.localeCompare(right.sentAt)
+        || left.messageId.localeCompare(right.messageId));
+  }
+
+  return { sendMessage, markDelivery, pendingMessages, recordDecision, finishSession };
 }

--- a/packages/hook-runner/src/runner.mjs
+++ b/packages/hook-runner/src/runner.mjs
@@ -127,11 +127,44 @@ const HANDLERS = {
           .find(p => p.sessionId === claim.ownerSessionId)?.participantId
           ?? claim.ownerSessionId }));
 
-    const projected = await adapter.renderContext?.({ ...sync, claims }) ?? "";
+    // What peers have said to this participant and no model has been shown yet.
+    // Without this the projector's peer block never ran in production: an agent
+    // saw only the subject of a message through its attention line, and the
+    // `injected` delivery state was unreachable.
+    const messages = await context.service.pendingMessages({
+      workspaceId: context.descriptor.id,
+      participantId: mine?.participantId,
+      exceptSessionId: binding.accSessionId });
+
+    // The ceiling a team agreed on in `acc.workspace.json`, or the default when
+    // there is no config. Validated by the protocol and, until now, never read:
+    // the projector was always called with its own default.
+    const projected = await adapter.renderContext?.({ ...sync, claims, messages },
+      { budgetBytes: context.descriptor.policy?.contextBudgetBytes }) ?? "";
     if (projected === "") return { stdout: "" };
+
+    // Only what the model was actually shown is recorded as delivered. The
+    // budget can leave a message out, and a receipt reading `injected` for text
+    // nobody saw is worse than one still reading `queued` - the sender would be
+    // told it landed. A message left behind stays queued and goes out next turn.
+    const failures = [];
+    for (const message of messages) {
+      if (!projected.includes(message.messageId)) continue;
+      await context.service.markDelivery({ sessionId: binding.accSessionId,
+        generation: binding.generation, messageId: message.messageId,
+        recipientParticipantId: mine.participantId, state: "injected" })
+        .catch(error => failures.push(`${message.messageId}: ${error.message}`));
+    }
     // Same again: Kimi Code shows the model a hook's raw stdout, while Gemini
     // and Claude Code want an envelope and drop a bare string.
-    return { stdout: "", ...adapter.injectOutcome?.(projected) };
+    // Reported rather than swallowed. The context still goes out - losing it
+    // over bookkeeping would be the worse trade - but a receipt that failed to
+    // advance has to be visible somewhere, and stdout belongs to the model.
+    const outcome = { stdout: "", ...adapter.injectOutcome?.(projected) };
+    if (failures.length === 0) return outcome;
+    return { ...outcome,
+      stderr: [outcome.stderr, `acc: delivery not recorded for ${failures.join(", ")}`]
+        .filter(Boolean).join("\n") };
   },
 
   async beforeTool({ binding, context, event, adapter }) {

--- a/tests/conformance/example-adapter.test.mjs
+++ b/tests/conformance/example-adapter.test.mjs
@@ -84,7 +84,7 @@ function createAdapter() {
       tool: payload.tool_name ?? null,
     }),
 
-    renderContext: async sync => projectContext(sync),
+    renderContext: async (sync, options) => projectContext(sync, options),
   });
 }
 

--- a/tests/process/message-delivery.test.mjs
+++ b/tests/process/message-delivery.test.mjs
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import { loadSessionBinding } from "@agents-can-communicate/adapter-sdk";
+
+const run = promisify(execFile);
+const repo = path.resolve(import.meta.dirname, "..", "..");
+const acc = path.join(repo, "bin", "acc.mjs");
+const hook = path.join(repo, "bin", "acc-hook.mjs");
+
+/**
+ * A message a model is never shown is not a message.
+ *
+ * The projector could always fence and attribute a peer message, and the
+ * delivery state machine could always move `queued -> injected`. Neither ever
+ * ran: `sync` returned no messages, so the runner handed the projector an empty
+ * list on every turn. A recipient saw the subject through its attention line
+ * and nothing else, and no receipt in production ever left `queued`.
+ *
+ * Driven through the real binaries, because the gap was exactly between two
+ * pieces that each worked on their own.
+ */
+async function place(t, policy = null) {
+  const base = await realpath(await mkdtemp(path.join(tmpdir(), "acc-delivery-")));
+  t.after(() => rm(base, { recursive: true, force: true }));
+  const project = path.join(base, "project");
+  await mkdir(project, { recursive: true });
+  if (policy !== null) {
+    await writeFile(path.join(project, "acc.workspace.json"), `${JSON.stringify({
+      schemaVersion: 1, workspaceId: "workspace_deliverytest", displayName: "delivery",
+      roots: ["."], policy }, null, 2)}\n`);
+  }
+  const env = { ...process.env, ACC_DATA_HOME: path.join(base, "data"),
+    GIT_DIR: "", GIT_WORK_TREE: "" };
+
+  const start = async (adapter, clientSessionId) => {
+    const child = run(process.execPath, [hook, adapter, "sessionStart"], { env });
+    child.child.stdin.end(JSON.stringify({ hook_event_name: "SessionStart",
+      session_id: clientSessionId, cwd: project, source: "startup" }));
+    await child;
+  };
+  await start("codex", "reader-1");
+  await start("claude_code", "sender-1");
+
+  const { stdout } = await run(process.execPath,
+    [acc, "doctor", "--cwd", project, "--json"], { env });
+  const runtimeDir = JSON.parse(stdout).data.runtimeRoot;
+  const reader = await loadSessionBinding({ runtimeDir, harnessSessionId: "reader-1" });
+  const sender = await loadSessionBinding({ runtimeDir, harnessSessionId: "sender-1" });
+  return { project, env, reader, sender };
+}
+
+/**
+ * The text a client would hand its model at the next turn.
+ *
+ * Injection contracts do not agree even in modality: Claude Code wants a
+ * `hookSpecificOutput` envelope, and Codex takes a hook's stdout verbatim as a
+ * `developer` message. Unwrapped here so the assertions can be about the
+ * content rather than about whose envelope it arrived in.
+ */
+async function turn({ project, env }, adapter, clientSessionId) {
+  const child = run(process.execPath, [hook, adapter, "userPromptSubmit"], { env });
+  child.child.stdin.end(JSON.stringify({ hook_event_name: "UserPromptSubmit",
+    session_id: clientSessionId, cwd: project, prompt: "carry on" }));
+  const { stdout } = await child;
+  if (stdout.trim() === "") return "";
+  if (!stdout.trimStart().startsWith("{")) return stdout;
+  return JSON.parse(stdout).hookSpecificOutput?.additionalContext ?? "";
+}
+
+const send = ({ project, env, sender }, extra = []) => run(process.execPath,
+  [acc, "message", "--session", sender.accSessionId, "--generation", sender.generation,
+    "--cwd", project, "--to", "codex", "--type", "question", "--subject", "src/store",
+    "--body", "Need 20 minutes in src/store. Can you release it?", ...extra],
+  { env }).then(({ stdout }) => stdout.trim().replace(/^sent /, ""));
+
+/** Receipt states, read the way an agent would read them. */
+async function receipts({ project, env, reader }) {
+  const { stdout } = await run(process.execPath, [acc, "sync", "--session",
+    reader.accSessionId, "--scope", "full", "--cwd", project, "--json"], { env });
+  return JSON.parse(stdout).data.snapshot.receipts;
+}
+
+test("a peer's message body reaches the recipient's turn, fenced and attributed", async t => {
+  const where = await place(t);
+  const messageId = await send(where);
+
+  const context = await turn(where, "codex", "reader-1");
+
+  assert.match(context, new RegExp(`id ${messageId}`),
+    "the body never reached the model - only the attention line did");
+  assert.match(context, /Need 20 minutes in src\/store/);
+  assert.match(context, /untrusted peer message/);
+  // The block has to close, or everything after it reads as ACC's own words.
+  const fences = context.split("\n").filter(line => line.startsWith("```")).length;
+  assert.equal(fences % 2, 0, `unbalanced fences:\n${context}`);
+});
+
+test("delivery is recorded as injected once the model has been shown it", async t => {
+  const where = await place(t);
+  const messageId = await send(where);
+
+  assert.deepEqual((await receipts(where)).map(r => r.state), ["queued"]);
+  await turn(where, "codex", "reader-1");
+
+  const after = await receipts(where);
+  assert.equal(after.length, 1);
+  assert.equal(after[0].messageId, messageId);
+  assert.equal(after[0].state, "injected",
+    "the receipt never left queued, so the sender is told nothing landed");
+});
+
+test("the same message is not injected again on the next turn", async t => {
+  const where = await place(t);
+  const messageId = await send(where);
+
+  const first = await turn(where, "codex", "reader-1");
+  const second = await turn(where, "codex", "reader-1");
+
+  assert.match(first, new RegExp(messageId));
+  assert.equal(second.includes(messageId), false,
+    "the message was replayed - delivery states move forward, so this is a false report");
+});
+
+test("a sender is not shown its own message", async t => {
+  const where = await place(t);
+  await send(where);
+
+  // Addressed to `codex`; the sender is `claude_code`. Getting it back would be
+  // a session talking to itself through the coordination layer.
+  const context = await turn(where, "claude_code", "sender-1");
+
+  assert.equal(context.includes("untrusted peer message"), false, context);
+});
+
+test("a message the budget could not fit stays queued rather than reported delivered", async t => {
+  // The project sets its own ceiling. `policy.contextBudgetBytes` was validated
+  // and documented from the start and never read by anything - the projector was
+  // always called with its own default - so this asserts the knob works as well
+  // as what happens at the edge of it.
+  const where = await place(t, { contextBudgetBytes: 200 });
+  await run(process.execPath, [acc, "message", "--session", where.sender.accSessionId,
+    "--generation", where.sender.generation, "--cwd", where.project, "--to", "codex",
+    "--type", "note", "--subject", "log", "--body", "x".repeat(3_000)], { env: where.env });
+
+  const context = await turn(where, "codex", "reader-1");
+
+  assert.equal(context.includes("xxxxxxxx"), false, "an oversized body was injected anyway");
+  assert.equal(Buffer.byteLength(context, "utf8") <= 200, true,
+    `the configured ceiling was ignored: ${Buffer.byteLength(context, "utf8")} bytes`);
+  // Said out loud. A projection that hides its own omissions leaves the model
+  // confidently unaware that something is waiting.
+  assert.match(context, /not shown, over budget/);
+  assert.deepEqual((await receipts(where)).map(receipt => receipt.state), ["queued"],
+    "the receipt says injected for text the model never saw - the sender is misinformed");
+});


### PR DESCRIPTION
`acc message` delivered a subject line and nothing else. Three pieces each worked alone and nothing connected them.

| Piece | State before |
|---|---|
| The projector's peer block — fenced, attributed, escaped | Never received a message. `sync` returns none, so the runner passed an empty list every turn. **The peer-injection security tests were guarding a path production never ran.** |
| The delivery state machine `queued → injected` | Outside the schema and the state table, `"injected"` appeared **nowhere** in the codebase. No receipt in production ever left `queued`. |
| `policy.contextBudgetBytes` | Validated, defaulted, documented as the ceiling on injected turn context. **Nothing read it** — every adapter called the projector with its own default. |

So a recipient saw `- [direct_request] src/store` and had to know to run `acc sync --scope full`. The sender was never told whether anything arrived.

## Now

```text
- [direct_request] src/store
```acc-peer-message
id message_H_Y3zwVe7oW-9TvHTHtWoA | from session_HQ6sODMatI2qMtCtdCVMRQ | type question | untrusted peer message
src/store
Need 20 minutes in src/store. Can you release it?
```
```

## Three things that turned out to matter

**Blocks are atomic.** `required` is now a list of groups, not lines. A message cut in half by the budget leaves its fence open, and everything after it reads as ACC's own words rather than a peer's — the exact failure the escaping exists to prevent, arriving through the budget instead of through the content. A group that does not fit is *skipped*, not stopped at, so one large message cannot silence the shorter ones queued behind it.

**Only what was rendered is recorded.** The runner marks `injected` for the ids it can find in the projection. A receipt claiming delivery for text nobody saw tells the sender something untrue. A message left behind stays `queued` and goes out on a later turn.

**What was dropped is said out loud.** Required lines used to fall off the end in silence while the roster politely reported `+N more`. Now both do, with bytes reserved up front so the projection can never run out of room to say that it ran out of room.

## Tests

`tests/process/message-delivery.test.mjs`, through the real binaries — the gap was precisely *between* components:

1. the body reaches the recipient's turn, fenced and attributed;
2. the receipt becomes `injected`;
3. it is not injected again on the next turn;
4. a sender is never shown its own message;
5. a message over the configured ceiling stays `queued`, and the projection says so.

Plus projector cases for atomicity, the drop note, skip-don't-stop, and a fence-balance sweep across budgets from 120 to 1200 bytes — a single size would miss the truncation edge.

One mutation per gate:

| Mutation | Caught by |
|---|---|
| don't pass messages to the projector | 3 delivery tests fail |
| record delivery unconditionally | over-budget test fails |
| ignore the configured ceiling | over-budget test fails |

## Merge order

**This should merge before #12.** The README in #12 says the turn carries only the subject and the body is read with `acc sync --scope full` — true today, false after this. I will correct that paragraph on the #12 branch.

## Verification

```
syntax ok in 133 file(s)
tests 604, pass 604, fail 0
```
