### PR TITLE
Put every client's files where that client reads them

### DIFF
--- a/packages/adapter-claude-code/src/adapter.mjs
+++ b/packages/adapter-claude-code/src/adapter.mjs
@@ -20,6 +20,10 @@ export function createClaudeCodeAdapter() {
   return defineAdapter({
     id: "claude_code",
     displayName: "Claude Code",
+    // The binary this client actually installs. Probed for a version to
+    // decide whether the client is on this machine, so it has to be the
+    // real command rather than the adapter id: `2.1.233 (Claude Code)`.
+    client: { command: "claude", versionArgs: ["--version"] },
     capabilities: {
       lifecycle: { sessionStart: true, sessionEnd: true },
       // A UserPromptSubmit hook's additionalContext was observed arriving in

--- a/packages/adapter-codex/src/adapter.mjs
+++ b/packages/adapter-codex/src/adapter.mjs
@@ -23,6 +23,10 @@ export function createCodexAdapter() {
   return defineAdapter({
     id: "codex",
     displayName: "Codex CLI",
+    // The binary this client actually installs. Probed for a version to
+    // decide whether the client is on this machine, so it has to be the
+    // real command rather than the adapter id: `codex-cli 0.147.0`.
+    client: { command: "codex", versionArgs: ["--version"] },
     capabilities: {
       lifecycle: { sessionStart: true, sessionEnd: true },
       // Observed reaching the model as a `developer` role message, unwrapped.

--- a/packages/adapter-codex/src/install.mjs
+++ b/packages/adapter-codex/src/install.mjs
@@ -15,8 +15,16 @@ const PLUGIN_NAME = "agents-can-communicate";
 const MARKETPLACE = "acc-local";
 const QUALIFIED = `${PLUGIN_NAME}@${MARKETPLACE}`;
 
-const marketplacePath = root => path.join(root, ".agents", "plugins", "marketplace.json");
-const pluginPath = (root, name = PLUGIN_NAME) => path.join(root, "plugins", name);
+// A marketplace is a directory whose manifest sits at
+// `<root>/.agents/plugins/marketplace.json`, and every `source.path` in that
+// manifest is relative to the manifest's own directory - `./plugins/<name>`,
+// as the client's own entries are written. Resolving the plugin from `root`
+// instead put the files two levels above where the manifest pointed, so the
+// entry named a directory that did not exist and the client loaded nothing.
+const marketplaceDir = root => path.join(root, ".agents", "plugins");
+const marketplacePath = root => path.join(marketplaceDir(root), "marketplace.json");
+const pluginPath = (root, name = PLUGIN_NAME) =>
+  path.join(marketplaceDir(root), "plugins", name);
 const configPath = codexHome => path.join(codexHome, "config.toml");
 // Where `codex plugin add` leaves the copy it actually runs. All three
 // components are ACC's own - the marketplace it created, the plugin name it

--- a/packages/adapter-codex/test/install.test.mjs
+++ b/packages/adapter-codex/test/install.test.mjs
@@ -41,7 +41,7 @@ test("install places the plugin and registers it in the marketplace", async t =>
   const result = await createCodexAdapter().install(context);
 
   assert.equal(result.ok, true);
-  const plugin = path.join(context.home, "plugins", "agents-can-communicate");
+  const plugin = path.join(context.home, ".agents", "plugins", "plugins", "agents-can-communicate");
   assert.deepEqual((await readdir(plugin)).sort(),
     [".codex-plugin", "acc-hook.sh", "hooks.json", "skills"].sort());
   const manifest = JSON.parse(await readFile(
@@ -75,7 +75,7 @@ test("uninstall removes only what ACC owns, twice safely", async t => {
   assert.deepEqual(afterFirst.plugins, EXISTING.plugins,
     "uninstall did not restore the marketplace");
   assert.deepEqual(await read(), afterFirst);
-  await assert.rejects(readdir(path.join(context.home, "plugins", "agents-can-communicate")),
+  await assert.rejects(readdir(path.join(context.home, ".agents", "plugins", "plugins", "agents-can-communicate")),
     error => error.code === "ENOENT");
 });
 
@@ -83,7 +83,7 @@ test("the hooks file wires only events this client actually has", async t => {
   const { context } = await fixture(t);
   await createCodexAdapter().install(context);
 
-  const wired = JSON.parse(await readFile(path.join(context.home, "plugins",
+  const wired = JSON.parse(await readFile(path.join(context.home, ".agents", "plugins", "plugins",
     "agents-can-communicate", "hooks.json"), "utf8"));
 
   for (const event of Object.keys(wired.hooks)) {
@@ -140,7 +140,7 @@ test("doctor reports the capture and the trust requirement", async t => {
 test("the guard matches the tools this client actually uses", async t => {
   const { context } = await fixture(t);
   await createCodexAdapter().install(context);
-  const wired = JSON.parse(await readFile(path.join(context.home, "plugins",
+  const wired = JSON.parse(await readFile(path.join(context.home, ".agents", "plugins", "plugins",
     "agents-can-communicate", "hooks.json"), "utf8"));
 
   // Codex names its edit tool apply_patch. A matcher copied from another

--- a/packages/adapter-gemini-cli/src/adapter.mjs
+++ b/packages/adapter-gemini-cli/src/adapter.mjs
@@ -28,6 +28,10 @@ export function createGeminiCliAdapter() {
   return defineAdapter({
     id: "gemini_cli",
     displayName: "Gemini CLI",
+    // The binary this client actually installs. Probed for a version to
+    // decide whether the client is on this machine, so it has to be the
+    // real command rather than the adapter id: `0.55.1`.
+    client: { command: "gemini", versionArgs: ["--version"] },
     capabilities: {
       lifecycle: { sessionStart: true, sessionEnd: true },
       context: { beforeTurnInjection: true },

--- a/packages/adapter-kimi/src/adapter.mjs
+++ b/packages/adapter-kimi/src/adapter.mjs
@@ -3,6 +3,9 @@ import { defineAdapter, projectContext } from "@agents-can-communicate/adapter-s
 import { denyOutcome, injectOutcome, normalizeKimiHook } from "./hooks.mjs";
 import { planKimiInstall, detectKimi, installKimiPlugin, uninstallKimiPlugin } from "./install.mjs";
 
+/** The installer works in this client's own home, wherever the caller put it. */
+const forClient = context => ({ ...context, home: context.kimiHome ?? context.home });
+
 export const KIMI_CODE_VERSION = "0.36.1";
 
 /**
@@ -24,6 +27,10 @@ export function createKimiAdapter() {
   return defineAdapter({
     id: "kimi",
     displayName: "Kimi Code",
+    // The binary this client actually installs. Probed for a version to
+    // decide whether the client is on this machine, so it has to be the
+    // real command rather than the adapter id: `0.36.1`.
+    client: { command: "kimi", versionArgs: ["--version"] },
     capabilities: {
       lifecycle: { sessionStart: true, heartbeat: true },
       context: { beforeTurnInjection: true },
@@ -37,10 +44,14 @@ export function createKimiAdapter() {
     guardShell: async () => ({ ok: true, changes: [], diagnostics: [] }),
     poll: async () => ({ ok: true, changes: [], diagnostics: [] }),
 
-    planInstall: context => planKimiInstall(context),
-    detect: context => detectKimi(context),
-    install: context => installKimiPlugin(context),
-    uninstall: context => uninstallKimiPlugin(context),
+    // This client keeps everything under its own directory, so the installer is
+    // handed that rather than the user's home. Pointed at the home itself it
+    // wrote `~/config.toml` and `~/plugins/` beside the client instead of
+    // inside it - an install that reports success and is never read.
+    planInstall: context => planKimiInstall(forClient(context)),
+    detect: context => detectKimi(forClient(context)),
+    install: context => installKimiPlugin(forClient(context)),
+    uninstall: context => uninstallKimiPlugin(forClient(context)),
 
     doctor: async context => {
       const detected = await detectKimi(context);

--- a/packages/adapter-sdk/src/capabilities.mjs
+++ b/packages/adapter-sdk/src/capabilities.mjs
@@ -80,6 +80,15 @@ export function defineAdapter(manifest) {
   if (typeof manifest.displayName !== "string" || manifest.displayName.trim() === "") {
     usage("an adapter must declare a displayName", { id: manifest.id });
   }
+  // Detection spawns this to decide whether the client is on the machine.
+  // Left undeclared it used to fall back to the adapter id, so `claude_code`
+  // and `gemini_cli` probed binaries that do not exist and were reported absent
+  // on every machine - `acc install` silently skipped half its clients.
+  const command = manifest.client?.command;
+  if (typeof command !== "string" || command.trim() === "") {
+    usage("an adapter must declare client.command, the binary its client installs",
+      { id: manifest.id });
+  }
   for (const method of BASE_METHODS) {
     if (typeof manifest[method] !== "function") {
       usage(`an adapter must implement ${method}()`, { id: manifest.id, method });

--- a/packages/adapter-sdk/test/capabilities.test.mjs
+++ b/packages/adapter-sdk/test/capabilities.test.mjs
@@ -17,6 +17,7 @@ const base = (overrides = {}) => ({
   doctor: noop,
   normalizeHook: () => ({ kind: "sessionStart", sessionId: "s", cwd: "/tmp" }),
   renderContext: () => "",
+  client: { command: "example", versionArgs: ["--version"] },
   ...overrides,
 });
 
@@ -98,4 +99,17 @@ test("an adapter must declare an id, a display name, and the base operations", (
       error => error.code === EXIT.USAGE && error.message.includes(method),
       `a missing ${method} was accepted`);
   }
+});
+
+test("an adapter without a client binary is refused at construction", () => {
+  // Detection spawns this to decide whether the client is on the machine. When
+  // it was optional the probe fell back to the adapter id, so `claude_code` and
+  // `gemini_cli` ran commands that exist nowhere and `acc install` reported
+  // both absent on every machine while claiming success.
+  const { client, ...withoutClient } = base();
+
+  assert.throws(() => defineAdapter(withoutClient),
+    error => error.code === EXIT.USAGE && /client\.command/.test(error.message));
+  assert.throws(() => defineAdapter({ ...base(), client: { command: "  " } }),
+    error => error.code === EXIT.USAGE);
 });

--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -1,6 +1,9 @@
 // Composition root: discovery, runtime locations, and the CLI surface.
 export { main } from "./main.mjs";
 export { COMMANDS, parseArgs } from "./args.mjs";
+// Exported so a test can hold every adapter to where it plans to write and
+// which binary decides it runs at all.
+export { ALL_ADAPTERS, clientContext } from "./install-command.mjs";
 export { discoverWorkspace } from "./workspace-discovery.mjs";
 export { createGitProbe, hermeticEnv } from "./git-probe.mjs";
 export { platformDataHome, runtimePaths } from "./runtime-paths.mjs";

--- a/packages/cli/src/install-command.mjs
+++ b/packages/cli/src/install-command.mjs
@@ -14,11 +14,15 @@ import { platformPaths } from "./platform-paths.mjs";
 // Where each client keeps its own configuration. All of it derives from one
 // home, so a test - or an operator with a second account - can point the whole
 // installation somewhere else in one move.
+// Each client keeps its own directory under the user's home, and an adapter
+// pointed at the home itself writes beside them rather than inside them. That
+// install reports success and the client never reads a byte of it.
 export const clientContext = home => ({
   home,
   configDir: path.join(home, ".claude"),
   agentsHome: home,
   codexHome: path.join(home, ".codex"),
+  kimiHome: path.join(home, ".kimi-code"),
 });
 
 export const ALL_ADAPTERS = () => [createClaudeCodeAdapter(), createCodexAdapter(),

--- a/packages/installer/src/detect.mjs
+++ b/packages/installer/src/detect.mjs
@@ -48,8 +48,10 @@ export async function detectInstallation({ adapters, context, probe = spawnProbe
 
       try {
         const output = await withTimeout(
-          Promise.resolve(probe(adapter.client?.command ?? adapter.id,
-            adapter.client?.versionArgs ?? ["--version"])),
+          // The declared binary, never the adapter id. Guessing the id made
+          // every client whose command differs from it look uninstalled.
+          Promise.resolve(probe(adapter.client.command,
+            adapter.client.versionArgs ?? ["--version"])),
           probeTimeoutMs, `${adapter.id} version probe`);
         if (typeof output === "string" && output !== "") {
           entry.present = true;

--- a/tests/conformance/example-adapter.test.mjs
+++ b/tests/conformance/example-adapter.test.mjs
@@ -42,6 +42,7 @@ function createAdapter() {
   return defineAdapter({
     id: "example_harness",
     displayName: "Example Harness",
+    client: { command: "example", versionArgs: ["--version"] },
     capabilities: {
       lifecycle: { sessionStart: true, sessionEnd: true },
       context: { startupInjection: true },

--- a/tests/process/hook-wiring.test.mjs
+++ b/tests/process/hook-wiring.test.mjs
@@ -28,8 +28,8 @@ const ADAPTERS = [
   { name: "codex", create: createCodexAdapter,
     context: home => ({ home, codexHome: path.join(home, ".codex") }),
     commands: async home => {
-      const wired = JSON.parse(await readFile(path.join(home, "plugins",
-        "agents-can-communicate", "hooks.json"), "utf8"));
+      const wired = JSON.parse(await readFile(path.join(home, ".agents", "plugins",
+        "plugins", "agents-can-communicate", "hooks.json"), "utf8"));
       return Object.values(wired.hooks)
         .flatMap(entries => entries.flatMap(entry => entry.hooks.map(h => h.command)));
     } },

--- a/tests/process/install-targets.test.mjs
+++ b/tests/process/install-targets.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+
+import { ALL_ADAPTERS, clientContext } from "@agents-can-communicate/cli";
+import { detectInstallation } from "@agents-can-communicate/installer";
+
+/**
+ * Where an install actually lands, and which binary decides it happens.
+ *
+ * Both halves of this were wrong on every real machine, and every test was
+ * green throughout, because the installer suite supplies a fake probe and a
+ * temporary home. Nothing compared what an adapter plans against how the client
+ * really lays itself out, and nothing ran the binary.
+ *
+ * The result looked like success: `acc install` listed files it had created,
+ * `acc doctor` reported them present, and two clients were skipped as "not
+ * installed" while a third was handed a manifest pointing at a directory that
+ * did not exist.
+ */
+const HOME = path.join(path.sep, "home", "dana");
+
+test("no adapter writes at the top of the user's home", () => {
+  const context = clientContext(HOME);
+
+  for (const adapter of ALL_ADAPTERS()) {
+    for (const artifact of adapter.planInstall(context)) {
+      const relative = path.relative(HOME, artifact.path);
+      assert.equal(relative.startsWith(".."), false,
+        `${adapter.id} plans ${artifact.path}, which is outside the home entirely`);
+      // `~/config.toml` and `~/plugins/` were real plans. A client keeps its
+      // own directory; anything a level above it sits beside the client rather
+      // than inside it, and is never read.
+      assert.equal(path.dirname(relative) === ".", false,
+        `${adapter.id} writes ${relative} directly into the home`);
+      assert.equal(relative.split(path.sep)[0].startsWith("."), true,
+        `${adapter.id} writes into ${relative.split(path.sep)[0]}/, `
+        + "which is not a client's own directory");
+    }
+  }
+});
+
+test("every adapter declares the binary its client installs", () => {
+  for (const adapter of ALL_ADAPTERS()) {
+    assert.equal(typeof adapter.client?.command, "string",
+      `${adapter.id} declares no client.command`);
+    assert.notEqual(adapter.client.command.trim(), "");
+  }
+});
+
+test("detection probes the declared binary, not the adapter id", async () => {
+  // The exact regression: with no declaration the probe fell back to the id, so
+  // `claude_code` and `gemini_cli` ran commands that exist nowhere and were
+  // reported absent on every machine.
+  const asked = [];
+  const probe = async command => {
+    asked.push(command);
+    return "1.2.3";
+  };
+
+  const adapters = ALL_ADAPTERS();
+  const detected = await detectInstallation({ adapters, context: clientContext(HOME), probe });
+
+  assert.deepEqual(asked.sort(), adapters.map(a => a.client.command).sort());
+  assert.deepEqual(detected.filter(entry => !entry.present), [],
+    "a client that answered its version probe was still reported absent");
+});
+
+test("a client whose binary is absent is reported absent, not assumed present", async () => {
+  const probe = async () => { throw new Error("command not found"); };
+
+  const detected = await detectInstallation({ adapters: ALL_ADAPTERS(),
+    context: clientContext(HOME), probe });
+
+  assert.deepEqual(detected.map(entry => entry.present), detected.map(() => false));
+});


### PR DESCRIPTION
`acc install` was broken for **three of the four clients** on a real machine, and looked successful for all of them.

Found by running the first step of the local test plan against this machine instead of a fixture.

## Two clients were never detected — anywhere, ever

Detection spawns a binary to decide whether a client is present. With no declaration it fell back to the **adapter id**, and no adapter declared anything:

```
codex        probe succeeded
claude_code  probe FAILED → present:false
gemini_cli   probe FAILED → present:false
kimi         probe succeeded
```

The binaries are `claude` and `gemini`. So `acc install` reported both "not installed on this machine" on every machine, forever.

## Kimi was written a level too high

| | |
|---|---|
| Installer wrote | `~/config.toml`, `~/plugins/managed/…`, `~/plugins/installed.json` |
| Client reads | `~/.kimi-code/config.toml`, `~/.kimi-code/plugins/…` |

Beside the client instead of inside it. Kimi never saw a hook.

## Codex wrote a manifest pointing at nothing

A marketplace entry's `source.path` is relative to the **manifest's own directory**. This machine's real entry:

```json
{ "name": "simplify", "source": { "source": "local", "path": "./plugins/simplify" } }
```

— and the files sit at `~/.agents/plugins/plugins/simplify`.

ACC wrote the same relative path into its entry, correctly, but resolved the actual directory from the marketplace root: `~/plugins/agents-can-communicate`. **The manifest named a directory that did not exist.**

## Why nothing caught it

Every test was green throughout. The installer suite supplies a fake probe and a temporary home, so nothing ever ran a real binary or compared a planned path against how a client lays itself out on disk.

And the failure was silent in the worst way: `acc install` would list the files it created, `acc doctor` would confirm them, and no client would load any of it.

## The gates

`tests/process/install-targets.test.mjs`:

- no adapter may write at the top of the home, or outside a dot-directory;
- every adapter must declare its client binary;
- detection must probe the declared command, and a client that answers must not be reported absent.

`defineAdapter` now refuses a manifest without `client.command`, so it cannot be forgotten again.

| Mutation | Caught by |
|---|---|
| point Kimi back at the home | `no adapter writes at the top of the user's home` |
| make `client.command` optional again | `an adapter without a client binary is refused at construction` |

## Verified against this machine

```
create ~/.claude/plugins/agents-can-communicate
add ACC entries to ~/.claude/settings.json
create ~/.agents/plugins/plugins/agents-can-communicate
create ~/.codex/plugins/cache/acc-local
add ACC entries to ~/.agents/plugins/marketplace.json
add ACC entries to ~/.codex/config.toml
create ~/.kimi-code/plugins/managed/agents-can-communicate
add ACC entries to ~/.kimi-code/config.toml
add ACC entries to ~/.kimi-code/plugins/installed.json
skip gemini_cli: Gemini CLI is not installed on this machine
```

Every target matches a directory that already exists there. Gemini is skipped truthfully — its binary is genuinely not on this shell's PATH.

```
syntax ok in 139 file(s)
tests 629, pass 629, fail 0
```
