### PR TITLE
fix: let an agent run the commands its skill teaches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `60817fb` |
-| Tarball | `agents-can-communicate-0.0.0.tgz`, 101 KB, 100 entries |
-| sha256 | `848ad59785f0a35fa34102e818869b6acf780f833f674122d4c0e74a41b30184` |
-| Tests | 662 passing, 0 failing |
+| Built from | `d72b6a1` |
+| Tarball | `agents-can-communicate-0.0.0.tgz`, 104 KB, 101 entries |
+| sha256 | `efce17db97375af414baeffd315fb64d7eb6ddbd10b0f556c956fabb453de00b` |
+| Tests | 670 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -43,6 +43,13 @@ telling the sender it landed. The ceiling is `policy.contextBudgetBytes`.
 Claims are enforced however the workspace path is spelled. A project reached
 through a symlink — `/tmp` and `/var` on macOS, a symlinked checkout anywhere —
 used to pass every write through while still reporting `protection guarded`.
+
+An agent can run the commands its skill teaches. Every mutating command took a
+session id and a generation on the command line, and the skills told agents to
+pass two environment variables nothing has ever set — so on all four native
+clients the documented workflow could not be carried out at all. `acc` now works
+out which session is running it, and stops rather than guessing when two live
+sessions in one checkout both fit.
 
 Installing edits configuration for four other tools, so uninstall removes the
 entries ACC recorded writing and nothing else. A settings key ACC had to create

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -61,14 +61,29 @@ graph LR
 
 ## Ownership arguments
 
-Anything that mutates needs `--session` and `--generation`. The generation is what stops a
-restarted process from acting as the old one.
+Anything that mutates acts as a session, and proves it with that session's generation —
+which is what stops a restarted process from acting as the old one. You do not pass
+either. `acc` works out which session is running it, from the binding the adapter wrote
+when the session started:
+
+| It uses | When |
+|---|---|
+| `--session` and `--generation` | you passed them — adapters and scripts do |
+| `--session` alone | you have an id from `acc status --json`; the rest is looked up |
+| the client's own session id in the environment | the client exports one, under any name |
+| the checkout you are in | several sessions here, each in its own worktree |
+| the only live session | you are the only one attached |
+
+If two live sessions in one checkout both fit, it stops and names them rather than
+guessing — acting as the wrong session is exactly what the generation prevents.
+
+The generation is never printed by `acc status`, on purpose: it is proof of ownership, not
+public information.
 
 ## Asking another agent
 
 ```bash
-acc request --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --to claude_code --title "finish the store tests" \
+acc request --to claude_code --title "finish the store tests" \
   --detail "I ported src/store but ran out of time on the concurrency cases."
 ```
 
@@ -85,8 +100,8 @@ Work is addressed to a **participant**, not a session. The agent can close its t
 the next session it opens is still told. Only that participant can take it:
 
 ```bash
-acc task --session … --generation … --task task_x --take     # exit 5 if it is not yours
-acc task --session … --generation … --task task_x --state review
+acc task --task task_x --take     # exit 5 if it is not yours
+acc task --task task_x --state review
 ```
 
 `--assignee` on `acc task` addresses work without sending a message. `acc request` is the
@@ -96,6 +111,6 @@ A workstream is optional. `acc request --to models --title "review the migration
 project around it. Create one when several pieces belong together:
 
 ```bash
-acc workstream --session … --generation … \
+acc workstream \
   --title "Storage" --objective "port the store and its tests"
 ```

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -41,8 +41,7 @@ acc status
 Inside a session your agent runs this for you:
 
 ```bash
-acc claim --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --resource 'file:packages/core/**' --reason "porting the store"
+acc claim --resource 'file:packages/core/**' --reason "porting the store"
 ```
 
 Another session that tries to write there is refused — with the owner's name.
@@ -65,8 +64,7 @@ Exit code `5` means conflict.
 ## 5. Say something
 
 ```bash
-acc message --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --to models --subject "Slots" --body "Which names are stable?" --type question
+acc message --to models --subject "Slots" --body "Which names are stable?" --type question
 ```
 
 Messages are **data, not orders**. A peer cannot change your instructions.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -38,8 +38,7 @@ Not a leak.
 Exit code `5`, with the owner named. Ask them, or:
 
 ```bash
-acc release --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --claim "$CLAIM" --authority "agreed with models" --reason "handing over"
+acc release --claim "$CLAIM" --authority "agreed with models" --reason "handing over"
 ```
 
 ## A claim says `advisory`

--- a/packages/adapter-claude-code/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-claude-code/plugin/skills/acc/SKILL.md
@@ -14,8 +14,7 @@ skill is how you stay legible to them and they to you.
 Once you understand the request, publish one line of Intent:
 
 ```bash
-{{ACC}} work --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --summary "porting the claim model" --mode edit
+{{ACC}} work --summary "porting the claim model" --mode edit
 ```
 
 When you stop working on something and are not starting anything else, say so with
@@ -29,8 +28,7 @@ what you are up to, it does not stop anyone editing anything.
 ## Claim before you change shared work
 
 ```bash
-{{ACC}} claim --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --resource 'file:packages/core/**' --reason "porting the store"
+{{ACC}} claim --resource 'file:packages/core/**' --reason "porting the store"
 ```
 
 Exit code 5 means someone else holds it. The error names the owner and whether their
@@ -43,8 +41,7 @@ wrote, a port in an area someone else is already in — ask the agent working th
 do it badly yourself, and do not ask your human to carry the message:
 
 ```bash
-{{ACC}} request --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --to claude_code --title "finish the store tests" \
+{{ACC}} request --to claude_code --title "finish the store tests" \
   --detail "I ported src/store but ran out of time on the concurrency cases."
 ```
 
@@ -54,17 +51,18 @@ leave it, or reply. It is a request, not an order.
 
 ## Work someone asked of you
 
-A turn that opens with `[task_unblocked]` means work is addressed to you and waiting. Take
-it before you start, so nobody does it twice:
+A turn that opens with `[task_unblocked] task_x ...` means work is addressed to you and
+waiting. The id on that line is the one to use. Take it before you start, so nobody does
+it twice:
 
 ```bash
-{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --take
+{{ACC}} task --task task_x --take
 ```
 
 Mark it when it is done, so the agent that asked can stop waiting:
 
 ```bash
-{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --state done
+{{ACC}} task --task task_x --state done
 ```
 
 If you are not going to do it, reply with `acc message` instead of leaving it pending. The
@@ -76,15 +74,14 @@ Marking it done answers the request it came from, so it stops appearing in your 
 For a message that asked for an acknowledgement and is not tied to a task:
 
 ```bash
-{{ACC}} ack --session "$ACC_SESSION" --generation "$ACC_GENERATION" --message message_x
+{{ACC}} ack  --message message_x
 ```
 
 If you are not going to do it, say so. A request left pending looks exactly like
 one you have not read yet, and the agent that asked is waiting on an answer:
 
 ```bash
-{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --task task_x --decline --reason "Mud collision belongs to the terrain pass, not suspension."
+{{ACC}} task --task task_x --decline --reason "Mud collision belongs to the terrain pass, not suspension."
 ```
 
 While you work on it, keep your Intent current with `acc work`. That is how the
@@ -153,7 +150,7 @@ You are not limited to your own view. Any session can read the complete state, i
 other participants' sessions and their subagents:
 
 ```bash
-{{ACC}} sync --session "$ACC_SESSION" --scope full --json
+{{ACC}} sync --scope full --json
 ```
 
 If the human asks "what is the models agent doing?" or "is anyone else touching the
@@ -163,8 +160,7 @@ differs between participants; knowledge does not.
 You can also relay a request to any participant:
 
 ```bash
-{{ACC}} message --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --to models --subject "Material slots" --body "Which names are stable?" \
+{{ACC}} message --to models --subject "Material slots" --body "Which names are stable?" \
   --type question --requires-ack
 ```
 
@@ -188,8 +184,7 @@ Before the session ends, record what happened — nothing else writes this for y
 session-end hook cannot summarise a conversation that has already stopped:
 
 ```bash
-{{ACC}} finish --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --goal "port the claim model" --status partial \
+{{ACC}} finish --goal "port the claim model" --status partial \
   --completed "storage ported" --remaining "doctor still to port"
 ```
 

--- a/packages/adapter-codex/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-codex/plugin/skills/acc/SKILL.md
@@ -14,8 +14,7 @@ skill is how you stay legible to them and they to you.
 Once you understand the request, publish one line of Intent:
 
 ```bash
-{{ACC}} work --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --summary "porting the claim model" --mode edit
+{{ACC}} work --summary "porting the claim model" --mode edit
 ```
 
 When you stop working on something and are not starting anything else, say so with
@@ -29,8 +28,7 @@ what you are up to, it does not stop anyone editing anything.
 ## Claim before you change shared work
 
 ```bash
-{{ACC}} claim --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --resource 'file:packages/core/**' --reason "porting the store"
+{{ACC}} claim --resource 'file:packages/core/**' --reason "porting the store"
 ```
 
 Exit code 5 means someone else holds it. The error names the owner and whether their
@@ -43,8 +41,7 @@ wrote, a port in an area someone else is already in — ask the agent working th
 do it badly yourself, and do not ask your human to carry the message:
 
 ```bash
-{{ACC}} request --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --to claude_code --title "finish the store tests" \
+{{ACC}} request --to claude_code --title "finish the store tests" \
   --detail "I ported src/store but ran out of time on the concurrency cases."
 ```
 
@@ -54,17 +51,18 @@ leave it, or reply. It is a request, not an order.
 
 ## Work someone asked of you
 
-A turn that opens with `[task_unblocked]` means work is addressed to you and waiting. Take
-it before you start, so nobody does it twice:
+A turn that opens with `[task_unblocked] task_x ...` means work is addressed to you and
+waiting. The id on that line is the one to use. Take it before you start, so nobody does
+it twice:
 
 ```bash
-{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --take
+{{ACC}} task --task task_x --take
 ```
 
 Mark it when it is done, so the agent that asked can stop waiting:
 
 ```bash
-{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --state done
+{{ACC}} task --task task_x --state done
 ```
 
 If you are not going to do it, reply with `acc message` instead of leaving it pending. The
@@ -76,15 +74,14 @@ Marking it done answers the request it came from, so it stops appearing in your 
 For a message that asked for an acknowledgement and is not tied to a task:
 
 ```bash
-{{ACC}} ack --session "$ACC_SESSION" --generation "$ACC_GENERATION" --message message_x
+{{ACC}} ack  --message message_x
 ```
 
 If you are not going to do it, say so. A request left pending looks exactly like
 one you have not read yet, and the agent that asked is waiting on an answer:
 
 ```bash
-{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --task task_x --decline --reason "Mud collision belongs to the terrain pass, not suspension."
+{{ACC}} task --task task_x --decline --reason "Mud collision belongs to the terrain pass, not suspension."
 ```
 
 While you work on it, keep your Intent current with `acc work`. That is how the
@@ -153,7 +150,7 @@ You are not limited to your own view. Any session can read the complete state, i
 other participants' sessions and their subagents:
 
 ```bash
-{{ACC}} sync --session "$ACC_SESSION" --scope full --json
+{{ACC}} sync --scope full --json
 ```
 
 If the human asks "what is the models agent doing?" or "is anyone else touching the
@@ -163,8 +160,7 @@ differs between participants; knowledge does not.
 You can also relay a request to any participant:
 
 ```bash
-{{ACC}} message --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --to models --subject "Material slots" --body "Which names are stable?" \
+{{ACC}} message --to models --subject "Material slots" --body "Which names are stable?" \
   --type question --requires-ack
 ```
 
@@ -188,8 +184,7 @@ Before the session ends, record what happened — nothing else writes this for y
 session-end hook cannot summarise a conversation that has already stopped:
 
 ```bash
-{{ACC}} finish --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --goal "port the claim model" --status partial \
+{{ACC}} finish --goal "port the claim model" --status partial \
   --completed "storage ported" --remaining "doctor still to port"
 ```
 

--- a/packages/adapter-gemini-cli/extension/skills/acc/SKILL.md
+++ b/packages/adapter-gemini-cli/extension/skills/acc/SKILL.md
@@ -14,8 +14,7 @@ skill is how you stay legible to them and they to you.
 Once you understand the request, publish one line of Intent:
 
 ```bash
-{{ACC}} work --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --summary "porting the claim model" --mode edit
+{{ACC}} work --summary "porting the claim model" --mode edit
 ```
 
 When you stop working on something and are not starting anything else, say so with
@@ -29,8 +28,7 @@ what you are up to, it does not stop anyone editing anything.
 ## Claim before you change shared work
 
 ```bash
-{{ACC}} claim --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --resource 'file:packages/core/**' --reason "porting the store"
+{{ACC}} claim --resource 'file:packages/core/**' --reason "porting the store"
 ```
 
 Exit code 5 means someone else holds it. The error names the owner and whether their
@@ -43,8 +41,7 @@ wrote, a port in an area someone else is already in — ask the agent working th
 do it badly yourself, and do not ask your human to carry the message:
 
 ```bash
-{{ACC}} request --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --to claude_code --title "finish the store tests" \
+{{ACC}} request --to claude_code --title "finish the store tests" \
   --detail "I ported src/store but ran out of time on the concurrency cases."
 ```
 
@@ -54,17 +51,18 @@ leave it, or reply. It is a request, not an order.
 
 ## Work someone asked of you
 
-A turn that opens with `[task_unblocked]` means work is addressed to you and waiting. Take
-it before you start, so nobody does it twice:
+A turn that opens with `[task_unblocked] task_x ...` means work is addressed to you and
+waiting. The id on that line is the one to use. Take it before you start, so nobody does
+it twice:
 
 ```bash
-{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --take
+{{ACC}} task --task task_x --take
 ```
 
 Mark it when it is done, so the agent that asked can stop waiting:
 
 ```bash
-{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --state done
+{{ACC}} task --task task_x --state done
 ```
 
 If you are not going to do it, reply with `acc message` instead of leaving it pending. The
@@ -76,15 +74,14 @@ Marking it done answers the request it came from, so it stops appearing in your 
 For a message that asked for an acknowledgement and is not tied to a task:
 
 ```bash
-{{ACC}} ack --session "$ACC_SESSION" --generation "$ACC_GENERATION" --message message_x
+{{ACC}} ack  --message message_x
 ```
 
 If you are not going to do it, say so. A request left pending looks exactly like
 one you have not read yet, and the agent that asked is waiting on an answer:
 
 ```bash
-{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --task task_x --decline --reason "Mud collision belongs to the terrain pass, not suspension."
+{{ACC}} task --task task_x --decline --reason "Mud collision belongs to the terrain pass, not suspension."
 ```
 
 While you work on it, keep your Intent current with `acc work`. That is how the
@@ -153,7 +150,7 @@ You are not limited to your own view. Any session can read the complete state, i
 other participants' sessions and their subagents:
 
 ```bash
-{{ACC}} sync --session "$ACC_SESSION" --scope full --json
+{{ACC}} sync --scope full --json
 ```
 
 If the human asks "what is the models agent doing?" or "is anyone else touching the
@@ -163,8 +160,7 @@ differs between participants; knowledge does not.
 You can also relay a request to any participant:
 
 ```bash
-{{ACC}} message --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --to models --subject "Material slots" --body "Which names are stable?" \
+{{ACC}} message --to models --subject "Material slots" --body "Which names are stable?" \
   --type question --requires-ack
 ```
 
@@ -188,8 +184,7 @@ Before the session ends, record what happened — nothing else writes this for y
 session-end hook cannot summarise a conversation that has already stopped:
 
 ```bash
-{{ACC}} finish --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --goal "port the claim model" --status partial \
+{{ACC}} finish --goal "port the claim model" --status partial \
   --completed "storage ported" --remaining "doctor still to port"
 ```
 

--- a/packages/adapter-kimi/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-kimi/plugin/skills/acc/SKILL.md
@@ -14,8 +14,7 @@ skill is how you stay legible to them and they to you.
 Once you understand the request, publish one line of Intent:
 
 ```bash
-{{ACC}} work --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --summary "porting the claim model" --mode edit
+{{ACC}} work --summary "porting the claim model" --mode edit
 ```
 
 When you stop working on something and are not starting anything else, say so with
@@ -29,8 +28,7 @@ what you are up to, it does not stop anyone editing anything.
 ## Claim before you change shared work
 
 ```bash
-{{ACC}} claim --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --resource 'file:packages/core/**' --reason "porting the store"
+{{ACC}} claim --resource 'file:packages/core/**' --reason "porting the store"
 ```
 
 Exit code 5 means someone else holds it. The error names the owner and whether their
@@ -43,8 +41,7 @@ wrote, a port in an area someone else is already in — ask the agent working th
 do it badly yourself, and do not ask your human to carry the message:
 
 ```bash
-{{ACC}} request --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --to claude_code --title "finish the store tests" \
+{{ACC}} request --to claude_code --title "finish the store tests" \
   --detail "I ported src/store but ran out of time on the concurrency cases."
 ```
 
@@ -54,17 +51,18 @@ leave it, or reply. It is a request, not an order.
 
 ## Work someone asked of you
 
-A turn that opens with `[task_unblocked]` means work is addressed to you and waiting. Take
-it before you start, so nobody does it twice:
+A turn that opens with `[task_unblocked] task_x ...` means work is addressed to you and
+waiting. The id on that line is the one to use. Take it before you start, so nobody does
+it twice:
 
 ```bash
-{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --take
+{{ACC}} task --task task_x --take
 ```
 
 Mark it when it is done, so the agent that asked can stop waiting:
 
 ```bash
-{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" --task task_x --state done
+{{ACC}} task --task task_x --state done
 ```
 
 If you are not going to do it, reply with `acc message` instead of leaving it pending. The
@@ -76,15 +74,14 @@ Marking it done answers the request it came from, so it stops appearing in your 
 For a message that asked for an acknowledgement and is not tied to a task:
 
 ```bash
-{{ACC}} ack --session "$ACC_SESSION" --generation "$ACC_GENERATION" --message message_x
+{{ACC}} ack  --message message_x
 ```
 
 If you are not going to do it, say so. A request left pending looks exactly like
 one you have not read yet, and the agent that asked is waiting on an answer:
 
 ```bash
-{{ACC}} task --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --task task_x --decline --reason "Mud collision belongs to the terrain pass, not suspension."
+{{ACC}} task --task task_x --decline --reason "Mud collision belongs to the terrain pass, not suspension."
 ```
 
 While you work on it, keep your Intent current with `acc work`. That is how the
@@ -153,7 +150,7 @@ You are not limited to your own view. Any session can read the complete state, i
 other participants' sessions and their subagents:
 
 ```bash
-{{ACC}} sync --session "$ACC_SESSION" --scope full --json
+{{ACC}} sync --scope full --json
 ```
 
 If the human asks "what is the models agent doing?" or "is anyone else touching the
@@ -163,8 +160,7 @@ differs between participants; knowledge does not.
 You can also relay a request to any participant:
 
 ```bash
-{{ACC}} message --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --to models --subject "Material slots" --body "Which names are stable?" \
+{{ACC}} message --to models --subject "Material slots" --body "Which names are stable?" \
   --type question --requires-ack
 ```
 
@@ -188,8 +184,7 @@ Before the session ends, record what happened — nothing else writes this for y
 session-end hook cannot summarise a conversation that has already stopped:
 
 ```bash
-{{ACC}} finish --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --goal "port the claim model" --status partial \
+{{ACC}} finish --goal "port the claim model" --status partial \
   --completed "storage ported" --remaining "doctor still to port"
 ```
 

--- a/packages/adapter-sdk/src/context-projector.mjs
+++ b/packages/adapter-sdk/src/context-projector.mjs
@@ -40,8 +40,21 @@ function truncate(line, limit) {
   return `${cut}…`;
 }
 
+/**
+ * An attention line an agent can act on without a round trip.
+ *
+ * `- [task_unblocked] Tank sinks through mud` says work is waiting and does not
+ * say which work. The commands that take it - `acc task --take --task <id>` -
+ * all need the id, and the only other place it appears is `acc sync --json`. An
+ * agent that is told to act and not told on what improvises, which in this
+ * project has already meant one hand-editing the store rather than admitting it
+ * could not name the task.
+ */
 function attentionLines(attention) {
-  return attention.map(item => `- [${item.kind}] ${item.summary}`);
+  return attention.map(item => (typeof item.sourceId === "string"
+    && item.sourceId.startsWith("task_")
+    ? `- [${item.kind}] ${item.sourceId} ${item.summary}`
+    : `- [${item.kind}] ${item.summary}`));
 }
 
 /**
@@ -115,7 +128,14 @@ export function projectContext(sync, { budgetBytes = DEFAULT_BUDGET_BYTES } = {}
     .sort((left, right) => left.priority - right.priority
       || left.sourceId.localeCompare(right.sourceId));
   const messages = sync.messages ?? [];
-  const roster = sync.roster ?? [];
+  // Who is here, which is not the same as who has ever been here. The roster
+  // keeps closed sessions - `sync` needs them to decide what a cursor has missed
+  // - and a turn that lists them says "3 session(s)" for two participants, one
+  // of them shown twice with contradictory presence. Left alone it also grows
+  // without limit: every session ever opened would take a line out of the
+  // context budget, crowding out messages actually addressed to the reader.
+  // Stale stays: a session that crashed holding a claim is very much news.
+  const roster = (sync.roster ?? []).filter(item => item.presence !== "offline");
   const claims = sync.claims ?? [];
 
   // Every entry is a group that appears whole or not at all. Single-line groups

--- a/packages/adapter-sdk/src/index.mjs
+++ b/packages/adapter-sdk/src/index.mjs
@@ -10,5 +10,6 @@ export { BEGIN, END, removeTomlBlock, renderBlock, stripBlock, tomlString, write
 export { projectContext } from "./context-projector.mjs";
 export { mergeOwnedConfig, mergeOwnedEntries, ownedEntries, ownedKeys,
   removeOwnedConfig, removeOwnedEntries } from "./config-merge.mjs";
-export { clearSessionBinding, loadSessionBinding, storeSessionBinding }
+export { clearSessionBinding, listSessionBindings, loadSessionBinding,
+  storeSessionBinding }
   from "./session-binding.mjs";

--- a/packages/adapter-sdk/src/session-binding.mjs
+++ b/packages/adapter-sdk/src/session-binding.mjs
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { AccError, EXIT } from "@agents-can-communicate/protocol";
@@ -59,4 +59,37 @@ export async function loadSessionBinding({ runtimeDir, harnessSessionId }) {
 
 export async function clearSessionBinding({ runtimeDir, harnessSessionId }) {
   await rm(fileFor(runtimeDir, harnessSessionId), { force: true });
+}
+
+/**
+ * Every binding in this workspace, whole.
+ *
+ * `loadSessionBinding` answers "which session is *this* harness session", which
+ * needs the harness id up front. The CLI has the opposite problem: an agent runs
+ * `acc work` from a shell that was never told any id, so the question is which
+ * of the live bindings is the one that spawned it.
+ *
+ * A file that cannot be read is skipped rather than fatal - the caller is trying
+ * to identify itself among several, and one unreadable neighbour should not stop
+ * it recognising its own.
+ */
+export async function listSessionBindings({ runtimeDir }) {
+  const dir = path.join(runtimeDir, "bindings");
+  let names;
+  try {
+    names = await readdir(dir);
+  } catch (error) {
+    if (error.code === "ENOENT") return [];
+    throw error;
+  }
+  const bindings = [];
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    const record = await readFile(path.join(dir, name), "utf8")
+      .then(JSON.parse).catch(() => null);
+    if (record?.schemaVersion !== SCHEMA_VERSION) continue;
+    bindings.push({ harnessSessionId: record.harnessSessionId,
+      accSessionId: record.accSessionId, generation: record.generation });
+  }
+  return bindings;
 }

--- a/packages/cli/src/args.mjs
+++ b/packages/cli/src/args.mjs
@@ -2,36 +2,42 @@ import { AccError, EXIT } from "@agents-can-communicate/protocol";
 
 // Commands the model is offered stay few and high level; attach, heartbeat, and
 // detach exist for adapters and are deliberately not advertised as model tools.
+//
+// `--session` and `--generation` are optional on every agent-facing command:
+// the CLI works out which session is calling it (see session-owner.mjs). They
+// stay accepted because an adapter, a script, or an agent holding a session id
+// from `acc status --json` has a reason to be explicit. They remain required on
+// attach, heartbeat and detach, which are the adapter's own lifecycle calls.
 export const COMMANDS = Object.freeze({
   attach: { required: ["participant"], optional: ["harness", "cadence", "parent", "session"] },
   heartbeat: { required: ["session", "generation"], optional: [] },
   detach: { required: ["session", "generation"], optional: [] },
   sync: { required: [], optional: ["session", "cursor", "limit", "scope"] },
-  work: { required: ["session", "generation"],
-    optional: ["summary", "mode", "state", "workstream"], repeated: ["hint"],
-    flags: ["clear"] },
-  claim: { required: ["session", "generation", "resource"],
-    optional: ["mode", "enforcement", "reason", "lease"] },
-  release: { required: ["session", "generation", "claim"],
-    optional: ["authority", "reason"] },
-  message: { required: ["session", "generation", "subject", "body"],
-    optional: ["type", "priority", "workstream"], repeated: ["to"],
-    flags: ["requires-ack"] },
+  work: { required: [], optional: ["session", "generation", "summary", "mode",
+    "state", "workstream"], repeated: ["hint"], flags: ["clear"] },
+  claim: { required: ["resource"],
+    optional: ["session", "generation", "mode", "enforcement", "reason", "lease"] },
+  release: { required: ["claim"],
+    optional: ["session", "generation", "authority", "reason"] },
+  message: { required: ["subject", "body"],
+    optional: ["session", "generation", "type", "priority", "workstream"],
+    repeated: ["to"], flags: ["requires-ack"] },
   // Asking another agent to do something: one call, because a task nobody was
   // told about and a message pointing at no task are each useless.
-  request: { required: ["session", "generation", "to", "title"],
-    optional: ["detail", "workstream", "priority"], repeated: ["depends-on"] },
+  request: { required: ["to", "title"],
+    optional: ["session", "generation", "detail", "workstream", "priority"],
+    repeated: ["depends-on"] },
   // Create a task, or act on one with --task. A workstream is optional: small
   // requests should not have to invent a project first.
-  task: { required: ["session", "generation"],
-    optional: ["workstream", "title", "detail", "assignee", "state", "task", "reason"],
+  task: { required: [], optional: ["session", "generation", "workstream", "title",
+    "detail", "assignee", "state", "task", "reason"],
     repeated: ["depends-on"], flags: ["take", "decline", "force"] },
-  workstream: { required: ["session", "generation", "title", "objective"], optional: [] },
+  workstream: { required: ["title", "objective"], optional: ["session", "generation"] },
   // Messages not tied to a task need a way to be answered too. Without one a
   // `requiresAck` message raised an attention item nothing could ever clear.
-  ack: { required: ["session", "generation", "message"], optional: ["state"] },
-  finish: { required: ["session", "generation", "goal"],
-    optional: ["status", "to"], repeated: ["completed", "remaining", "blocker"] },
+  ack: { required: ["message"], optional: ["session", "generation", "state"] },
+  finish: { required: ["goal"], optional: ["session", "generation", "status", "to"],
+    repeated: ["completed", "remaining", "blocker"] },
   status: { required: [], optional: ["participant"] },
   doctor: { required: [], optional: ["home"], flags: ["repair"] },
   // The one command with a subcommand. Kept as an explicit list rather than a

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -13,6 +13,7 @@ import { runInstallCommand } from "./install-command.mjs";
 import { runDoctor } from "./doctor-command.mjs";
 import { createGitProbe } from "./git-probe.mjs";
 import { platformDataHome, runtimePaths } from "./runtime-paths.mjs";
+import { resolveOwner } from "./session-owner.mjs";
 import { discoverWorkspace } from "./workspace-discovery.mjs";
 
 const DEFAULT_CADENCE_MS = 30_000;
@@ -245,8 +246,13 @@ export async function main(argv, runtime) {
     const context = ["config", "install", "uninstall"].includes(parsed.command)
       ? null
       : await openContext(parsed.options, runtime);
-    const { data, text } = await HANDLERS[parsed.command]({ options: parsed.options,
-      context, runtime });
+    // Which session is calling is answered once, here, rather than by each
+    // handler: every one of them needs the same pair, and a handler that forgot
+    // to ask would be an operation an agent cannot reach.
+    const options = context === null ? parsed.options
+      : await resolveOwner({ command: parsed.command, options: parsed.options,
+        context, env: runtime.env });
+    const { data, text } = await HANDLERS[parsed.command]({ options, context, runtime });
     // Machine mode writes exactly one JSON object to stdout and nothing else.
     if (parsed.options.json === true) await write(runtime.stdout, `${JSON.stringify(ok(data))}\n`);
     else if (text !== "") await write(runtime.stdout, `${human(text)}\n`);

--- a/packages/cli/src/session-owner.mjs
+++ b/packages/cli/src/session-owner.mjs
@@ -1,0 +1,126 @@
+import { listSessionBindings } from "@agents-can-communicate/adapter-sdk";
+import { AccError, EXIT } from "@agents-can-communicate/protocol";
+
+/**
+ * Work out which session is running this command.
+ *
+ * Every mutating command needs a session id and the generation that proves the
+ * caller is that session. Until this existed, both had to be passed on the
+ * command line, and the shipped skills told agents to pass
+ * `--session "$ACC_SESSION" --generation "$ACC_GENERATION"` - two variables that
+ * nothing in the system has ever set. The generation is not printed by `acc
+ * status` either, deliberately: it is the proof of ownership, not public
+ * information. So the documented workflow could not be carried out by any agent
+ * on any client, and the only way through was to read ACC's own files by hand,
+ * which the same skill forbids in as many words.
+ *
+ * The hook runtime already knows both. It writes them into a binding at
+ * SessionStart, keyed by the harness's own session id. What was missing was a
+ * way for a shell inside that session to find its own binding. Each step below
+ * answers that from something the caller demonstrably has.
+ */
+const NEEDS_OWNER = Object.freeze(new Set(["work", "claim", "release", "message",
+  "request", "ack", "workstream", "task", "finish"]));
+
+/**
+ * Reads that are answers about *you*.
+ *
+ * Attention is computed per session: what is addressed to you, what has become
+ * unblocked for you. Run by hand with nothing identifying the caller, both of
+ * these answered for nobody and returned an empty list - so an agent told at the
+ * top of its turn that work was waiting could ask `acc status` and be told there
+ * was none. They resolve softly: a shell with no session attached still gets the
+ * roster and the events, which is what it came for.
+ */
+const WANTS_OWNER = Object.freeze(new Set(["sync", "status"]));
+
+export const needsOwner = command => NEEDS_OWNER.has(command);
+
+/**
+ * Bindings whose session is still open, carrying the session's own checkout.
+ *
+ * A binding outlives a crash, so one that names a closed or vanished session is
+ * a leftover. Acting as a closed session would fail deeper in the service with a
+ * conflict; dropping it here means the *next* candidate can be recognised
+ * instead.
+ */
+async function liveCandidates({ context }) {
+  const bindings = await listSessionBindings({ runtimeDir: context.paths.root });
+  if (bindings.length === 0) return [];
+  const status = await context.service.collectStatus({});
+  const live = new Map(status.participants
+    .filter(participant => participant.presence !== "offline")
+    .map(participant => [participant.sessionId, participant]));
+  return bindings
+    .filter(binding => live.has(binding.accSessionId))
+    .map(binding => ({ ...binding, session: live.get(binding.accSessionId) }));
+}
+
+const describe = candidates => candidates
+  .map(candidate => `${candidate.session.participantId} (${candidate.session.harness})`)
+  .join(", ");
+
+export async function resolveOwner({ command, options, context, env = {} }) {
+  const soft = WANTS_OWNER.has(command);
+  if (!soft && !needsOwner(command)) return options;
+  if (options.session !== undefined && options.generation !== undefined) return options;
+  if (soft && options.participant !== undefined) return options;
+
+  const candidates = await liveCandidates({ context });
+  const take = candidate => ({ ...options, session: candidate.accSessionId,
+    generation: candidate.generation,
+    // `status` filters by participant rather than by session, so it is told who
+    // the caller is in the terms it works in.
+    participant: options.participant ?? candidate.session.participantId });
+
+  // Named a session but not the generation: the id is in `acc status --json`,
+  // so this is what an agent reaches for first, and refusing it would teach the
+  // wrong lesson about which half is secret.
+  if (options.session !== undefined) {
+    // The reads never needed a generation, and a session opened by `acc attach`
+    // has no binding to find one in. Answering for the session it was given is
+    // both what it was asked and what it did before this resolver existed.
+    if (soft) return options;
+    const named = candidates.find(candidate => candidate.accSessionId === options.session);
+    if (named !== undefined) return take(named);
+    throw new AccError(EXIT.USAGE,
+      `no live session ${options.session} in this workspace`,
+      { command, session: options.session });
+  }
+
+  // The documented pair, honoured for anyone who has wired it up themselves.
+  if (typeof env.ACC_SESSION === "string" && typeof env.ACC_GENERATION === "string") {
+    return { ...options, session: env.ACC_SESSION, generation: env.ACC_GENERATION };
+  }
+
+  // The client's own session id, under whatever name it exports it. Claude Code
+  // sets CLAUDE_CODE_SESSION_ID, measured equal to the `session_id` its hooks
+  // receive; matching on the value rather than the variable name means a client
+  // that names it something else works without ACC knowing the name.
+  const exported = new Set(Object.values(env).filter(value => typeof value === "string"));
+  const byEnvironment = candidates
+    .filter(candidate => exported.has(candidate.harnessSessionId));
+  if (byEnvironment.length === 1) return take(byEnvironment[0]);
+
+  // Two agents in one workspace are the normal case, and each is usually in its
+  // own checkout - that is what the worktree story is. Same repository, so the
+  // same workspace, and the checkout tells them apart.
+  const here = context.descriptor.git?.worktreeRoot;
+  const byCheckout = here === undefined
+    ? []
+    : candidates.filter(candidate => candidate.session.checkoutRoot === here);
+  if (byCheckout.length === 1) return take(byCheckout[0]);
+
+  if (candidates.length === 1) return take(candidates[0]);
+
+  // Guessing between two live sessions would let one agent act as another, which
+  // is exactly what the generation exists to prevent. So this refuses, and says
+  // what it found.
+  if (soft) return options;
+  throw new AccError(EXIT.USAGE, candidates.length === 0
+    ? `${command} could not tell which session is running it: no live session is `
+      + "attached here. An adapter attaches one at SessionStart; `acc status` shows who is."
+    : `${command} could not tell which of ${candidates.length} live sessions is running `
+      + `it (${describe(candidates)}). Pass --session, which \`acc status --json\` lists.`,
+  { command, candidates: candidates.map(candidate => candidate.accSessionId) });
+}

--- a/tests/process/abandoned-work.test.mjs
+++ b/tests/process/abandoned-work.test.mjs
@@ -108,7 +108,7 @@ test("the agent waiting is told, even when it is the only session left", async t
 
   const shown = await turn(place, "codex", "gfx", "graphics");
 
-  assert.match(shown, /\[request_stalled\] tank sinks into mud/,
+  assert.match(shown, /\[request_stalled\] task_\S+ tank sinks into mud/,
     "the requester was left waiting with nothing said");
 });
 

--- a/tests/process/request-work.test.mjs
+++ b/tests/process/request-work.test.mjs
@@ -93,8 +93,9 @@ test("an agent in one worktree can ask an agent in another to finish something",
 
     const shown = await turn(place, "claude_code", "doer", place.second);
     // Both halves reach them: the task as work waiting, the message as the
-    // reason. Either alone leaves the recipient guessing.
-    assert.match(shown, /\[task_unblocked\] finish the store tests/);
+    // reason. Either alone leaves the recipient guessing - and the line carries
+    // the task id, since every command that acts on it needs one.
+    assert.match(shown, /\[task_unblocked\] task_\S+ finish the store tests/);
     assert.match(shown, /type work_request/);
     assert.match(shown, /I ran out of time on the concurrency cases\./);
   });
@@ -120,7 +121,7 @@ test("work outlives the session it was addressed to", async t => {
   assert.notEqual(second.accSessionId, first.accSessionId, "the same session came back");
 
   const shown = await turn(place, "claude_code", "doer-2", place.second);
-  assert.match(shown, /\[task_unblocked\] finish the store tests/,
+  assert.match(shown, /\[task_unblocked\] task_\S+ finish the store tests/,
     "a restarted agent was never told about work waiting for it");
 });
 

--- a/tests/process/session-resolution.test.mjs
+++ b/tests/process/session-resolution.test.mjs
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, readdir, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+const repo = path.resolve(import.meta.dirname, "..", "..");
+const acc = path.join(repo, "bin", "acc.mjs");
+const hook = path.join(repo, "bin", "acc-hook.mjs");
+
+/**
+ * An agent has to be able to say who it is.
+ *
+ * Every mutating command acts as a session and proves it with that session's
+ * generation. Both used to be required on the command line, and the shipped
+ * skills told agents to pass `--session "$ACC_SESSION" --generation
+ * "$ACC_GENERATION"` — two variables nothing in this system has ever set. The
+ * generation is deliberately absent from `acc status` as well, being proof of
+ * ownership rather than public information.
+ *
+ * So the whole documented workflow was unreachable: on all four native clients,
+ * `work`, `claim`, `message`, `request`, `task`, `ack` and `finish` could not be
+ * run by the agent they were written for. Only the MCP path worked, because that
+ * server resolves its own session and never asks the model for one.
+ *
+ * These tests drive the real CLI through the real hook runtime, and pass no
+ * identifiers at all — the way the skill now tells an agent to.
+ */
+async function stage(t, { participants }) {
+  const root = await realpath(await mkdtemp(path.join(tmpdir(), "acc-resolve-")));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const project = path.join(root, "project");
+  const env = { ...process.env, ACC_DATA_HOME: path.join(root, "data"),
+    GIT_DIR: "", GIT_WORK_TREE: "" };
+  await run("git", ["init", "-q", "-b", "main", project], { env, cwd: root })
+    .catch(async () => { await run("mkdir", ["-p", project]); });
+
+  for (const { participant, harness, session } of participants) {
+    const child = run("node", [hook, harness],
+      { env: { ...env, ACC_PARTICIPANT: participant } });
+    child.child.stdin.end(JSON.stringify({ hook_event_name: "SessionStart",
+      session_id: session, cwd: project, source: "startup" }));
+    await child;
+  }
+  const cli = (args, extra = {}) => run("node", [acc, ...args],
+    { cwd: project, env: { ...env, ...extra } });
+  return { project, env, cli };
+}
+
+test("an agent that was told no identifiers can still publish intent", async t => {
+  const { cli } = await stage(t,
+    { participants: [{ participant: "solo", harness: "codex", session: "h-1" }] });
+
+  // Exactly what the skill now says to run. Nothing here names a session.
+  const { stdout } = await cli(["work", "--summary", "porting the claim model"]);
+
+  assert.match(stdout, /intent: porting the claim model/);
+});
+
+test("the whole request loop runs with no identifiers on either side", async t => {
+  const { cli } = await stage(t, { participants: [
+    { participant: "graphics", harness: "claude_code", session: "gfx" },
+    { participant: "physics", harness: "codex", session: "phy" }] });
+
+  // Two live sessions in one checkout, so neither is resolvable by elimination.
+  // Each is recognised by the session id its own client exports.
+  await cli(["request", "--to", "physics", "--title", "Tank sinks through mud",
+    "--detail", "settle() adds mudDepth with nothing stopping it."],
+  { CLAUDE_CODE_SESSION_ID: "gfx" });
+
+  const { stdout: waiting } = await cli(["status", "--json"],
+    { CLAUDE_CODE_SESSION_ID: "phy" });
+  const attention = JSON.parse(waiting).data.attention;
+  const taskId = attention.find(item => item.kind === "task_unblocked")?.sourceId;
+  assert.equal(typeof taskId, "string",
+    `physics was not told work is waiting: ${JSON.stringify(attention)}`);
+
+  const { stdout: taken } = await cli(["task", "--task", taskId, "--take"],
+    { CLAUDE_CODE_SESSION_ID: "phy" });
+  assert.match(taken, /in_progress/);
+  const { stdout: done } = await cli(["task", "--task", taskId, "--state", "done"],
+    { CLAUDE_CODE_SESSION_ID: "phy" });
+  assert.match(done, /done/);
+});
+
+test("a session id from status is enough; the generation is looked up", async t => {
+  const { cli } = await stage(t,
+    { participants: [{ participant: "solo", harness: "codex", session: "h-1" }] });
+  const { stdout } = await cli(["status", "--json"]);
+  const { sessionId } = JSON.parse(stdout).data.participants[0];
+
+  // The half an agent can discover is the half it may use. Refusing this would
+  // teach that both halves are public, or that neither is usable.
+  const { stdout: intent } = await cli(["work", "--session", sessionId,
+    "--summary", "reading the store"]);
+
+  assert.match(intent, /intent: reading the store/);
+});
+
+test("two live sessions it cannot tell apart stop it rather than guessing", async t => {
+  const { cli } = await stage(t, { participants: [
+    { participant: "graphics", harness: "claude_code", session: "gfx" },
+    { participant: "physics", harness: "codex", session: "phy" }] });
+
+  // Same checkout, nothing in the environment. Picking one would let an agent
+  // act as another - the single thing the generation exists to prevent.
+  const failure = await cli(["work", "--summary", "whose intent is this"])
+    .then(() => null, error => error);
+
+  assert.notEqual(failure, null, "it guessed instead of refusing");
+  assert.match(failure.stderr, /could not tell which of 2 live sessions/);
+  assert.match(failure.stderr, /graphics \(claude_code\)|physics \(codex\)/);
+});
+
+test("a session that has closed is not mistaken for the caller", async t => {
+  const { project, env, cli } = await stage(t, { participants: [
+    { participant: "gone", harness: "codex", session: "old" },
+    { participant: "here", harness: "claude_code", session: "new" }] });
+
+  const child = run("node", [hook, "codex"], { env: { ...env, ACC_PARTICIPANT: "gone" } });
+  child.child.stdin.end(JSON.stringify({ hook_event_name: "SessionEnd",
+    session_id: "old", cwd: project, reason: "exit" }));
+  await child;
+
+  // One live session left, so elimination is unambiguous again. A stale binding
+  // that still counted would make this ambiguous forever.
+  const { stdout } = await cli(["work", "--summary", "carrying on alone"]);
+
+  assert.match(stdout, /intent: carrying on alone/);
+});
+
+/**
+ * The gate for the class, not for the instance.
+ *
+ * `surface-coverage.test.mjs` asks whether a core operation can be called at
+ * all. It passed throughout, because every one of these commands existed and was
+ * routed. What could not be supplied was the *arguments*: an operation whose
+ * required argument an agent has no way to obtain is as unreachable as one with
+ * no command. This runs each agent-facing command the way the skill tells an
+ * agent to, and fails if any of them refuses for want of identity.
+ */
+const AGENT_FACING = Object.freeze([
+  ["sync", []],
+  ["status", []],
+  ["work", ["--summary", "a line of intent"]],
+  ["claim", ["--resource", "file:src/**", "--reason", "editing"]],
+  ["message", ["--to", "peer", "--subject", "s", "--body", "b"]],
+  ["request", ["--to", "peer", "--title", "please take this"]],
+  ["task", ["--title", "something to do"]],
+  ["workstream", ["--title", "a stream", "--objective", "an objective"]],
+  ["ack", ["--message", "message_absent"]],
+  ["finish", ["--goal", "what this session was for"]],
+]);
+
+test("no agent-facing command refuses for want of an identity", async t => {
+  const { cli } = await stage(t,
+    { participants: [{ participant: "solo", harness: "codex", session: "h-1" }] });
+
+  const refused = [];
+  for (const [command, args] of AGENT_FACING) {
+    const error = await cli([command, ...args]).then(() => null, failure => failure);
+    // Some of these legitimately fail on their own subject - `ack` names a
+    // message that does not exist. What none of them may do is fail because the
+    // caller could not say who it is.
+    if (error !== null && /--session|--generation|could not tell which session/
+      .test(error.stderr)) refused.push(`${command}: ${error.stderr.trim()}`);
+  }
+
+  assert.deepEqual(refused, [],
+    "these ask the agent for something the agent has no way to obtain");
+});
+
+test("no shipped skill or document teaches a variable nothing sets", async () => {
+  // The general form of the defect: instructions an agent cannot follow read
+  // exactly like instructions it can. `$ACC_SESSION` survived four rewrites of
+  // the skill and three of the docs, because nothing ever ran what they said.
+  const sources = [];
+  for (const root of ["packages", "docs"]) {
+    const entries = await readdir(path.join(repo, root),
+      { recursive: true, withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+      const file = path.join(entry.parentPath ?? entry.path, entry.name);
+      if (file.includes("node_modules")) continue;
+      sources.push({ file, text: await readFile(file, "utf8") });
+    }
+  }
+  sources.push({ file: path.join(repo, "README.md"),
+    text: await readFile(path.join(repo, "README.md"), "utf8") });
+
+  // Every ACC_* variable the code actually reads. Anything else in a code block
+  // is a promise the runtime does not keep.
+  const provided = new Set(["ACC_DATA_HOME", "ACC_PARTICIPANT", "ACC_SESSION",
+    "ACC_GENERATION"]);
+  const taught = new Map();
+  for (const { file, text } of sources) {
+    for (const [, name] of text.matchAll(/\$\{?(ACC_[A-Z_]+)\}?/g)) {
+      if (!provided.has(name)) (taught.get(name) ?? taught.set(name, []).get(name)).push(file);
+    }
+  }
+  assert.deepEqual([...taught.keys()], [],
+    "documentation tells an agent to use a variable nothing exports");
+
+  // ACC_SESSION and ACC_GENERATION are read by the resolver as an escape hatch,
+  // but nothing sets them, so no instruction may depend on one.
+  for (const { file, text } of sources) {
+    assert.equal(text.includes("$ACC_SESSION"), false,
+      `${file} still tells an agent to pass a session id it has no way to obtain`);
+  }
+});

--- a/tests/process/surface-coverage.test.mjs
+++ b/tests/process/surface-coverage.test.mjs
@@ -26,9 +26,18 @@ const repo = path.resolve(import.meta.dirname, "..", "..");
  *                      could never be cleared
  *   nearby_intent      an attention kind with no rule behind it
  *
- * Every one passed its own tests. This is the gate that makes the seventh
- * impossible to add quietly: a new core operation has to be given a surface, or
- * be named here as deliberately internal.
+ * Every one passed its own tests. This is the gate that makes another of *this*
+ * shape impossible to add quietly: a new core operation has to be given a
+ * surface, or be named here as deliberately internal.
+ *
+ * The next one had a different shape and walked straight past this gate. Every
+ * agent-facing command existed, was routed, and was documented - and required
+ * `--session` and `--generation`, which no agent could obtain: nothing exported
+ * them, and the generation is deliberately absent from `acc status`. An
+ * operation whose required argument is unobtainable is as unreachable as one
+ * with no command at all. That shape is gated by
+ * `tests/process/session-resolution.test.mjs`, which runs each command the way
+ * the skill tells an agent to run it.
  */
 function coreOperations() {
   const clock = createFakeClock("2026-08-17T00:00:00.000Z");


### PR DESCRIPTION
On all four native clients, no agent could run any mutating ACC command.

## What was wrong

Every mutating command required `--session` and `--generation`, and the four shipped skills told agents to pass them like this:

```bash
{{ACC}} work --session "$ACC_SESSION" --generation "$ACC_GENERATION" --summary "..."
```

**Nothing in this system has ever set either variable.** They appear only in the skills and the docs. The generation is not printed by `acc status` either, deliberately — it is proof of ownership, not public information.

So `work`, `claim`, `release`, `message`, `request`, `task`, `workstream`, `ack` and `finish` were unreachable by the agent they were written for. Only the MCP path worked, because that server resolves its own session and never asks the model for one. The only way through the CLI was to read ACC's own store by hand — which the same skill forbids in as many words, and which a real Claude Code session has already been observed doing.

## The fix

The hook runtime already knows both ids and writes them into a binding at SessionStart. What was missing was a way for a shell *inside* that session to find its own binding. `acc` now works this out, in order:

| It uses | When |
|---|---|
| `--session` and `--generation` | passed explicitly — adapters and scripts still do |
| `--session` alone | an id from `acc status --json`; the generation is looked up |
| the client's session id found in the environment | matched **by value**, so a client that names the variable anything works without ACC knowing the name |
| the checkout it is in | several sessions in one workspace, each in its own worktree |
| the only live session | nothing else to confuse it with |

Two live sessions in one checkout that both fit stop it rather than resolving to one — acting as the wrong session is precisely what the generation exists to prevent.

`CLAUDE_CODE_SESSION_ID` was measured equal to the `session_id` Claude Code's hooks receive, which is what the binding is keyed by.

## Two more things, found by running it

- **`acc sync` and `acc status` computed attention for nobody** when nothing identified the caller. An agent told at the top of its turn that work was waiting could ask what it was and be told there was none. Both resolve softly now; a shell with no session attached still gets the roster.
- **A turn said `[task_unblocked] <title>` and never the task id**, while every command that acts on a task needs it. The id is on the line now.

The roster in a turn no longer lists closed sessions. It named the same participant twice with contradictory presence, and grew without limit — every session ever opened taking a line out of the context budget forever.

## Evidence

A full negotiated handoff, cross-vendor, across two git worktrees of one repository, with **no identifiers passed anywhere**:

```
1. physics (codex) attaches in its worktree      -> acc work --summary "physics and collision"
2. graphics (claude_code) attaches in another    -> acc work --summary "sprite rendering"
3. graphics reads the roster                     -> physics, codex, on branch physics
4. graphics asks                                 -> acc request --to physics --title ...
5. the physics session dies without warning
6. a NEW physics session opens, and its turn carries:
     - [task_unblocked] task_kcM-ljZm2Wuf-dyTEyN9ag Tank sinks through mud
     ```acc-peer-message ... type work_request ...```
7. physics takes it, edits src/physics.mjs       -> acc task --take --task task_kcM…
8. graphics' next turn carries "accepted" and "done"
```

## Gates

`tests/process/session-resolution.test.mjs` runs **each** agent-facing command exactly as the skill tells an agent to, and fails if any refuses for want of an identity — the gate is for the class, not this instance. It also rejects documentation that teaches an `ACC_*` variable nothing exports.

Proven by mutation: all seven tests fail against `main`, all seven pass here. `surface-coverage.test.mjs` records why it did not catch this one — it asks whether a command exists, not whether its required arguments can be obtained.

- 670 tests passing, 0 failing
- `syntax ok in 146 file(s)`
- `PASS … sha256 efce17db…3de00b built from d72b6a1`
