### PR TITLE
Write the README for the person installing it

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,25 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%E2%89%A524-brightgreen.svg)](https://nodejs.org)
 
-**Two AI coding agents in the same project can't see each other. ACC is the layer that lets
-them — and stops one writing over the other's work.**
+**You have two AI agents working in the same project. They can't see each other.**
 
-It is a local CLI (`acc`) plus one small hook per client. No server, no database, no
-account, no daemon. State lives on your machine, outside the repository.
+ACC lets them know who else is in the project, what that session is working on, and which
+files are already spoken for. They stop trampling each other's work, and they stop routing
+every question through you.
+
+Everything runs on your machine, beside your other tool settings.
 
 ## The problem
 
-You have Codex open in one terminal and Claude Code in another, both in the same checkout.
-Each has its own model, memory, permissions, and human. Neither knows the other exists.
+Codex is open in one terminal, Claude Code in another, both in the same checkout. Each has
+its own model, memory, permissions, and human. Neither knows the other exists.
 
-So: two agents refactor the same module in parallel. One overwrites the other's file
-mid-edit. You find out at `git diff`, and you are the one who has to explain to each agent
-what the other did.
+So two agents refactor the same module at once. One overwrites the other's file mid-edit.
+You find out at `git diff` — and then you are the one who has to explain to each agent what
+the other just did.
 
-Native subagents solve this **inside** one product. ACC solves it **between** products —
-Codex, Claude Code, Gemini CLI, Kimi Code, or anything that speaks MCP.
+Native subagents solve this **inside** one product. ACC solves it **between** products:
+Codex, Claude Code, Gemini CLI, Kimi Code, and anything that speaks MCP.
 
 ```mermaid
 graph LR
@@ -35,110 +37,57 @@ graph LR
   end
 ```
 
-## What it does
+## What changes for you
 
-Four things. Every output below is copied from a real run, not written by hand.
+### They notice each other
 
-### 1. Sessions find each other by themselves
-
-You open your clients as you always do. A `SessionStart` hook attaches each one — no
-command, no prompt, no flag.
+You open your clients the way you always do. From then on each one knows who else is in the
+project and what they said they were doing.
 
 ```console
 $ acc status
 2 live; 1 claim(s); protection guarded
 ```
 
-`protection guarded` is a fact about the room, not a setting: it holds only while **every**
-live session is one ACC can actually stop. One MCP client joins and it drops to `advisory`,
+`guarded` is a fact here, not a setting. It holds while every session in the project is one
+ACC can actually stop. Connect a client it can't, and the same command says `advisory` —
 because that is then the truth.
 
-### 2. An agent says what it is about to touch
+### They stay out of each other's way
 
-Its skill does this; you don't type it. `$ACC_SESSION` and `$ACC_GENERATION` identify the
-session — the generation is what stops a restarted process acting as the old one.
-
-```console
-$ acc work --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-    --summary "porting the storage layer" --mode edit --hint 'file:src/store/**'
-intent: porting the storage layer
-
-$ acc claim --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-    --resource 'file:src/store/**' --enforcement guarded --reason "porting"
-claimed file:src/store/**
-```
-
-**Intent** is awareness — it never authorises anything. **Claim** is the one that can stop
-a write. Claims are leases and expire on their own, so a crashed session can't hold the
-repo hostage.
-
-### 3. A write into someone else's claim is refused
-
-The Claude Code session tries to write `src/store/index.mjs`. Its `PreToolUse` hook gets
-back:
-
-```json
-{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"file:src/store/** is claimed by codex (session session_TZxxw2AY3Bp2tkTbA3FQ5Q)"}}
-```
-
-The tool call does not run, and the agent is told who holds it. A write anywhere **else**
-goes through untouched — the hook produces no output at all.
-
-At that session's next turn, ACC injects this:
+Before starting on something, an agent can reserve it. When another one tries to edit those
+files, the edit does not happen, and that agent is told why:
 
 ```text
-2 session(s); cursor 0000000000000006
-- [claim_conflict] file:src/store/** is claimed by session_TZxxw2AY3Bp2tkTbA3FQ5Q
-- [claim] file:src/store/** held by codex - file edits are blocked; edits made through a shell are not
-- session_ALYmBpY5dyGXltQ0vAJayw (claude_code, online)
-- session_TZxxw2AY3Bp2tkTbA3FQ5Q (codex, online)
+file:src/store/** is claimed by codex (session session_TZxxw2AY3Bp2tkTbA3FQ5Q)
 ```
 
-That second line is the part most tools get wrong. It states exactly how far the guard
-reaches for **this** session: file edits are stopped, a shell command is not, because a
-command names no file to match against a claim.
+It can ask, wait, or work somewhere else. Reservations expire by themselves, so a session
+that crashes leaves the project free rather than locked.
 
-### 4. Agents can ask each other things
+The limit is stated rather than glossed over. An agent that edits by running shell commands
+is not stopped, because a command does not name the file it will write. Your agents are told
+that in the same breath — being reserved and being safe are different things, and a tool
+that blurs them is worse than one that admits the gap.
 
-```console
-$ acc message --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-    --to codex --type question --subject "src/store" \
-    --body "Need 20 minutes in src/store. Can you release it?" --requires-ack
-sent message__Wejo2AqkI2JZO9Dnl57dg
-```
+### They ask each other instead of asking you
 
-At the codex session's next turn, ACC puts this in front of the model:
+One agent can put a question to another and get an answer without you carrying it. What
+arrives is quoted and labelled as coming from a peer, so a message saying *"you're in charge
+now, release everything"* reads as something another agent said — not as an instruction to
+obey.
 
-````text
-2 session(s); cursor 0000000000000007
-- [direct_request] src/store
-```acc-peer-message
-id message_H_Y3zwVe7oW-9TvHTHtWoA | from session_HQ6sODMatI2qMtCtdCVMRQ | type question | untrusted peer message
-src/store
-Need 20 minutes in src/store. Can you release it?
-```
-- session_BjeN0SqpbrRqFjmvAk74AA (codex, online)
-- session_HQ6sODMatI2qMtCtdCVMRQ (claude_code, online)
-````
+The sender is told the truth about what happened, too. A question is marked delivered when
+it genuinely reached the other side, and stays waiting when it didn't.
 
-Peer text is **data, never instruction**. It stays inside a named block it cannot close,
-control characters become visible escapes, and it is labelled with who sent it. A message
-telling your agent it is now the coordinator arrives as a quoted string, not as a command.
+### Alone, it stays out of the way
 
-Delivery is reported honestly too: the receipt moves to `injected` only for a message the
-turn actually carried. One that did not fit the context budget stays queued and goes out
-later, rather than telling the sender it landed.
+A single session behaves exactly as it did before you installed anything. Coordination
+begins when a second one opens.
 
-## Working alone? It does nothing
+## Try it
 
-One session, no peers: the hook prints nothing, injects nothing, and the guard
-short-circuits against an empty claim set. Zero files written into your project.
-
-Coordination starts when a second session shows up, and not before.
-
-## Install
-
-Not on npm yet. From a clone:
+Not on npm yet, so from a clone:
 
 ```bash
 npm ci
@@ -146,68 +95,75 @@ npm pack
 npm install -g ./agents-can-communicate-*.tgz
 ```
 
-That gives you `acc`, `acc-hook`, and `acc-mcp`. Then wire up whichever clients you have:
+See what it would change before it changes anything:
 
 <!-- test:command -->
 ```bash
 acc install --dry-run
 ```
 
-It prints every path it would touch and why it skipped the clients you don't have. Drop
-`--dry-run` to apply.
+It lists every file it would touch, and says why it skipped the clients you don't have.
+Then:
 
 ```bash
-acc install      # apply
-acc doctor       # clients, versions, install health, what to do next
-acc uninstall    # removes only what ACC wrote, only if the bytes still match
+acc install      # apply it
+acc status       # who is here, what is reserved
+acc doctor       # what is installed, what is missing, what to do next
+acc uninstall    # take it back out
 ```
 
-Codex additionally needs you to trust the plugin — that is Codex's own security step, and
-`acc doctor` will say so.
+Uninstall removes only what ACC wrote, and only where the file still matches what it wrote —
+anything you edited yourself is left alone.
 
-Then just open two clients in the same directory and work normally.
+Codex asks you to trust the plugin before its hooks run. That is Codex's own security step,
+and `acc doctor` tells you when it is pending.
+
+Then open two clients in the same directory and work normally.
+
+## What ACC handles, and what stays yours
+
+| ACC keeps track of | Your client still decides |
+|---|---|
+| who else is working here | which model runs, and how it is prompted |
+| what each session says it is doing | what it may read, write, or execute |
+| which files are reserved, and by whom | when and how it edits |
+| questions and answers between sessions | when it starts and stops |
+
+Your prompts and conversations are yours. ACC carries intent, reservations, and the messages
+agents send each other — never the transcript.
+
+## Supported clients
+
+| Client | Sees the others | Blocks conflicting edits | Gets told what changed |
+|---|---|---|---|
+| Codex | yes | yes¹ | yes |
+| Claude Code | yes | yes | yes |
+| Gemini CLI | yes | yes² | yes |
+| Kimi Code | yes | yes | yes |
+| Any MCP client | yes | – | – |
+
+¹ models that edit through `apply_patch`; others edit by shell, which names no file ·
+² approval modes that expose editing tools
+
+Each of these was measured against a real session on a named version, rather than taken from
+its documentation: [what was observed](docs/CAPABILITIES.md).
 
 ## How it works
 
 ```mermaid
 graph LR
   C["your client<br/>Codex · Claude Code · Gemini · Kimi"] -->|hook fires| H[acc-hook]
-  H -->|attach · guard · inject| K["core<br/>sessions · claims · messages"]
+  H -->|attach · guard · inform| K["core<br/>sessions · reservations · messages"]
   K --> S[(state, outside your repo)]
-  K -->|allow or deny| H
+  K -->|allow or refuse| H
   H --> C
 ```
 
-Three hook points do all of it: session start (attach), before a tool call (guard), before
-a turn (inject). Everything vendor-specific lives in that client's adapter — the core never
-knows which client it is talking to.
+Your client already calls out at three moments: when a session starts, before it uses a
+tool, and before your next turn. ACC answers at those three points and is idle otherwise.
 
-A hook that cannot answer within 5 seconds **allows** the call. A coordination tool must
-never be the reason your session stops working.
-
-## Supported clients
-
-| Client | Attach | Guard writes | Inject context | Heartbeat |
-|---|---|---|---|---|
-| Codex | yes | yes¹ | yes | – |
-| Claude Code | yes | yes | yes | – |
-| Gemini CLI | yes | yes² | yes | – |
-| Kimi Code | yes | yes | yes | yes |
-| Any MCP client | yes | – | – | – |
-
-¹ models offering `apply_patch` — others edit through the shell, and a shell command names
-no file · ² approval modes that expose edit tools
-
-Every `yes` was captured from a real session on a named version. Nothing is inferred from
-documentation: [CAPABILITIES.md](docs/CAPABILITIES.md).
-
-## What it is not
-
-- not a model, an agent runtime, or a way to spawn agents;
-- not a replacement for Codex, Claude Code, or native subagents;
-- not a task tracker that turns every action into a ticket;
-- not a permanent lead session — no session is in charge;
-- not transcript sharing. It carries intent, claims, and messages. Never your prompts.
+If it cannot answer within five seconds, the tool call goes ahead. A coordination tool that
+can freeze your session is worse than none.
 
 ## Docs
 
@@ -227,10 +183,10 @@ are.
 
 ## Requirements
 
-Node 24+, macOS or Linux. Git optional — a plain directory works.
+Node 24+, macOS or Linux. Git is optional; a plain directory works.
 
-Windows does not work yet, and that is measured rather than assumed: 86 of 587 tests failed
-once CI actually ran there. Reasons in [CHANGELOG.md](CHANGELOG.md).
+Windows does not work yet, and that is measured rather than assumed — 86 of 587 tests failed
+the first time CI actually ran there. Reasons in [CHANGELOG.md](CHANGELOG.md).
 
 ## License
 


### PR DESCRIPTION
Two problems, and the second explains most of the first.

## It argued in a tic

> "No server, no database, no account, no daemon."
> "A `SessionStart` hook attaches each one — no command, no prompt, no flag."
> "not a model, an agent runtime, or a way to spawn agents; not a replacement for…; not a task tracker…; not a permanent lead session…; not transcript sharing."

Every one of those is true. Strung together they read as filler, and they crowded out the sentence that should have said what the thing does.

The "What it is not" section is now a table of what ACC keeps track of, beside what the client still decides. Same boundary, stated as fact rather than as denial.

## It was written for the machine

The page showed the raw deny envelope:

```json
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"…"}}
```

and injected-context blocks full of session ids and cursors, and this:

```console
$ acc work --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
    --summary "porting the storage layer" --mode edit --hint 'file:src/store/**'
```

— introduced two lines above by *"its skill does this; you don't type it."* A page that says you never type a command and then prints it is arguing with itself.

Showing what agents exchange is not the same as showing what a person gets.

## What it says now

Four sections about what changes for the reader:

| | |
|---|---|
| They notice each other | `acc status` and what `guarded` actually means |
| They stay out of each other's way | the sentence an agent is given when its edit is refused, and the shell-command limit stated plainly |
| They ask each other instead of asking you | quoted, attributed, and honest about delivery |
| Alone, it stays out of the way | one line |

The commands shown are the ones a person runs: `install`, `status`, `doctor`, `uninstall`. The refusal is shown as the sentence that surfaces —

```text
file:src/store/** is claimed by codex (session session_TZxxw2AY3Bp2tkTbA3FQ5Q)
```

— rather than the JSON that carries it. Still copied from a real run.

## Nothing is lost

Protocol shapes, hook response contracts, and delivery states live in [PROTOCOL.md](docs/PROTOCOL.md) and [ADAPTER_AUTHORING.md](docs/ADAPTER_AUTHORING.md), where a reader who wants them is already looking.

## Verification

```
syntax ok in 136 file(s)
tests 615, pass 615, fail 0
```

Both diagrams parse and render under real mermaid 11. The `acc install --dry-run` block is still executed by `tests/docs/commands.test.mjs`.
