### PR TITLE
fix: run the documentation, and stop config init from orphaning sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `d72b6a1` |
-| Tarball | `agents-can-communicate-0.0.0.tgz`, 104 KB, 101 entries |
-| sha256 | `efce17db97375af414baeffd315fb64d7eb6ddbd10b0f556c956fabb453de00b` |
-| Tests | 670 passing, 0 failing |
+| Built from | `26a1525` |
+| Tarball | `agents-can-communicate-0.0.0.tgz`, 105 KB, 101 entries |
+| sha256 | `b9caa5dc83afd0018481350645b98f0adcee385d382d7dfc2b68ab4305e3de3c` |
+| Tests | 677 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -50,6 +50,11 @@ pass two environment variables nothing has ever set — so on all four native
 clients the documented workflow could not be carried out at all. `acc` now works
 out which session is running it, and stops rather than guessing when two live
 sessions in one checkout both fit.
+
+`acc config init` refuses while sessions are attached. The config carries the
+workspace identity, so writing one moved the project to a different workspace and
+left every running session heartbeating the old one, invisible to everyone and
+not recovering until its client restarted.
 
 Installing edits configuration for four other tools, so uninstall removes the
 entries ACC recorded writing and nothing else. A settings key ACC had to create

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -54,6 +54,7 @@ some sessions in a project and not others.
 
 ## Commands
 
+<!-- test:illustration asks a person to confirm; there is nobody to ask in a test -->
 ```bash
 acc config init        # preview, then write after you agree
 acc config validate    # read-only; reports what applies
@@ -63,6 +64,23 @@ acc config validate    # read-only; reports what applies
 CI job, an agent - there is nobody to ask, so it refuses unless you pass `--yes`. It never
 overwrites an existing config: a committed identity is shared by everyone on the project,
 and replacing it on a mistyped command would split one workspace into two.
+
+### Writing one while sessions are running
+
+The config carries the workspace identity, so writing one moves the project to a new
+workspace. Sessions already attached stay on the old one: they keep heartbeating it, they
+drop off everyone else's roster, and claims they hold stop being seen. They do not recover
+by themselves either - a session attaches when its client starts and at no other point.
+
+So `init` refuses while sessions are attached, and names them:
+
+```text
+2 session(s) are attached here and would stop seeing each other: graphics (claude_code),
+physics (codex). They re-attach only when their client starts, so close them first, or
+pass --force to write anyway.
+```
+
+Close them, or pass `--force` if you mean it — and restart them afterwards.
 
 `validate` only reads. A command someone runs to find out what is wrong must not change
 the thing it is inspecting. With no config present it reports the defaults rather than

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -35,10 +35,10 @@ Not a leak.
 
 ## My write was blocked
 
-Exit code `5`, with the owner named. Ask them, or:
+Exit code `5`, with the owner and the claim id named. Ask them, or:
 
 ```bash
-acc release --claim "$CLAIM" --authority "agreed with models" --reason "handing over"
+acc release --claim claim_x --authority "agreed with models" --reason "handing over"
 ```
 
 ## A claim says `advisory`

--- a/examples/non-git-research.md
+++ b/examples/non-git-research.md
@@ -24,8 +24,7 @@ Writes `acc.workspace.json` with an id that survives a rename.
 ## Divide the work
 
 ```bash
-acc claim --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --resource 'file:notes/sources.md' --reason "collecting sources"
+acc claim --resource 'file:notes/sources.md' --reason "collecting sources"
 ```
 
 The reviewer claims `file:notes/summary.md`. Neither overwrites the other.
@@ -33,8 +32,7 @@ The reviewer claims `file:notes/summary.md`. Neither overwrites the other.
 ## Hand over a finding
 
 ```bash
-acc message --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --to review --subject "Two sources disagree" \
+acc message --to review --subject "Two sources disagree" \
   --body "Fig. 3 vs Table 2 — which do we trust?" --type question --requires-ack
 ```
 

--- a/examples/three-workstreams.md
+++ b/examples/three-workstreams.md
@@ -17,11 +17,9 @@ other.
 ## What each session does
 
 ```bash
-acc work --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --summary "porting the material slots" --mode edit
+acc work --summary "porting the material slots" --mode edit
 
-acc claim --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --resource 'file:packages/core/**' --enforcement guarded --reason "porting"
+acc claim --resource 'file:packages/core/**' --enforcement guarded --reason "porting"
 ```
 
 ## When two want the same thing
@@ -46,7 +44,7 @@ Nobody is in charge. The conflict is surfaced; the humans and agents settle it.
 Any session can answer for the whole workspace:
 
 ```bash
-acc sync --session "$ACC_SESSION" --scope full --json
+acc sync --scope full --json
 ```
 
 "What is physics doing?" is answerable from visual's session. Authority differs;
@@ -55,8 +53,7 @@ knowledge does not.
 ## Ending
 
 ```bash
-acc finish --session "$ACC_SESSION" --generation "$ACC_GENERATION" \
-  --goal "port the material slots" --status partial \
+acc finish --goal "port the material slots" --status partial \
   --completed "slots ported" --remaining "physics review"
 ```
 

--- a/packages/cli/src/args.mjs
+++ b/packages/cli/src/args.mjs
@@ -43,7 +43,7 @@ export const COMMANDS = Object.freeze({
   // The one command with a subcommand. Kept as an explicit list rather than a
   // free positional: `acc config delete` should fail at the parser, not deep
   // inside a handler that has already decided what to do.
-  config: { required: [], optional: [], flags: ["yes"],
+  config: { required: [], optional: [], flags: ["yes", "force"],
     subcommands: ["init", "validate"] },
   install: { required: [], optional: ["adapter", "home"], flags: ["dry-run", "yes"] },
   uninstall: { required: [], optional: ["adapter", "home"], flags: ["yes"] },

--- a/packages/cli/src/config-command.mjs
+++ b/packages/cli/src/config-command.mjs
@@ -48,12 +48,49 @@ async function readConfig(cwd) {
   }
 }
 
-async function initConfig({ cwd, interactive, yes, confirm, ids, displayName }) {
+/**
+ * Sessions that would stop seeing each other the moment this file lands.
+ *
+ * The config carries its own `workspaceId`, so writing one moves the project to
+ * a new workspace. Sessions attached to the old one keep heartbeating it and
+ * vanish from everyone else's roster - measured: `1 live` before, `0 live`
+ * after. They do not recover on their own either: a session re-attaches at
+ * SessionStart and at nothing else, so the client has to be restarted.
+ *
+ * A coordination tool that silently stops coordinating is the worst way for
+ * this to be found, so it is refused unless the caller says to go ahead.
+ */
+async function attachedSessions(probeWorkspace) {
+  if (typeof probeWorkspace !== "function") return [];
+  try {
+    const context = await probeWorkspace();
+    const status = await context.service.collectStatus({});
+    return status.participants.filter(item => item.presence !== "offline");
+  } catch {
+    // Nothing to warn about if the workspace cannot be opened at all - and this
+    // command must still run on a workspace ACC cannot read, which is half of
+    // what it is for.
+    return [];
+  }
+}
+
+async function initConfig({ cwd, interactive, yes, confirm, ids, displayName,
+  force = false, probeWorkspace }) {
   const file = configPathIn(cwd);
   if (await readConfig(cwd) !== null) {
     // A committed identity is shared by everyone on the project. Replacing it
     // on a mistyped command would split one workspace into two.
     throw new AccError(EXIT.CONFLICT, `${CONFIG_FILENAME} already exists`, { file });
+  }
+
+  const attached = await attachedSessions(probeWorkspace);
+  if (attached.length > 0 && !force) {
+    const who = attached.map(item => `${item.participantId} (${item.harness})`).join(", ");
+    throw new AccError(EXIT.CONFLICT,
+      `${attached.length} session(s) are attached here and would stop seeing each `
+      + `other: ${who}. They re-attach only when their client starts, so close them `
+      + "first, or pass --force to write anyway.",
+      { file, sessions: attached.map(item => item.sessionId) });
   }
 
   const preview = renderConfig({ ids, displayName: displayName ?? path.basename(cwd) });
@@ -101,9 +138,11 @@ async function validateConfig({ cwd }) {
  * find out what is wrong must not change the thing it is inspecting.
  */
 export async function runConfigCommand({ subcommand, cwd, interactive = true, yes = false,
-  confirm, displayName, ids = { next: kind => createId(kind) } }) {
+  confirm, displayName, force = false, probeWorkspace,
+  ids = { next: kind => createId(kind) } }) {
   if (subcommand === "init") {
-    return initConfig({ cwd, interactive, yes, confirm, ids, displayName });
+    return initConfig({ cwd, interactive, yes, confirm, ids, displayName,
+      force, probeWorkspace });
   }
   if (subcommand === "validate") return validateConfig({ cwd });
   throw new AccError(EXIT.USAGE, `unknown config subcommand: ${subcommand}`, { subcommand });

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -209,6 +209,11 @@ const HANDLERS = Object.freeze({
       interactive: runtime.stdout?.isTTY === true,
       yes: options.yes === true,
       confirm: runtime.confirm ?? (async () => false),
+      force: options.force === true,
+      // Opened lazily and only by `init`: `config validate` has to work on a
+      // workspace discovery cannot open, which is what a reader runs it to
+      // find out.
+      probeWorkspace: () => openContext(options, runtime),
       ids: runtime.ids });
     if (result.subcommand === "validate") {
       return { data: result, text: result.present

--- a/tests/docs/executable.test.mjs
+++ b/tests/docs/executable.test.mjs
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, readdir, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import { EXIT } from "@agents-can-communicate/protocol";
+
+const run = promisify(execFile);
+const repo = path.resolve(import.meta.dirname, "..", "..");
+
+/**
+ * Every documented command, not the ones someone remembered to mark.
+ *
+ * `commands.test.mjs` runs blocks carrying `<!-- test:command -->`. That is
+ * opt-in, and 18 of the 23 `acc` lines in the documentation had never opted in -
+ * among them every example of the form
+ *
+ *     acc work --session "$ACC_SESSION" --generation "$ACC_GENERATION" ...
+ *
+ * which could not work, because nothing has ever set either variable. It stayed
+ * through four rewrites of the skills and three of the docs. Opting in is what
+ * let it stay: a line nobody marked is a line nobody ran.
+ *
+ * So this runs all of them, and asks the weaker question that every one of them
+ * can be held to: the CLI must *accept* the command. A document may name a task
+ * that does not exist in your workspace - `task_x` is a placeholder and should
+ * be - but it may not name a flag the CLI does not have, or tell a reader to
+ * expand a variable nothing sets.
+ */
+const ILLUSTRATION = /<!-- test:illustration([^>]*)-->/g;
+
+/**
+ * Everything that tells someone what to run - including the four shipped skills.
+ *
+ * A skill is documentation with the highest stakes in the project: it is read by
+ * an agent that cannot ask a follow-up question, and an instruction it cannot
+ * carry out is answered by improvising. One session, finding no `acc`, wrote to
+ * the store by hand and reported the work as coordinated.
+ */
+async function documents() {
+  const files = [path.join(repo, "README.md")];
+  for (const root of ["docs", "examples"]) {
+    for (const entry of await readdir(path.join(repo, root), { withFileTypes: true })) {
+      if (entry.isFile() && entry.name.endsWith(".md")) {
+        files.push(path.join(repo, root, entry.name));
+      }
+    }
+  }
+  for (const entry of await readdir(path.join(repo, "packages"), { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    for (const bundle of ["plugin", "extension"]) {
+      const skill = path.join(repo, "packages", entry.name, bundle, "skills", "acc", "SKILL.md");
+      if (await readFile(skill, "utf8").then(() => true, () => false)) files.push(skill);
+    }
+  }
+  return files;
+}
+
+/** `acc` invocations in bash blocks, with continuations joined and comments cut. */
+function accCommands(text) {
+  const found = [];
+  for (const block of text.matchAll(/(<!-- test:illustration[^>]*-->\s*)?```bash\n([\s\S]*?)```/g)) {
+    if (block[1] !== undefined) continue;
+    const joined = block[2].replace(/\\\n\s*/g, " ");
+    for (const line of joined.split("\n")) {
+      const command = line.replace(/\s+#.*$/, "").trim();
+      // A skill ships `{{ACC}}`, replaced with a real command at install time.
+      // Both forms are instructions someone is meant to run.
+      if (command.startsWith("acc ") || command.startsWith("{{ACC}} ")) found.push(command);
+    }
+  }
+  return found;
+}
+
+/** Split a command line, honouring the quoting the documentation actually uses. */
+function argv(command) {
+  const parts = command.match(/"[^"]*"|'[^']*'|\S+/g) ?? [];
+  return parts.slice(1).map(part => (/^["']/.test(part) ? part.slice(1, -1) : part));
+}
+
+/**
+ * A sandbox with a session already attached, because that is the situation the
+ * documentation describes. Attached through the hook runtime rather than `acc
+ * attach`, so what the commands resolve against is what a real client leaves
+ * behind.
+ */
+async function sandbox(t) {
+  const home = await realpath(await mkdtemp(path.join(tmpdir(), "acc-exec-home-")));
+  const cwd = await realpath(await mkdtemp(path.join(tmpdir(), "acc-exec-cwd-")));
+  const dataHome = await realpath(await mkdtemp(path.join(tmpdir(), "acc-exec-data-")));
+  t.after(() => Promise.all([home, cwd, dataHome]
+    .map(dir => rm(dir, { recursive: true, force: true }))));
+  const env = { ...process.env, HOME: home, ACC_DATA_HOME: dataHome,
+    GIT_DIR: "", GIT_WORK_TREE: "" };
+
+  const child = run(process.execPath, [path.join(repo, "bin", "acc-hook.mjs"), "codex"],
+    { env: { ...env, ACC_PARTICIPANT: "reader" } });
+  child.child.stdin.end(JSON.stringify({ hook_event_name: "SessionStart",
+    session_id: "docs-reader", cwd, source: "startup" }));
+  await child;
+  return { home, cwd, dataHome, env };
+}
+
+test("every documented acc command is one the CLI accepts", async t => {
+  const rejected = [];
+  let checked = 0;
+
+  for (const file of await documents()) {
+    const commands = accCommands(await readFile(file, "utf8"));
+    if (commands.length === 0) continue;
+    // One sandbox per document, because a document is what a reader follows.
+    // Sharing one made `acc finish` in the CLI reference close the session that
+    // every later document's commands then failed to find.
+    const place = await sandbox(t);
+    for (const command of commands) {
+      checked += 1;
+      const parts = argv(command);
+      const result = await run(process.execPath,
+        [path.join(repo, "bin", "acc.mjs"), ...parts, "--cwd", place.cwd,
+          ...(parts.includes("--json") ? [] : ["--json"])],
+        { env: place.env })
+        .then(() => ({ code: 0 }), error => ({ code: error.code, stdout: error.stdout ?? "" }));
+      // Exit 2 is the parser refusing: an option that does not exist, a value
+      // missing, a required argument absent. Anything deeper is the command
+      // working on a workspace this sandbox does not have, which is fine.
+      if (result.code === EXIT.USAGE) {
+        const reported = JSON.parse(result.stdout || "{}").error?.message ?? "";
+        rejected.push(`${path.relative(repo, file)}: ${command}\n    ${reported}`);
+      }
+    }
+  }
+
+  assert.equal(checked > 15, true, `only ${checked} documented commands were found`);
+  assert.deepEqual(rejected, [],
+    `documentation tells a reader to run something the CLI refuses:\n  ${rejected.join("\n  ")}`);
+});
+
+/**
+ * A `$VAR` in a documented command is a promise that something sets it.
+ *
+ * `$ACC_SESSION` was in seven files for months. It reads exactly like a variable
+ * the runtime provides, and nothing has ever provided it - and the gate above
+ * cannot catch it, because a command carrying an unexpanded variable is still a
+ * command the parser accepts. Neither can a reader: `$CLAIM` next to it was a
+ * placeholder for a value they were meant to type, and the two look identical.
+ *
+ * So the documentation does not use `$VAR` for a value the reader supplies. It
+ * uses a visibly false literal - `task_x`, `claim_x` - the way the rest of it
+ * already did.
+ */
+const EXPORTED = Object.freeze(new Set(["HOME", "PATH", "ACC_DATA_HOME", "ACC_PARTICIPANT"]));
+
+test("no documented command expands a variable nothing sets", async () => {
+  const unset = [];
+  for (const file of await documents()) {
+    const text = await readFile(file, "utf8");
+    for (const block of text.matchAll(/```bash\n([\s\S]*?)```/g)) {
+      const body = block[1];
+      const assigned = new Set([...body.matchAll(/^\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=/gm)]
+        .map(match => match[1]));
+      for (const command of accCommands(`\`\`\`bash\n${body}\`\`\``)) {
+        for (const [, name] of command.matchAll(/\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?/g)) {
+          if (assigned.has(name) || EXPORTED.has(name)) continue;
+          unset.push(`${path.relative(repo, file)}: $${name} in \`${command}\``);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(unset, [],
+    "documentation expands a variable that is neither set in the block nor by the runtime");
+});
+
+test("a block excused from running says so in the document", async () => {
+  // The excuse is a decision, visible in the file being read, rather than the
+  // absence of a marker somewhere else. Anything opted out has to be worth
+  // opting out - so this fails if the escape hatch starts carrying the load.
+  let illustrations = 0;
+  for (const file of await documents()) {
+    const text = await readFile(file, "utf8");
+    for (const [, reason] of text.matchAll(ILLUSTRATION)) {
+      illustrations += 1;
+      assert.notEqual(reason.trim(), "",
+        `${path.relative(repo, file)} excuses a block from running without saying why`);
+    }
+  }
+  assert.equal(illustrations <= 2, true,
+    `${illustrations} blocks are excused from running; the marker is becoming the rule`);
+});

--- a/tests/process/config-identity.test.mjs
+++ b/tests/process/config-identity.test.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import { EXIT } from "@agents-can-communicate/protocol";
+
+const run = promisify(execFile);
+const repo = path.resolve(import.meta.dirname, "..", "..");
+const acc = path.join(repo, "bin", "acc.mjs");
+const hook = path.join(repo, "bin", "acc-hook.mjs");
+
+/**
+ * Writing a workspace config decouples everyone already in the workspace.
+ *
+ * The config carries its own `workspaceId`, which is the point: an identity that
+ * survives the directory being moved or cloned. The cost is that writing one
+ * moves the project to a *different* workspace, and sessions attached to the old
+ * one go on heartbeating it. Measured before this refused: `1 live` before `acc
+ * config init`, `0 live` after, with the session still running.
+ *
+ * Nothing recovers on its own. A session attaches at SessionStart and at no
+ * other event; the next turn finds no binding for the new workspace and returns
+ * empty. So the agents keep working, keep believing they are coordinating, and
+ * are invisible to each other until their clients restart - which is the worst
+ * possible failure for a tool whose whole job is that they are not.
+ */
+async function attached(t, { sessions }) {
+  const root = await realpath(await mkdtemp(path.join(tmpdir(), "acc-config-")));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const project = path.join(root, "project");
+  await run("mkdir", ["-p", project]);
+  const env = { ...process.env, ACC_DATA_HOME: path.join(root, "data"),
+    GIT_DIR: "", GIT_WORK_TREE: "" };
+
+  for (const { participant, harness } of sessions) {
+    const child = run("node", [hook, harness],
+      { env: { ...env, ACC_PARTICIPANT: participant } });
+    child.child.stdin.end(JSON.stringify({ hook_event_name: "SessionStart",
+      session_id: `h-${participant}`, cwd: project, source: "startup" }));
+    await child;
+  }
+  const cli = args => run("node", [acc, ...args, "--cwd", project], { env });
+  const live = async () => JSON.parse(
+    (await cli(["status", "--json"])).stdout).data.counts.live;
+  return { project, cli, live };
+}
+
+test("init refuses while sessions are attached, and names them", async t => {
+  const { cli, live } = await attached(t, { sessions: [
+    { participant: "graphics", harness: "claude_code" },
+    { participant: "physics", harness: "codex" }] });
+  assert.equal(await live(), 2);
+
+  const failure = await cli(["config", "init", "--yes"]).then(() => null, error => error);
+
+  assert.notEqual(failure, null, "it wrote the config and orphaned two live sessions");
+  assert.equal(failure.code, EXIT.CONFLICT);
+  assert.match(failure.stderr, /2 session\(s\) are attached here/);
+  assert.match(failure.stderr, /graphics \(claude_code\)/);
+  assert.match(failure.stderr, /physics \(codex\)/);
+  // `--yes` answers "may I write this file", which is not the question here.
+  assert.equal(await live(), 2, "the workspace moved anyway");
+});
+
+test("--force writes it, because sometimes that is what you mean", async t => {
+  const { cli, live } = await attached(t,
+    { sessions: [{ participant: "solo", harness: "codex" }] });
+
+  const { stdout } = await cli(["config", "init", "--yes", "--force"]);
+
+  assert.match(stdout, /acc\.workspace\.json/);
+  // The consequence is real and is now the caller's decision rather than a
+  // surprise: this is the number the refusal exists to protect.
+  assert.equal(await live(), 0);
+});
+
+test("with nobody attached it writes without ceremony", async t => {
+  const { cli } = await attached(t, { sessions: [] });
+
+  const { stdout } = await cli(["config", "init", "--yes"]);
+
+  assert.match(stdout, /acc\.workspace\.json/);
+});
+
+test("validate still works where the workspace cannot be opened", async t => {
+  const { cli } = await attached(t, { sessions: [] });
+
+  // The probe `init` uses must not become a precondition of the command a
+  // reader runs precisely because something is wrong.
+  const { stdout } = await cli(["config", "validate", "--json"]);
+
+  assert.equal(JSON.parse(stdout).ok, true);
+});


### PR DESCRIPTION
Two findings, both from running what the documentation says rather than reading it.

## `acc config init` silently decoupled every attached session

The config carries its own `workspaceId` — that is the point of it, an identity that survives the directory being moved or cloned. The cost was never handled: writing one moves the project to a **different** workspace, and sessions attached to the old one keep heartbeating it.

Measured, with the session still running:

```
before config init: 1 live; 0 claim(s); protection none
wrote /tmp/…/acc.workspace.json
after  config init: 0 live; 0 claim(s); protection none
```

It does not heal, either. A session attaches at `SessionStart` and at no other event, so the next turn finds no binding for the new workspace and returns empty. The agents go on working, go on believing they are coordinating, and are invisible to each other until their clients restart — the worst available failure for a tool whose whole job is that they are not.

`init` now refuses while sessions are attached and names them:

```
2 session(s) are attached here and would stop seeing each other: graphics (claude_code),
physics (codex). They re-attach only when their client starts, so close them first, or
pass --force to write anyway.
```

`--yes` does not cover this: it answers "may I write this file", which is not the question. `--force` is for someone who means it.

## The documentation's own test was opt-in

`commands.test.mjs` runs blocks marked `<!-- test:command -->`. **18 of the 23 `acc` lines in the docs had never opted in** — among them every `--session "$ACC_SESSION"` example. That is how a phantom variable survived four rewrites of the skills and three of the docs: a line nobody marked is a line nobody ran.

`tests/docs/executable.test.mjs` runs all of them, plus the four shipped skills — **65 commands**, against a sandbox with a session attached the way a real client attaches one, one sandbox per document (sharing one made `acc finish` in the CLI reference close the session every later document then failed to find). A command may fail on its subject — `task_x` is a placeholder and should be — but the CLI must accept its shape.

### And a second gate, because the first is not enough

That gate alone would **not** have caught `$ACC_SESSION`: a command carrying an unexpanded variable still parses, so it is accepted. Verified by putting the old form back:

```
✔ every documented acc command is one the CLI accepts     <- passes anyway
✖ no documented command expands a variable nothing sets
  + 'docs/CLI.md: $ACC_SESSION in `acc task --session "$ACC_SESSION" …`'
```

So a `$VAR` in a documented command must be assigned in the same block or exported by the runtime. `$CLAIM` in the troubleshooting guide was the same shape — a placeholder for a value the reader types — and is now `claim_x`, matching the visibly-false literals the rest of the documentation already used. A reader cannot tell those two apart by looking, which is exactly how one of them went unnoticed.

`examples/` still carried `$ACC_SESSION`: the earlier sweep and its gate covered `packages/` and `docs/` and missed the directory.

## Verification

- 677 tests passing, 0 failing · `syntax ok in 148 file(s)`
- Both new suites proven by mutation: the config tests fail against `main`, and the variable gate fails the moment the old form is restored.
- `PASS … sha256 b9caa5dc…e3de3c built from 26a1525`
