### PR TITLE
Refresh the release record against merged main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `70b793b` |
-| Tarball | `agents-can-communicate-0.0.0.tgz`, 84 KB, 99 entries |
-| sha256 | `a5c8bb1de3e811694633f4cc4a0c238790b79774c546d9bc7cefaaa36eb7cdfa` |
-| Tests | 598 passing, 0 failing |
+| Built from | `484e02b` |
+| Tarball | `agents-can-communicate-0.0.0.tgz`, 88 KB, 99 entries |
+| sha256 | `1d47407b2ee0e7ae6e7729c1e9ad3eff6796b6653a44a7b03fba72a923962c24` |
+| Tests | 615 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -34,6 +34,15 @@ when the working tree is dirty.
 
 Coordinates independent agent sessions in one workspace: presence, intent,
 workspace-global claims, typed messages, handoffs. No session is in charge.
+
+A peer's message reaches the recipient's turn as a fenced, attributed, escaped
+block, and its receipt advances to `injected` only for what the turn actually
+carried — a message the context budget could not fit stays queued rather than
+telling the sender it landed. The ceiling is `policy.contextBudgetBytes`.
+
+Claims are enforced however the workspace path is spelled. A project reached
+through a symlink — `/tmp` and `/var` on macOS, a symlinked checkout anywhere —
+used to pass every write through while still reporting `protection guarded`.
 
 ### Clients
 


### PR DESCRIPTION
Four merges landed since the record was written, and three of them changed shipped code — so the digest and the test count no longer described anything.

Re-measured on a clean tree at `484e02b`:

| | Was | Now |
|---|---|---|
| Built from | `70b793b` | `484e02b` |
| Tarball | 84 KB | 88 KB |
| sha256 | `a5c8bb1d…` | `1d47407b…` |
| Tests | 598 | 615 |

```
PASS  agents-can-communicate-0.0.0.tgz  sha256 1d47407b…  built from 484e02b
```

This is the mechanism from #10 doing its job: the record names the commit it belongs to, so a stale one reads as a measurement of an older tree rather than as a false claim about this one. It still needs refreshing — it just no longer misleads while it waits.

## Also

The description gained the two behaviour changes a reader would otherwise have to find in the diff:

- a peer's message now reaches the recipient's turn as a fenced, attributed block, and its receipt advances to `injected` only for what the turn actually carried;
- claims are enforced however the workspace path is spelled, where a symlinked checkout used to pass every write through while still reporting `protection guarded`.

## Verification

```
syntax ok in 136 file(s)
tests 615, pass 615, fail 0
verify-package: PASS, clean tree
```
