### PR TITLE
Let a request stop asking once it has been answered

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -37,6 +37,7 @@ graph LR
 | `acc work` | Publish what this session is doing |
 | `acc claim` | Reserve a resource. Exit `5` on conflict |
 | `acc release` | Give it back |
+| `acc ack` | Answer a message that asked for one, so it stops asking |
 | `acc message` | Send a typed message to participants |
 | `acc request` | Ask another agent to do something. One call: the work plus why |
 | `acc task` | Create work, `--take` it, or `--state` it along |
@@ -70,6 +71,11 @@ acc request --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
   --to claude_code --title "finish the store tests" \
   --detail "I ported src/store but ran out of time on the concurrency cases."
 ```
+
+Finishing the task answers the request it came from, so the message stops demanding an
+acknowledgement. `acc ack --message <id>` does the same for messages that are not tied to a
+task — and a session can only mark its own receipt, since reading something is a statement
+only the reader can make.
 
 One write. The recipient learns about it twice, and the two facts are different: the work
 appears as an attention item addressed to them, and the message explains why. A task with

--- a/packages/adapter-claude-code/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-claude-code/plugin/skills/acc/SKILL.md
@@ -68,6 +68,13 @@ agent that asked is waiting on an answer, and silence is not one.
 
 ## Work someone asked of you, continued
 
+Marking it done answers the request it came from, so it stops appearing in your turn.
+For a message that asked for an acknowledgement and is not tied to a task:
+
+```bash
+{{ACC}} ack --session "$ACC_SESSION" --generation "$ACC_GENERATION" --message message_x
+```
+
 If you are not going to do it, say so. A request left pending looks exactly like
 one you have not read yet, and the agent that asked is waiting on an answer:
 

--- a/packages/adapter-codex/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-codex/plugin/skills/acc/SKILL.md
@@ -68,6 +68,13 @@ agent that asked is waiting on an answer, and silence is not one.
 
 ## Work someone asked of you, continued
 
+Marking it done answers the request it came from, so it stops appearing in your turn.
+For a message that asked for an acknowledgement and is not tied to a task:
+
+```bash
+{{ACC}} ack --session "$ACC_SESSION" --generation "$ACC_GENERATION" --message message_x
+```
+
 If you are not going to do it, say so. A request left pending looks exactly like
 one you have not read yet, and the agent that asked is waiting on an answer:
 

--- a/packages/adapter-gemini-cli/extension/skills/acc/SKILL.md
+++ b/packages/adapter-gemini-cli/extension/skills/acc/SKILL.md
@@ -68,6 +68,13 @@ agent that asked is waiting on an answer, and silence is not one.
 
 ## Work someone asked of you, continued
 
+Marking it done answers the request it came from, so it stops appearing in your turn.
+For a message that asked for an acknowledgement and is not tied to a task:
+
+```bash
+{{ACC}} ack --session "$ACC_SESSION" --generation "$ACC_GENERATION" --message message_x
+```
+
 If you are not going to do it, say so. A request left pending looks exactly like
 one you have not read yet, and the agent that asked is waiting on an answer:
 

--- a/packages/adapter-kimi/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-kimi/plugin/skills/acc/SKILL.md
@@ -68,6 +68,13 @@ agent that asked is waiting on an answer, and silence is not one.
 
 ## Work someone asked of you, continued
 
+Marking it done answers the request it came from, so it stops appearing in your turn.
+For a message that asked for an acknowledgement and is not tied to a task:
+
+```bash
+{{ACC}} ack --session "$ACC_SESSION" --generation "$ACC_GENERATION" --message message_x
+```
+
 If you are not going to do it, say so. A request left pending looks exactly like
 one you have not read yet, and the agent that asked is waiting on an answer:
 

--- a/packages/cli/src/args.mjs
+++ b/packages/cli/src/args.mjs
@@ -26,6 +26,9 @@ export const COMMANDS = Object.freeze({
     optional: ["workstream", "title", "detail", "assignee", "state", "task", "reason"],
     repeated: ["depends-on"], flags: ["take", "decline", "force"] },
   workstream: { required: ["session", "generation", "title", "objective"], optional: [] },
+  // Messages not tied to a task need a way to be answered too. Without one a
+  // `requiresAck` message raised an attention item nothing could ever clear.
+  ack: { required: ["session", "generation", "message"], optional: ["state"] },
   finish: { required: ["session", "generation", "goal"],
     optional: ["status", "to"], repeated: ["completed", "remaining", "blocker"] },
   status: { required: [], optional: ["participant"] },

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -131,6 +131,13 @@ const HANDLERS = Object.freeze({
       text: `requested ${task.taskId} of ${options.to}` };
   },
 
+  ack: async ({ options, context }) => {
+    const receipt = await context.service.markDelivery({ sessionId: options.session,
+      generation: options.generation, messageId: options.message,
+      state: options.state ?? "acknowledged" });
+    return { data: receipt, text: `${receipt.messageId} ${receipt.state}` };
+  },
+
   workstream: async ({ options, context }) => {
     const workstream = await context.service.createWorkstream({
       sessionId: options.session, generation: options.generation,

--- a/packages/core/src/communication.mjs
+++ b/packages/core/src/communication.mjs
@@ -73,10 +73,18 @@ export function createCommunicationService(ports, sessions, claims) {
 
   async function markDelivery(input) {
     const session = await requireOpenSession(input, "update delivery");
+    // Your own receipt, unless you say otherwise and mean it. A session
+    // advancing another participant's receipt would be reporting that someone
+    // else had read something.
+    const recipient = input.recipientParticipantId ?? session.participantId;
+    if (recipient !== session.participantId) {
+      throw new AccError(EXIT.CONFLICT, "a session can only mark its own receipt",
+        { recipient, participantId: session.participantId });
+    }
     const now = clock.now();
     let record = null;
     await store.transaction(async tx => {
-      const id = receiptId(input.messageId, input.recipientParticipantId);
+      const id = receiptId(input.messageId, recipient);
       const existing = tx.get("receipt", id);
       if (existing === null) {
         throw new AccError(EXIT.DATA, "no receipt exists for that recipient", { id });
@@ -90,7 +98,7 @@ export function createCommunicationService(ports, sessions, claims) {
         workspaceId: existing.workspaceId, actorSessionId: session.sessionId,
         type: `message.${record.state}`, occurredAt: now,
         payload: { messageId: input.messageId,
-          recipientParticipantId: input.recipientParticipantId } });
+          recipientParticipantId: recipient } });
     });
     return record;
   }

--- a/packages/core/src/notify.mjs
+++ b/packages/core/src/notify.mjs
@@ -1,4 +1,5 @@
-import { SCHEMA_VERSION, createId, validateRecord } from "@agents-can-communicate/protocol";
+import { SCHEMA_VERSION, advanceDelivery, createId, validateRecord }
+  from "@agents-can-communicate/protocol";
 
 const receiptId = (messageId, recipient) => `${messageId}--${recipient}`;
 
@@ -60,4 +61,34 @@ export function writeWorkResponse(tx, { task, actor, workspaceId, now, ids, outc
     actorSessionId: actor.sessionId, type: `work.${outcome}`, occurredAt: now,
     payload: { taskId: task.taskId, messageId, asker } });
   return record;
+}
+
+/**
+ * Close the request a task came from, once it has been answered.
+ *
+ * `acc request` marks its message as needing an acknowledgement, which raises a
+ * `direct_request` attention item for the recipient. Finishing the work did not
+ * clear it, and nothing else could: the operation existed in the core and was
+ * reachable from no surface. So every completed request left a line repeating in
+ * the doer's turn for good.
+ *
+ * Doing the work is the acknowledgement. An explicit `acc ack` exists for
+ * messages that are not tied to a task.
+ */
+export function closeRequestReceipt(tx, { task, actor, now, ids }) {
+  for (const message of tx.list("message")) {
+    if (message.taskId !== task.taskId || message.type !== "work_request") continue;
+    if (!message.toParticipantIds.includes(actor.participantId)) continue;
+    const id = `${message.messageId}--${actor.participantId}`;
+    const existing = tx.get("receipt", id);
+    if (existing === null || existing.state === "acknowledged") continue;
+    const record = { ...existing, state: advanceDelivery(existing.state, "acknowledged"),
+      updatedAt: now };
+    tx.put("receipt", id, record, tx.generationOf("receipt", id));
+    tx.append({ schemaVersion: SCHEMA_VERSION, eventId: ids.next("event"),
+      workspaceId: existing.workspaceId, actorSessionId: actor.sessionId,
+      type: "message.acknowledged", occurredAt: now,
+      payload: { messageId: message.messageId,
+        recipientParticipantId: actor.participantId } });
+  }
 }

--- a/packages/core/src/tasks.mjs
+++ b/packages/core/src/tasks.mjs
@@ -3,7 +3,7 @@ import { AccError, EXIT, SCHEMA_VERSION, createId, transitionTask as stepTask, v
 
 import { ensureMaterialised } from "./materialisation.mjs";
 import { classifySessionPresence } from "./sessions.mjs";
-import { writeWorkResponse } from "./notify.mjs";
+import { closeRequestReceipt, writeWorkResponse } from "./notify.mjs";
 
 // Dependency completion unblocks tasks deterministically, inside the same
 // transaction that completed the dependency. It must never depend on a model
@@ -172,6 +172,8 @@ export function createTaskService(ports, workstreams) {
         writeWorkResponse(tx, { task: record, actor: session,
           workspaceId: session.workspaceId, now, ids, outcome: record.state });
       }
+      // Doing the work answers the request that asked for it.
+      if (record.state === "done") closeRequestReceipt(tx, { task: record, actor: session, now, ids });
       if (record.state !== "done") return;
       // Unblock dependents here, in the same transaction, so the graph is
       // never left in a state that needs someone to notice it later.
@@ -213,6 +215,8 @@ export function createTaskService(ports, workstreams) {
       writeWorkResponse(tx, { task: existing, actor: session,
         workspaceId: session.workspaceId, now, ids, outcome: "declined",
         reason: input.reason ?? null });
+      // Refusing is also an answer, so the request stops demanding one.
+      closeRequestReceipt(tx, { task: existing, actor: session, now, ids });
       tx.append({ schemaVersion: SCHEMA_VERSION, eventId: ids.next("event"),
         workspaceId: session.workspaceId, actorSessionId: session.sessionId,
         type: "task.declined", occurredAt: now,

--- a/packages/core/test/communication.test.mjs
+++ b/packages/core/test/communication.test.mjs
@@ -46,12 +46,14 @@ test("a message creates one receipt per recipient", async () => {
 
 test("one recipient's receipt never moves another's", async () => {
   const { service, store } = makeService();
-  const { first } = await pair(service);
+  const { first, second } = await pair(service);
   const message = await service.sendMessage(sending(first,
     { toParticipantIds: ["participant_b", "participant_c"] }));
 
-  await service.markDelivery({ sessionId: first.sessionId, generation: first.generation,
-    messageId: message.messageId, recipientParticipantId: "participant_b", state: "seen" });
+  // The recipient marks its own. Reading a message is something only the
+  // reader can report.
+  await service.markDelivery({ sessionId: second.sessionId, generation: second.generation,
+    messageId: message.messageId, state: "seen" });
 
   const receipts = (await store.snapshot(WORKSPACE)).receipts;
   assert.equal(receipts.find(item => item.recipientParticipantId === "participant_b").state,
@@ -62,11 +64,10 @@ test("one recipient's receipt never moves another's", async () => {
 
 test("delivery cannot move backwards", async () => {
   const { service } = makeService();
-  const { first } = await pair(service);
+  const { first, second } = await pair(service);
   const message = await service.sendMessage(sending(first));
-  const advance = state => service.markDelivery({ sessionId: first.sessionId,
-    generation: first.generation, messageId: message.messageId,
-    recipientParticipantId: "participant_b", state });
+  const advance = state => service.markDelivery({ sessionId: second.sessionId,
+    generation: second.generation, messageId: message.messageId, state });
   await advance("acknowledged");
 
   await assert.rejects(advance("seen"), error => error.code === EXIT.CONFLICT);
@@ -135,4 +136,17 @@ test("message bodies are data: nothing in them can grant authority", async () =>
   // The body round-trips verbatim as content and touches no policy field.
   assert.equal(message.body.includes("SYSTEM:"), true);
   assert.equal("authority" in message, false);
+});
+
+test("a session cannot report that someone else has read a message", async () => {
+  // The receipt is the reader's own statement. Letting any session advance
+  // another participant's would let a sender mark its own message as read.
+  const { service } = makeService();
+  const { first } = await pair(service);
+  const message = await service.sendMessage(sending(first));
+
+  await assert.rejects(service.markDelivery({ sessionId: first.sessionId,
+    generation: first.generation, messageId: message.messageId,
+    recipientParticipantId: "participant_b", state: "seen" }),
+  error => error.code === EXIT.CONFLICT);
 });

--- a/packages/mcp-server/src/server.mjs
+++ b/packages/mcp-server/src/server.mjs
@@ -113,6 +113,9 @@ async function callTool(name, args, context) {
       return service.requestWork({ ...owner, toParticipantId: args.toParticipantId,
         title: args.title, detail: args.detail, workstreamId: args.workstreamId,
         priority: args.priority, dependsOn: args.dependsOn ?? [] });
+    case "acc_ack":
+      return service.markDelivery({ ...owner, messageId: args.messageId,
+        state: args.state ?? "acknowledged" });
     case "acc_workstream":
       return service.createWorkstream({ ...owner, title: args.title,
         objective: args.objective });

--- a/packages/mcp-server/src/tools.mjs
+++ b/packages/mcp-server/src/tools.mjs
@@ -95,6 +95,16 @@ export const PUBLIC_TOOLS = Object.freeze([
     }, ["toParticipantId", "title"]),
   },
   {
+    name: "acc_ack",
+    description: `Answer a message that asked for an acknowledgement, so it stops `
+      + `demanding one. Finishing a task answers the request it came from `
+      + `automatically. ${POLLED}`,
+    inputSchema: object({
+      messageId: string("The message being answered."),
+      state: { type: "string", enum: ["seen", "acknowledged"] },
+    }, ["messageId"]),
+  },
+  {
     name: "acc_workstream",
     description: `Group related work so several agents can see it as one thing. Optional: `
       + `a single request needs no workstream. ${POLLED}`,

--- a/packages/mcp-server/test/tools.test.mjs
+++ b/packages/mcp-server/test/tools.test.mjs
@@ -10,8 +10,8 @@ test("the model-facing surface is exactly this list", () => {
   // reachable by adapters and stay out of here. Named rather than counted, so
   // a tool swapped for another still trips this.
   assert.deepEqual(names.sort(),
-    ["acc_claim", "acc_finish", "acc_message", "acc_request", "acc_sync", "acc_task",
-      "acc_work", "acc_workstream"]);
+    ["acc_ack", "acc_claim", "acc_finish", "acc_message", "acc_request", "acc_sync",
+      "acc_task", "acc_work", "acc_workstream"]);
 });
 
 test("every tool declares a strict 2020-12 input schema", () => {

--- a/tests/docs/skills.test.mjs
+++ b/tests/docs/skills.test.mjs
@@ -22,7 +22,7 @@ const repo = path.resolve(import.meta.dirname, "..", "..");
 // `heartbeat`, `detach`) are deliberately absent — a skill that taught those
 // would have models running the installer.
 const TAUGHT = Object.freeze(["sync", "work", "claim", "request", "task", "message",
-  "finish", "status"]);
+  "finish", "status", "ack"]);
 
 // Reachable by an agent but not worth a section: `release` is covered by
 // `finish`, `workstream` only matters once work

--- a/tests/process/abandoned-work.test.mjs
+++ b/tests/process/abandoned-work.test.mjs
@@ -175,3 +175,50 @@ test("accepting and finishing both answer the agent that asked", async t => {
   assert.match(finished, /done: tank sinks into mud/,
     "the requester was never told the work was finished");
 });
+
+test("finishing the work answers the request it came from", async t => {
+  // `acc request` marks its message as needing an acknowledgement, which raises
+  // a `direct_request` item for the recipient. Nothing cleared it: the operation
+  // existed in the core and was reachable from no surface, so every completed
+  // request left a line repeating in the doer's turn for good. A live Claude
+  // Code session reported exactly this and refused to clear it by hand, which
+  // was the right call and left it stuck.
+  const { place, doer, task } = await inFlight(t);
+
+  const before = await turn(place, "kimi", "phys", "physics");
+  assert.match(before, /\[direct_request\] tank sinks into mud/);
+
+  await cli(place, "task", "--session", doer.accSessionId, "--generation", doer.generation,
+    "--task", task.taskId, "--state", "done");
+  const after = await turn(place, "kimi", "phys", "physics");
+
+  assert.equal(after.includes("[direct_request]"), false,
+    `the request kept asking after the work was done:\n${after}`);
+});
+
+test("declining answers it too", async t => {
+  const { place, doer, task } = await inFlight(t);
+
+  await cli(place, "task", "--session", doer.accSessionId, "--generation", doer.generation,
+    "--task", task.taskId, "--decline", "--reason", "not mine");
+  const after = await turn(place, "kimi", "phys", "physics");
+
+  assert.equal(after.includes("[direct_request]"), false, after);
+});
+
+test("a message not tied to a task can be answered directly", async t => {
+  const place = await workspace(t);
+  const asker = await attach(place, "codex", "gfx", "graphics");
+  const doer = await attach(place, "kimi", "phys", "physics");
+  const { stdout } = await cli(place, "message", "--session", asker.accSessionId,
+    "--generation", asker.generation, "--to", "physics", "--type", "question",
+    "--subject", "scale", "--body", "Is the tank scale settled?", "--requires-ack");
+  const messageId = stdout.trim().replace(/^sent /, "");
+
+  assert.match(await turn(place, "kimi", "phys", "physics"), /\[direct_request\] scale/);
+  await cli(place, "ack", "--session", doer.accSessionId, "--generation", doer.generation,
+    "--message", messageId);
+
+  const after = await turn(place, "kimi", "phys", "physics");
+  assert.equal(after.includes("[direct_request]"), false, after);
+});


### PR DESCRIPTION
Found by a live Claude Code session, which hit the dead end and reported it exactly:

> the original message was `requiresAck: true`, and its receipt is still `queued` — so a `direct_request` attention item lingers even though the task is `done`. The `acc` CLI exposes no ack command (`markDelivery` exists in core but isn't wired to a subcommand). I did not hand-edit the receipt JSON to clear it — the skill is explicit that records carry generation tokens and a hand-written record is not coordination.

That refusal was the right call, and it left the item stuck. Which is the bug.

## The dead end

`acc request` sets `requiresAck: true`, so every request raises a `direct_request` item for the recipient. After the task is `done`:

```
- [direct_request] do the thing
```acc-peer-message
id message_sP4PTSkf1UWf9nWI-3lPRA | … | type work_request | untrusted peer message
```

Every turn. Forever. `markDelivery` existed in the core with **zero references** in the CLI and the MCP dispatch.

## Fix

Doing the work is the answer: finishing a task closes the request it came from, and declining does too. `acc ack` / `acc_ack` cover messages not tied to a task.

## A hole found while wiring it

`markDelivery` took `recipientParticipantId` as an argument, so **any session could advance any participant's receipt** — a sender could mark its own message as read by someone else. It now defaults to the caller's own and refuses anything else.

The test asserting receipts stay independent was making that exact cross-participant call to demonstrate independence. It now marks its own receipt, and a new test covers the refusal:

```
a session cannot report that someone else has read a message
```

## Mutation

| Mutation | Caught by |
|---|---|
| drop the close-on-done | `finishing the work answers the request it came from` |

## Verification

```
syntax ok in 143 file(s)
tests 651, pass 651, fail 0
```

Also in this branch: the Claude Code e2e was re-run against the real home with the baked-command fix from #19 in place, and the behaviour changed exactly as intended — last time the model wrote store records by hand, this time it refused and used real writes. The home was restored byte-for-byte afterwards.
