### PR TITLE
Give the agent a command that runs, and shut the door it went round

### DIFF
--- a/packages/adapter-claude-code/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-claude-code/plugin/skills/acc/SKILL.md
@@ -14,7 +14,7 @@ skill is how you stay legible to them and they to you.
 Once you understand the request, publish one line of Intent:
 
 ```bash
-acc work --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} work --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --summary "porting the claim model" --mode edit
 ```
 
@@ -25,7 +25,7 @@ what you are up to, it does not stop anyone editing anything.
 ## Claim before you change shared work
 
 ```bash
-acc claim --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} claim --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --resource 'file:packages/core/**' --reason "porting the store"
 ```
 
@@ -39,7 +39,7 @@ wrote, a port in an area someone else is already in — ask the agent working th
 do it badly yourself, and do not ask your human to carry the message:
 
 ```bash
-acc request --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} request --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --to claude_code --title "finish the store tests" \
   --detail "I ported src/store but ran out of time on the concurrency cases."
 ```
@@ -54,13 +54,13 @@ A turn that opens with `[task_unblocked]` means work is addressed to you and wai
 it before you start, so nobody does it twice:
 
 ```bash
-acc task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --take
+{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --take
 ```
 
 Mark it when it is done, so the agent that asked can stop waiting:
 
 ```bash
-acc task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --state done
+{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --state done
 ```
 
 If you are not going to do it, reply with `acc message` instead of leaving it pending. The
@@ -72,7 +72,7 @@ If you are not going to do it, say so. A request left pending looks exactly like
 one you have not read yet, and the agent that asked is waiting on an answer:
 
 ```bash
-acc task --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --task task_x --decline --reason "Mud collision belongs to the terrain pass, not suspension."
 ```
 
@@ -92,13 +92,32 @@ Do one of three things, and tell your human which:
   refused without `--force` while the holder is merely quiet rather than gone;
 - drop it, if it no longer matters.
 
+## If the command does not work, stop
+
+Everything above runs through the command shown in these examples. It is the one
+this installation wired up, with absolute paths, because a shell that a hook or a
+tool call starts does not reliably carry your PATH.
+
+If it fails to run, say so to your human and carry on with the actual work.
+
+Do not write to ACC's files yourself. The coordination state is plain JSON in a
+directory you can find, and it looks editable. It is not: writes go through a
+lock, records carry generation tokens that are checked on every change, and the
+event log is ordered. A record placed there by hand is not coordination - the
+other agents will read it and act on something that never happened.
+
+This is not hypothetical. A session that could not find the command once read the
+store, worked out its schema, and wrote records and events by hand, inventing an
+event type and its own generation tokens. Everything it reported had happened,
+had not.
+
 ## You can answer for the whole workspace
 
 You are not limited to your own view. Any session can read the complete state, including
 other participants' sessions and their subagents:
 
 ```bash
-acc sync --session "$ACC_SESSION" --scope full --json
+{{ACC}} sync --session "$ACC_SESSION" --scope full --json
 ```
 
 If the human asks "what is the models agent doing?" or "is anyone else touching the
@@ -108,7 +127,7 @@ differs between participants; knowledge does not.
 You can also relay a request to any participant:
 
 ```bash
-acc message --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} message --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --to models --subject "Material slots" --body "Which names are stable?" \
   --type question --requires-ack
 ```
@@ -133,7 +152,7 @@ Before the session ends, record what happened — nothing else writes this for y
 session-end hook cannot summarise a conversation that has already stopped:
 
 ```bash
-acc finish --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} finish --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --goal "port the claim model" --status partial \
   --completed "storage ported" --remaining "doctor still to port"
 ```

--- a/packages/adapter-claude-code/src/install.mjs
+++ b/packages/adapter-claude-code/src/install.mjs
@@ -2,7 +2,8 @@ import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { mergeOwnedConfig, ownedKeys, removeInstalledTree, removeOwnedConfig, writeHookShim }
+import { bakeSkillCommand, mergeOwnedConfig, ownedKeys, removeInstalledTree,
+  removeOwnedConfig, writeHookShim }
   from "@agents-can-communicate/adapter-sdk";
 
 const bundle = fileURLToPath(new URL("../plugin", import.meta.url));
@@ -35,6 +36,9 @@ export async function installClaudePlugin({ configDir, runner, node }) {
   const target = pluginPath(configDir);
   await rm(target, { recursive: true, force: true });
   await cp(bundle, target, { recursive: true });
+  // The skill ships with a placeholder where the command belongs: `acc` is
+  // not on PATH everywhere, and an agent that cannot run it improvises.
+  await bakeSkillCommand({ root: target, node });
   // The bundle's hooks.json names this script; until now nothing wrote it, so
   // every hook resolved to a command that does not exist and failed silently.
   await writeHookShim({ dir: path.join(target, "hooks"), adapterId: "claude_code",

--- a/packages/adapter-codex/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-codex/plugin/skills/acc/SKILL.md
@@ -14,7 +14,7 @@ skill is how you stay legible to them and they to you.
 Once you understand the request, publish one line of Intent:
 
 ```bash
-acc work --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} work --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --summary "porting the claim model" --mode edit
 ```
 
@@ -25,7 +25,7 @@ what you are up to, it does not stop anyone editing anything.
 ## Claim before you change shared work
 
 ```bash
-acc claim --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} claim --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --resource 'file:packages/core/**' --reason "porting the store"
 ```
 
@@ -39,7 +39,7 @@ wrote, a port in an area someone else is already in — ask the agent working th
 do it badly yourself, and do not ask your human to carry the message:
 
 ```bash
-acc request --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} request --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --to claude_code --title "finish the store tests" \
   --detail "I ported src/store but ran out of time on the concurrency cases."
 ```
@@ -54,13 +54,13 @@ A turn that opens with `[task_unblocked]` means work is addressed to you and wai
 it before you start, so nobody does it twice:
 
 ```bash
-acc task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --take
+{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --take
 ```
 
 Mark it when it is done, so the agent that asked can stop waiting:
 
 ```bash
-acc task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --state done
+{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --state done
 ```
 
 If you are not going to do it, reply with `acc message` instead of leaving it pending. The
@@ -72,7 +72,7 @@ If you are not going to do it, say so. A request left pending looks exactly like
 one you have not read yet, and the agent that asked is waiting on an answer:
 
 ```bash
-acc task --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --task task_x --decline --reason "Mud collision belongs to the terrain pass, not suspension."
 ```
 
@@ -92,13 +92,32 @@ Do one of three things, and tell your human which:
   refused without `--force` while the holder is merely quiet rather than gone;
 - drop it, if it no longer matters.
 
+## If the command does not work, stop
+
+Everything above runs through the command shown in these examples. It is the one
+this installation wired up, with absolute paths, because a shell that a hook or a
+tool call starts does not reliably carry your PATH.
+
+If it fails to run, say so to your human and carry on with the actual work.
+
+Do not write to ACC's files yourself. The coordination state is plain JSON in a
+directory you can find, and it looks editable. It is not: writes go through a
+lock, records carry generation tokens that are checked on every change, and the
+event log is ordered. A record placed there by hand is not coordination - the
+other agents will read it and act on something that never happened.
+
+This is not hypothetical. A session that could not find the command once read the
+store, worked out its schema, and wrote records and events by hand, inventing an
+event type and its own generation tokens. Everything it reported had happened,
+had not.
+
 ## You can answer for the whole workspace
 
 You are not limited to your own view. Any session can read the complete state, including
 other participants' sessions and their subagents:
 
 ```bash
-acc sync --session "$ACC_SESSION" --scope full --json
+{{ACC}} sync --session "$ACC_SESSION" --scope full --json
 ```
 
 If the human asks "what is the models agent doing?" or "is anyone else touching the
@@ -108,7 +127,7 @@ differs between participants; knowledge does not.
 You can also relay a request to any participant:
 
 ```bash
-acc message --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} message --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --to models --subject "Material slots" --body "Which names are stable?" \
   --type question --requires-ack
 ```
@@ -133,7 +152,7 @@ Before the session ends, record what happened — nothing else writes this for y
 session-end hook cannot summarise a conversation that has already stopped:
 
 ```bash
-acc finish --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} finish --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --goal "port the claim model" --status partial \
   --completed "storage ported" --remaining "doctor still to port"
 ```

--- a/packages/adapter-codex/src/install.mjs
+++ b/packages/adapter-codex/src/install.mjs
@@ -2,7 +2,8 @@ import { cp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { removeInstalledTree, removeTomlBlock, stripBlock, tomlString, writeHookShim, writeTomlBlock }
+import { bakeSkillCommand, removeInstalledTree, removeTomlBlock, stripBlock, tomlString,
+  writeHookShim, writeTomlBlock }
   from "@agents-can-communicate/adapter-sdk";
 import { AccError, EXIT } from "@agents-can-communicate/protocol";
 
@@ -89,6 +90,9 @@ export async function installCodexPlugin({ home, agentsHome = home,
   const target = pluginPath(agentsHome);
   await rm(target, { recursive: true, force: true });
   await cp(bundle, target, { recursive: true });
+  // The skill ships with a placeholder where the command belongs: `acc` is
+  // not on PATH everywhere, and an agent that cannot run it improvises.
+  await bakeSkillCommand({ root: target, node });
   const shim = await writeHookShim({ dir: target, adapterId: "codex", runner, node });
   await writeJson(path.join(target, "hooks.json"),
     withShim(await readJson(path.join(bundle, "hooks.json"), { hooks: {} }), shim));

--- a/packages/adapter-gemini-cli/extension/skills/acc/SKILL.md
+++ b/packages/adapter-gemini-cli/extension/skills/acc/SKILL.md
@@ -14,7 +14,7 @@ skill is how you stay legible to them and they to you.
 Once you understand the request, publish one line of Intent:
 
 ```bash
-acc work --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} work --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --summary "porting the claim model" --mode edit
 ```
 
@@ -25,7 +25,7 @@ what you are up to, it does not stop anyone editing anything.
 ## Claim before you change shared work
 
 ```bash
-acc claim --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} claim --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --resource 'file:packages/core/**' --reason "porting the store"
 ```
 
@@ -39,7 +39,7 @@ wrote, a port in an area someone else is already in — ask the agent working th
 do it badly yourself, and do not ask your human to carry the message:
 
 ```bash
-acc request --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} request --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --to claude_code --title "finish the store tests" \
   --detail "I ported src/store but ran out of time on the concurrency cases."
 ```
@@ -54,13 +54,13 @@ A turn that opens with `[task_unblocked]` means work is addressed to you and wai
 it before you start, so nobody does it twice:
 
 ```bash
-acc task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --take
+{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --take
 ```
 
 Mark it when it is done, so the agent that asked can stop waiting:
 
 ```bash
-acc task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --state done
+{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --state done
 ```
 
 If you are not going to do it, reply with `acc message` instead of leaving it pending. The
@@ -72,7 +72,7 @@ If you are not going to do it, say so. A request left pending looks exactly like
 one you have not read yet, and the agent that asked is waiting on an answer:
 
 ```bash
-acc task --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --task task_x --decline --reason "Mud collision belongs to the terrain pass, not suspension."
 ```
 
@@ -92,13 +92,32 @@ Do one of three things, and tell your human which:
   refused without `--force` while the holder is merely quiet rather than gone;
 - drop it, if it no longer matters.
 
+## If the command does not work, stop
+
+Everything above runs through the command shown in these examples. It is the one
+this installation wired up, with absolute paths, because a shell that a hook or a
+tool call starts does not reliably carry your PATH.
+
+If it fails to run, say so to your human and carry on with the actual work.
+
+Do not write to ACC's files yourself. The coordination state is plain JSON in a
+directory you can find, and it looks editable. It is not: writes go through a
+lock, records carry generation tokens that are checked on every change, and the
+event log is ordered. A record placed there by hand is not coordination - the
+other agents will read it and act on something that never happened.
+
+This is not hypothetical. A session that could not find the command once read the
+store, worked out its schema, and wrote records and events by hand, inventing an
+event type and its own generation tokens. Everything it reported had happened,
+had not.
+
 ## You can answer for the whole workspace
 
 You are not limited to your own view. Any session can read the complete state, including
 other participants' sessions and their subagents:
 
 ```bash
-acc sync --session "$ACC_SESSION" --scope full --json
+{{ACC}} sync --session "$ACC_SESSION" --scope full --json
 ```
 
 If the human asks "what is the models agent doing?" or "is anyone else touching the
@@ -108,7 +127,7 @@ differs between participants; knowledge does not.
 You can also relay a request to any participant:
 
 ```bash
-acc message --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} message --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --to models --subject "Material slots" --body "Which names are stable?" \
   --type question --requires-ack
 ```
@@ -133,7 +152,7 @@ Before the session ends, record what happened — nothing else writes this for y
 session-end hook cannot summarise a conversation that has already stopped:
 
 ```bash
-acc finish --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} finish --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --goal "port the claim model" --status partial \
   --completed "storage ported" --remaining "doctor still to port"
 ```

--- a/packages/adapter-gemini-cli/src/install.mjs
+++ b/packages/adapter-gemini-cli/src/install.mjs
@@ -2,7 +2,7 @@ import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { removeInstalledTree, writeHookShim }
+import { bakeSkillCommand, removeInstalledTree, writeHookShim }
   from "@agents-can-communicate/adapter-sdk";
 
 const bundle = fileURLToPath(new URL("../extension", import.meta.url));
@@ -49,6 +49,9 @@ export async function installGeminiExtension({ home, runner, node }) {
   const target = extensionPath(home);
   await rm(target, { recursive: true, force: true });
   await cp(bundle, target, { recursive: true });
+  // The skill ships with a placeholder where the command belongs: `acc` is
+  // not on PATH everywhere, and an agent that cannot run it improvises.
+  await bakeSkillCommand({ root: target, node });
   // This client offers no plugin-root variable in a hook command, so the shim's
   // absolute path is written in at install time.
   const shim = await writeHookShim({ dir: path.join(target, "hooks"),

--- a/packages/adapter-kimi/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-kimi/plugin/skills/acc/SKILL.md
@@ -14,7 +14,7 @@ skill is how you stay legible to them and they to you.
 Once you understand the request, publish one line of Intent:
 
 ```bash
-acc work --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} work --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --summary "porting the claim model" --mode edit
 ```
 
@@ -25,7 +25,7 @@ what you are up to, it does not stop anyone editing anything.
 ## Claim before you change shared work
 
 ```bash
-acc claim --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} claim --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --resource 'file:packages/core/**' --reason "porting the store"
 ```
 
@@ -39,7 +39,7 @@ wrote, a port in an area someone else is already in — ask the agent working th
 do it badly yourself, and do not ask your human to carry the message:
 
 ```bash
-acc request --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} request --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --to claude_code --title "finish the store tests" \
   --detail "I ported src/store but ran out of time on the concurrency cases."
 ```
@@ -54,13 +54,13 @@ A turn that opens with `[task_unblocked]` means work is addressed to you and wai
 it before you start, so nobody does it twice:
 
 ```bash
-acc task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --take
+{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --take
 ```
 
 Mark it when it is done, so the agent that asked can stop waiting:
 
 ```bash
-acc task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --state done
+{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --state done
 ```
 
 If you are not going to do it, reply with `acc message` instead of leaving it pending. The
@@ -72,7 +72,7 @@ If you are not going to do it, say so. A request left pending looks exactly like
 one you have not read yet, and the agent that asked is waiting on an answer:
 
 ```bash
-acc task --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --task task_x --decline --reason "Mud collision belongs to the terrain pass, not suspension."
 ```
 
@@ -92,13 +92,32 @@ Do one of three things, and tell your human which:
   refused without `--force` while the holder is merely quiet rather than gone;
 - drop it, if it no longer matters.
 
+## If the command does not work, stop
+
+Everything above runs through the command shown in these examples. It is the one
+this installation wired up, with absolute paths, because a shell that a hook or a
+tool call starts does not reliably carry your PATH.
+
+If it fails to run, say so to your human and carry on with the actual work.
+
+Do not write to ACC's files yourself. The coordination state is plain JSON in a
+directory you can find, and it looks editable. It is not: writes go through a
+lock, records carry generation tokens that are checked on every change, and the
+event log is ordered. A record placed there by hand is not coordination - the
+other agents will read it and act on something that never happened.
+
+This is not hypothetical. A session that could not find the command once read the
+store, worked out its schema, and wrote records and events by hand, inventing an
+event type and its own generation tokens. Everything it reported had happened,
+had not.
+
 ## You can answer for the whole workspace
 
 You are not limited to your own view. Any session can read the complete state, including
 other participants' sessions and their subagents:
 
 ```bash
-acc sync --session "$ACC_SESSION" --scope full --json
+{{ACC}} sync --session "$ACC_SESSION" --scope full --json
 ```
 
 If the human asks "what is the models agent doing?" or "is anyone else touching the
@@ -108,7 +127,7 @@ differs between participants; knowledge does not.
 You can also relay a request to any participant:
 
 ```bash
-acc message --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} message --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --to models --subject "Material slots" --body "Which names are stable?" \
   --type question --requires-ack
 ```
@@ -133,7 +152,7 @@ Before the session ends, record what happened — nothing else writes this for y
 session-end hook cannot summarise a conversation that has already stopped:
 
 ```bash
-acc finish --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
+{{ACC}} finish --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --goal "port the claim model" --status partial \
   --completed "storage ported" --remaining "doctor still to port"
 ```

--- a/packages/adapter-kimi/src/install.mjs
+++ b/packages/adapter-kimi/src/install.mjs
@@ -2,7 +2,7 @@ import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { assertRunner, defaultRunner, removeInstalledTree, runnerExists }
+import { assertRunner, bakeSkillCommand, defaultRunner, removeInstalledTree, runnerExists }
   from "@agents-can-communicate/adapter-sdk";
 
 const bundle = fileURLToPath(new URL("../plugin", import.meta.url));
@@ -114,6 +114,9 @@ export async function installKimiPlugin({ home, runner = defaultRunner(), node }
   const target = pluginPath(home);
   await rm(target, { recursive: true, force: true });
   await cp(bundle, target, { recursive: true });
+  // The skill ships with a placeholder where the command belongs: `acc` is
+  // not on PATH everywhere, and an agent that cannot run it improvises.
+  await bakeSkillCommand({ root: target, node });
 
   const file = configPath(home);
   const existing = await readText(file, "");

--- a/packages/adapter-sdk/src/hook-shim.mjs
+++ b/packages/adapter-sdk/src/hook-shim.mjs
@@ -1,4 +1,5 @@
-import { access, chmod, mkdir, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, readFile, readdir, rm, writeFile }
+  from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -28,6 +29,9 @@ export async function assertRunner(runner) {
   }
   return runner;
 }
+
+// What the shipped skill carries where the runnable command belongs.
+const PLACEHOLDER = "{{ACC}}";
 
 // Shell metacharacters in a path are the caller's problem to survive, not the
 // shell's to interpret.
@@ -72,4 +76,42 @@ export async function removeInstalledTree(target, keep = []) {
   if (keep.includes(target)) return false;
   await rm(target, { recursive: true, force: true });
   return true;
+}
+
+/** Where the CLI lives, resolved from this package rather than from PATH. */
+export const defaultCli = () =>
+  fileURLToPath(new URL("../../../bin/acc.mjs", import.meta.url));
+
+/**
+ * Bake the runnable command into the skill this adapter installs.
+ *
+ * The skill is what tells an agent how to coordinate, and it used to say `acc`.
+ * A hook never depends on PATH - its command is pinned at install time - but the
+ * skill did, and on a machine where the package is not installed globally the
+ * word `acc` runs nothing.
+ *
+ * A model that cannot run the command does not stop. Observed on a real Claude
+ * Code session: told to take a task and finding no `acc`, it read the store's
+ * JSON, worked out the schema, and wrote records and events by hand - inventing
+ * an event type, a harness name, and its own generation tokens. So the command
+ * is pinned here for the same reason it is pinned in the shim.
+ */
+export async function bakeSkillCommand({ root, node = process.execPath,
+  cli = defaultCli() }) {
+  const command = `${quote(node)} ${quote(cli)}`;
+  const baked = [];
+  const walk = async directory => {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const full = path.join(directory, entry.name);
+      if (entry.isDirectory()) await walk(full);
+      else if (entry.name === "SKILL.md") {
+        const text = await readFile(full, "utf8");
+        if (!text.includes(PLACEHOLDER)) continue;
+        await writeFile(full, text.replaceAll(PLACEHOLDER, command));
+        baked.push(full);
+      }
+    }
+  };
+  await walk(root);
+  return baked;
 }

--- a/packages/adapter-sdk/src/index.mjs
+++ b/packages/adapter-sdk/src/index.mjs
@@ -2,7 +2,8 @@
 // that survives between two ephemeral hook processes.
 export { CAPABILITY_SHAPE, assertCapabilities, defineAdapter } from "./capabilities.mjs";
 export { EVENT_KINDS, NORMALIZED_EVENT_KEYS, normalizedEvent } from "./events.mjs";
-export { assertRunner, defaultRunner, removeInstalledTree, runnerExists, writeHookShim }
+export { assertRunner, bakeSkillCommand, defaultCli, defaultRunner, removeInstalledTree,
+  runnerExists, writeHookShim }
   from "./hook-shim.mjs";
 export { BEGIN, END, removeTomlBlock, renderBlock, stripBlock, tomlString, writeTomlBlock }
   from "./toml-block.mjs";

--- a/packages/core/test/service-contract.test.mjs
+++ b/packages/core/test/service-contract.test.mjs
@@ -25,12 +25,12 @@ export function runStoreContract(name, makeStore) {
 
     await store.transaction(async tx => {
       tx.put("workspace", WORKSPACE, workspaceRecord());
-      tx.append(eventRecord("workspace.created"));
+      tx.append(eventRecord("workspace.materialised"));
     });
 
     const page = await store.eventsSince(WORKSPACE, null, 10);
     assert.equal(page.events.length, 1);
-    assert.equal(page.events[0].type, "workspace.created");
+    assert.equal(page.events[0].type, "workspace.materialised");
     assert.equal((await store.snapshot(WORKSPACE)).workspace.displayName, "Example");
   });
 
@@ -40,7 +40,7 @@ export function runStoreContract(name, makeStore) {
 
     await assert.rejects(store.transaction(async tx => {
       tx.put("workspace", WORKSPACE, workspaceRecord());
-      tx.append(eventRecord("workspace.created"));
+      tx.append(eventRecord("workspace.materialised"));
       throw boom;
     }), boom);
 
@@ -52,7 +52,7 @@ export function runStoreContract(name, makeStore) {
     const store = await makeStore();
     await store.transaction(async tx => {
       tx.put("workspace", WORKSPACE, workspaceRecord());
-      tx.append(eventRecord("workspace.created"));
+      tx.append(eventRecord("workspace.materialised"));
     });
     const generationA = await store.transaction(async tx => tx.generationOf("workspace", WORKSPACE));
 
@@ -62,12 +62,12 @@ export function runStoreContract(name, makeStore) {
 
     await assert.rejects(store.transaction(async tx => {
       tx.put("workspace", WORKSPACE, { ...workspaceRecord(), displayName: "C" }, generationA);
-      tx.append(eventRecord("workspace.renamed"));
+      tx.append(eventRecord("session.opened"));
     }), error => error.code === EXIT.CONFLICT);
 
     assert.equal((await store.snapshot(WORKSPACE)).workspace.displayName, "B");
     assert.deepEqual((await store.eventsSince(WORKSPACE, null, 10)).events.map(e => e.type),
-      ["workspace.created"]);
+      ["workspace.materialised"]);
   });
 
   test(`${name}: creating an existing record without an expectation conflicts`, async () => {

--- a/packages/protocol/src/schema.mjs
+++ b/packages/protocol/src/schema.mjs
@@ -33,6 +33,32 @@ const artifactRef = (value, field) => {
   return value;
 };
 
+// Every event ACC itself appends. Closed on purpose: `type` used to be free
+// text, so a record written by hand validated cleanly and `acc doctor` called
+// the store healthy. That is not theoretical - a session that could not run the
+// CLI wrote its own events, inventing `task.completed`, and the store reported
+// no problem.
+const EVENT_TYPES = Object.freeze([
+  "workspace.materialised",
+  "session.opened", "session.closed",
+  "intent.published", "intent.cleared",
+  "workstream.created", "workstream.coordinator_acquired",
+  "workstream.coordinator_released",
+  "task.created", "task.claimed", "task.transitioned", "task.unblocked",
+  "task.declined", "task.released",
+  "claim.acquired", "claim.released", "claim.renewed", "claim.force_released",
+  "message.sent", "decision.recorded", "handoff.created",
+  // Delivery transitions and request outcomes are templated from their state,
+  // so the set has to carry each one they can produce.
+  ...["recorded", "queued", "injected", "seen", "acknowledged", "failed"]
+    .map(state => `message.${state}`),
+  ...["accepted", "declined", "review", "done", "released"]
+    .map(outcome => `work.${outcome}`),
+  "work.requested",
+]);
+
+const eventType = oneOf(...EVENT_TYPES);
+
 const RECORDS = Object.freeze({
   workspace: { workspaceId: id, displayName: line, source: oneOf("config", "git", "directory"),
     roots: listOf(line), createdAt: timestamp },
@@ -102,7 +128,7 @@ const RECORDS = Object.freeze({
     remaining: listOf(line), blockers: listOf(line), claimsToRelease: listOf(resourceUri),
     verification: listOf(artifactRef), artifacts: listOf(artifactRef), createdAt: timestamp },
 
-  event: { sequence, eventId: id, workspaceId: id, actorSessionId: id, type: line,
+  event: { sequence, eventId: id, workspaceId: id, actorSessionId: id, type: eventType,
     occurredAt: timestamp, payload: plainObject },
 });
 

--- a/packages/storage-filesystem/test/recovery.test.mjs
+++ b/packages/storage-filesystem/test/recovery.test.mjs
@@ -26,7 +26,7 @@ const workspaceRecord = () => ({ schemaVersion: SCHEMA_VERSION, workspaceId: WOR
   displayName: "Example", source: "directory", roots: ["/tmp/example"], createdAt: NOW });
 
 const eventRecord = id => ({ schemaVersion: SCHEMA_VERSION, eventId: id,
-  workspaceId: WORKSPACE, actorSessionId: "session_a", type: "workspace.created",
+  workspaceId: WORKSPACE, actorSessionId: "session_a", type: "workspace.materialised",
   occurredAt: NOW, payload: {} });
 
 function crashAt(marker) {

--- a/tests/docs/skills.test.mjs
+++ b/tests/docs/skills.test.mjs
@@ -55,8 +55,12 @@ test("every adapter ships a skill", async () => {
 test("each skill teaches the operations an agent is expected to use", async () => {
   for (const { file, text } of await skills()) {
     for (const command of TAUGHT) {
-      assert.match(text, new RegExp(`acc ${command}\\b`),
-        `${file} never mentions acc ${command}, so no agent will ever run it`);
+      // `{{ACC}}` is the placeholder the installer replaces with this
+      // machine's absolute invocation. The shipped file carries it; a skill
+      // saying a bare `acc` would be telling agents to run something that is
+      // not on PATH on every machine.
+      assert.match(text, new RegExp(`\\{\\{ACC\\}\\} ${command}\\b`),
+        `${file} never runs ${command}, so no agent will ever do it`);
     }
   }
 });

--- a/tests/process/skill-command.test.mjs
+++ b/tests/process/skill-command.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, readdir, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import { ALL_ADAPTERS, clientContext } from "@agents-can-communicate/cli";
+
+const run = promisify(execFile);
+const repo = path.resolve(import.meta.dirname, "..", "..");
+const acc = path.join(repo, "bin", "acc.mjs");
+
+/**
+ * The command the skill hands an agent has to be one that runs.
+ *
+ * It used to say `acc`, which works only where the package is installed
+ * globally. Hooks never had this problem - their command is pinned at install
+ * time, because a hook's environment carries neither PATH nor a shell profile -
+ * but the skill did, and the skill is the half an agent reads.
+ *
+ * The failure was not a refusal. A real Claude Code session, told to take a task
+ * and finding no `acc`, read the store's JSON, worked out the schema, and wrote
+ * records and events by hand - inventing an event type, a harness name, and its
+ * own generation tokens. It then reported the work as coordinated. None of it
+ * had gone through a lock, a generation check, or the event log.
+ */
+async function installed(t, adapterId, relative) {
+  const home = await realpath(await mkdtemp(path.join(tmpdir(), "acc-skill-")));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  // The adapter's own install, not `acc install`: that one first asks whether
+  // the client is on this machine, and what is under test here is what gets
+  // written, not which clients happen to be installed on the test runner.
+  const adapter = ALL_ADAPTERS().find(item => item.id === adapterId);
+  assert.notEqual(adapter, undefined, `no adapter named ${adapterId}`);
+  await adapter.install(clientContext(home));
+  return { home, skill: path.join(home, relative) };
+}
+
+const ADAPTERS = [
+  ["kimi", ".kimi-code/plugins/managed/agents-can-communicate/skills/acc/SKILL.md"],
+  ["claude_code", ".claude/plugins/agents-can-communicate/skills/acc/SKILL.md"],
+  ["codex", ".agents/plugins/plugins/agents-can-communicate/skills/acc/SKILL.md"],
+  ["gemini_cli", ".gemini/extensions/agents-can-communicate/skills/acc/SKILL.md"],
+];
+
+for (const [adapter, relative] of ADAPTERS) {
+  test(`${adapter}: the installed skill leaves no placeholder behind`, async t => {
+    const { skill } = await installed(t, adapter, relative);
+    const text = await readFile(skill, "utf8");
+
+    assert.equal(text.includes("{{ACC}}"), false,
+      "the skill still tells the agent to run a placeholder");
+    assert.match(text, /acc\.mjs/, "the skill carries no path to the CLI at all");
+  });
+}
+
+test("the command baked into the skill actually runs", async t => {
+  const { home, skill } = await installed(t, "kimi", ADAPTERS[0][1]);
+  const text = await readFile(skill, "utf8");
+
+  // Taken from the file rather than reconstructed: the point is that what an
+  // agent copies out of the skill is what works.
+  const [, node, cli] = /"([^"]*node[^"]*)" "([^"]*acc\.mjs)"/.exec(text) ?? [];
+  assert.equal(typeof node, "string", `no runnable command in:\n${text.slice(0, 400)}`);
+
+  const project = path.join(home, "project");
+  await mkdir(project, { recursive: true });
+  const { stdout } = await run(node, [cli, "status", "--cwd", project, "--json"],
+    { env: { ...process.env, ACC_DATA_HOME: path.join(home, "data"),
+      GIT_DIR: "", GIT_WORK_TREE: "" } });
+
+  assert.equal(JSON.parse(stdout).ok, true);
+});
+
+test("the skill tells the agent not to write to the store by hand", async t => {
+  const { skill } = await installed(t, "kimi", ADAPTERS[0][1]);
+  const text = await readFile(skill, "utf8");
+
+  // Saying it is the weakest of the three layers and still worth saying: the
+  // strong one is that the command works, so improvising has no motive.
+  assert.match(text, /Do not write to ACC's files yourself/);
+});
+
+test("every shipped skill is templated, none forgotten", async () => {
+  // Four adapters, four bundles. A new one that forgets to bake would ship a
+  // skill telling agents to run a placeholder.
+  const roots = [];
+  for (const entry of await readdir(path.join(repo, "packages"), { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    for (const bundle of ["plugin", "extension"]) {
+      const file = path.join(repo, "packages", entry.name, bundle,
+        "skills", "acc", "SKILL.md");
+      const text = await readFile(file, "utf8").catch(() => null);
+      if (text !== null) roots.push({ file, text });
+    }
+  }
+
+  assert.equal(roots.length, 4, roots.map(item => item.file).join("\n"));
+  for (const { file, text } of roots) {
+    assert.match(text, /\{\{ACC\}\}/, `${file} ships without the placeholder to replace`);
+  }
+});

--- a/tests/process/store-concurrency.test.mjs
+++ b/tests/process/store-concurrency.test.mjs
@@ -49,7 +49,7 @@ try {
       ${JSON.stringify(generation)});
     tx.append({ schemaVersion: ${SCHEMA_VERSION}, eventId: \`event_${label}\`,
       workspaceId: ${JSON.stringify(WORKSPACE)}, actorSessionId: "session_a",
-      type: "workspace.renamed", occurredAt: ${JSON.stringify(NOW)}, payload: {} });
+      type: "session.opened", occurredAt: ${JSON.stringify(NOW)}, payload: {} });
   });
   process.stdout.write("won");
   process.exit(0);
@@ -69,7 +69,7 @@ test("independent processes cannot both win the same optimistic write", async t 
   await store.transaction(async tx => {
     tx.put("workspace", WORKSPACE, workspaceRecord("seed"));
     tx.append({ schemaVersion: SCHEMA_VERSION, eventId: "event_seed",
-      workspaceId: WORKSPACE, actorSessionId: "session_a", type: "workspace.created",
+      workspaceId: WORKSPACE, actorSessionId: "session_a", type: "workspace.materialised",
       occurredAt: NOW, payload: {} });
   });
   const generation = await store.transaction(async tx => tx.generationOf("workspace", WORKSPACE));
@@ -105,7 +105,7 @@ test("the event log has no gaps and no duplicate sequences after contention", as
   await store.transaction(async tx => {
     tx.put("workspace", WORKSPACE, workspaceRecord("seed"));
     tx.append({ schemaVersion: SCHEMA_VERSION, eventId: "event_seed",
-      workspaceId: WORKSPACE, actorSessionId: "session_a", type: "workspace.created",
+      workspaceId: WORKSPACE, actorSessionId: "session_a", type: "workspace.materialised",
       occurredAt: NOW, payload: {} });
   });
   const generation = await store.transaction(async tx => tx.generationOf("workspace", WORKSPACE));
@@ -129,6 +129,6 @@ test("the event log has no gaps and no duplicate sequences after contention", as
   const events = await Promise.all(files.map(async file =>
     JSON.parse(await readFile(path.join(root, "events", file), "utf8"))));
   assert.deepEqual(events.map(event => event.type),
-    ["workspace.created", "workspace.renamed"]);
+    ["workspace.materialised", "session.opened"]);
   await access(path.join(root, "protocol.json"));
 });


### PR DESCRIPTION
Found by running the thing for real. A live Claude Code session was told to take a task, found no `acc` on PATH, and **did not stop**:

> there's no `acc` CLI installed, so I updated the file-based store directly, matching its existing schema

It created participant and session records, flipped a receipt, changed the task state, appended events 05–08, and bumped the generation tokens by hand. Then reported the work as coordinated.

The log it left:

```
0000000000000005 session.opened        ← written by hand
0000000000000006 message.acknowledged
0000000000000007 task.claimed
0000000000000008 task.completed        ← a type ACC does not emit
```

```
participantId=physics  harness=claude-code    ← ACC's adapter is claude_code
```

`acc doctor`: **`store healthy`**.

## Three things wrong

**1. The command does not exist on every machine.** Hooks never had this problem — their command is pinned at install time, because a hook's environment carries neither PATH nor a shell profile. The skill, which is the half an agent reads, said `acc`.

It now ships with `{{ACC}}`, replaced at install with this installation's absolute invocation:

```bash
"/…/node" "/…/bin/acc.mjs" work --session "$ACC_SESSION" …
```

**2. Nothing told it not to.** The skill now says the state is not editable by hand, and why: writes go through a lock, records carry generation tokens checked on every change, the log is ordered. A record placed there by hand is not coordination — other agents read it and act on something that never happened.

**3. Nothing noticed.** `event.type` was free text. The vocabulary is now closed to what ACC actually appends:

```
before:  store healthy
after:   store state is ambiguous; repair is blocked
```

— reproduced by planting the exact `task.completed` the model invented.

Three fixtures had invented their own event types (`workspace.created`, `workspace.renamed`). They were changed to real ones rather than added to the list: a vocabulary padded to keep tests quiet would not be a statement about anything.

## Gates

`tests/process/skill-command.test.mjs` — for each of the four adapters: no placeholder survives install, the skill carries a path to the CLI, the command found in the installed file **is executed** and answers, and the prohibition is present. It drives the adapters directly rather than through `acc install`, so it does not depend on which clients exist on the runner.

## Verification

```
syntax ok in 142 file(s)
tests 643, pass 643, fail 0
```

Ordering matters here: making the command work is the fix. Telling the agent not to improvise and noticing when it did are the second and third layers — an agent with no way to do the right thing will do something.
