### PR TITLE
fix: bring the lockfile back in sync with the manifest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,10 @@
         "@agents-can-communicate/storage-filesystem"
       ],
       "license": "MIT",
+      "os": [
+        "darwin",
+        "linux"
+      ],
       "workspaces": [
         "packages/*"
       ],

--- a/tests/acceptance/packaging.test.mjs
+++ b/tests/acceptance/packaging.test.mjs
@@ -140,6 +140,39 @@ test("a clean install runs the CLI and attaches a session", async t => {
   assert.equal(status.participants[0].harness, "kimi");
 });
 
+/**
+ * A fresh clone has to stay clean through `npm install`.
+ *
+ * `"os": ["darwin", "linux"]` went into the manifest when Windows support was
+ * withdrawn, and the lockfile was never regenerated. Nothing failed: `npm ci`
+ * tolerates it and CI stayed green for the whole difference. What broke was the
+ * evidence - `npm install` rewrote the lockfile, so the next
+ * `scripts/verify-package.mjs` printed `(dirty)` and refused to claim
+ * reproducibility, on a tree where nobody had changed anything.
+ *
+ * `--package-lock-only` reads the manifests and nothing else, and the package
+ * has no runtime dependencies, so `--offline` needs no cache and no network.
+ */
+test("the committed lockfile is the one these manifests produce", async t => {
+  const into = await realpath(await mkdtemp(path.join(tmpdir(), "acc-lock-")));
+  t.after(() => rm(into, { recursive: true, force: true }));
+
+  const manifests = ["package.json", "package-lock.json"];
+  for (const entry of await readdir(path.join(repo, "packages"), { withFileTypes: true })) {
+    if (entry.isDirectory()) manifests.push(path.join("packages", entry.name, "package.json"));
+  }
+  for (const relative of manifests) {
+    await mkdir(path.dirname(path.join(into, relative)), { recursive: true });
+    await writeFile(path.join(into, relative), await readFile(path.join(repo, relative)));
+  }
+
+  await runNpm(["install", "--package-lock-only", "--offline", "--silent"], { cwd: into });
+
+  assert.equal(await readFile(path.join(into, "package-lock.json"), "utf8"),
+    await readFile(path.join(repo, "package-lock.json"), "utf8"),
+    "`npm install` rewrites the lockfile, so a clone is dirty before anyone edits it");
+});
+
 test("the manifest declares the binaries and the engine it was certified on", async t => {
   const manifest = JSON.parse(await readFile(path.join(repo, "package.json"), "utf8"));
 


### PR DESCRIPTION
`npm install` on a clean clone of `main` rewrites `package-lock.json` before anyone has changed anything.

## What was wrong

`"os": ["darwin", "linux"]` went into `package.json` when Windows support was withdrawn (`678edeb`); the lockfile was never regenerated. Nothing failed for it — `npm ci` tolerates the difference, so CI stayed green for the entire time it was there.

What broke was the **evidence**. The changelog points a reader at `node scripts/verify-package.mjs` to check the release digest. On a fresh clone that sequence is `npm install` then `verify-package.mjs`, and the second command printed `(dirty)` and refused to claim reproducibility — on a tree the reader had not touched.

```
PASS  agents-can-communicate-0.0.0.tgz  sha256 848ad597…30184  built from ba312cd (dirty)
```

## The fix

Regenerated the lockfile. The tarball digest is unchanged (`848ad597…30184`) because the lockfile is not packed, so every digest recorded so far still holds; only the `(dirty)` marker goes away.

## The gate

`tests/acceptance/packaging.test.mjs` now regenerates the lockfile from the committed manifests and compares:

```
npm install --package-lock-only --offline
```

`--package-lock-only` reads the manifests and nothing else, and the package has no runtime dependencies, so this needs no cache and no network. It runs in about a tenth of a second.

Proven by mutation: against the lockfile as `main` had it, the test fails with

```
`npm install` rewrites the lockfile, so a clone is dirty before anyone edits it
```

## Verification

- 663 tests passing, 0 failing
- `syntax ok in 144 file(s)`
- `PASS … built from 0db01ac` — no `(dirty)`
- `npm install` on the committed tree now leaves `git status` empty
