### PR TITLE
fix: guard a claim by where the file is, not where a process started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `26a1525` |
+| Built from | `6a94e9a` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 105 KB, 101 entries |
-| sha256 | `b9caa5dc83afd0018481350645b98f0adcee385d382d7dfc2b68ab4305e3de3c` |
-| Tests | 677 passing, 0 failing |
+| sha256 | `d4347217a21e9f3551043e2060950e7a664b99ddd0827f02ecdb4d4fa449d1cc` |
+| Tests | 682 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -40,9 +40,13 @@ block, and its receipt advances to `injected` only for what the turn actually
 carried — a message the context budget could not fit stays queued rather than
 telling the sender it landed. The ceiling is `policy.contextBudgetBytes`.
 
-Claims are enforced however the workspace path is spelled. A project reached
-through a symlink — `/tmp` and `/var` on macOS, a symlinked checkout anywhere —
-used to pass every write through while still reporting `protection guarded`.
+Claims are enforced however the workspace path is spelled, and wherever the
+client starts its hooks. A project reached through a symlink — `/tmp` and `/var`
+on macOS, a symlinked checkout anywhere — used to pass every write through while
+still reporting `protection guarded`. So did a relative target when the hook
+process began somewhere other than the session's own directory, and so did a file
+named from a subdirectory of the project, which gave one file two names. A claim
+taken in one worktree stops a write in another worktree of the same repository.
 
 An agent can run the commands its skill teaches. Every mutating command took a
 session id and a generation on the command line, and the skills told agents to

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -75,6 +75,12 @@ graph TB
 a write. The two are deliberately separate: announcing that you are editing is cheap and
 constant; reserving a resource is a commitment other sessions are held to.
 
+A file resource is named relative to the **repository**, not to wherever a session happens
+to have been started: `file:src/physics.mjs` means one file in the project, whether the
+agent that names it opened at the root, in `src/`, or in another worktree of the same
+repository. One name for one file is what makes a claim mean anything — two agents calling
+it two things is the same as no claim at all.
+
 ## When coordination starts
 
 ```mermaid

--- a/packages/hook-runner/src/runner.mjs
+++ b/packages/hook-runner/src/runner.mjs
@@ -55,20 +55,29 @@ export function resourceFor(root, target) {
  * what would create it. So the deepest existing ancestor is resolved and the
  * remainder appended, which is also what keeps this from following a symlink
  * the write itself would replace.
+ *
+ * A relative target is resolved against `base` - the session's own cwd, as the
+ * payload states it - and never against this process's. A hook is a child whose
+ * working directory belongs to the client, and Codex's `apply_patch` names its
+ * files relative to the session. Resolving those against wherever the hook
+ * happened to start sent them outside the workspace, `resourceFor` returned
+ * null, and every write was allowed while `acc status` said `protection
+ * guarded`. It only ever worked because a client usually starts hooks in the
+ * project directory - and "usually" is what made it invisible.
  */
-export async function canonicalTarget(realpath, target) {
-  let current = path.resolve(target);
+export async function canonicalTarget(realpath, target, base = process.cwd()) {
+  let current = path.resolve(base, target);
   const trailing = [];
   for (;;) {
     try {
       return path.join(await realpath(current), ...trailing);
     } catch (error) {
-      if (error.code !== "ENOENT" && error.code !== "ENOTDIR") return path.resolve(target);
+      if (error.code !== "ENOENT" && error.code !== "ENOTDIR") return path.resolve(base, target);
       const parent = path.dirname(current);
       // Reached the filesystem root without finding anything that exists. The
       // unresolved path is the best answer available, and `resourceFor` will
       // reject it if it is outside the workspace.
-      if (parent === current) return path.resolve(target);
+      if (parent === current) return path.resolve(base, target);
       trailing.unshift(path.basename(current));
       current = parent;
     }
@@ -248,9 +257,20 @@ const HANDLERS = {
 
     const status = await context.service.collectStatus({
       workspaceId: context.descriptor.id });
-    const root = context.descriptor.roots[0];
+    // Anchored to the repository, not to wherever this session was started. A
+    // session opened in `repo/src` relativised the same file to
+    // `file:physics.mjs` where one at `repo` called it `file:src/physics.mjs`,
+    // so a claim on either did not cover the other and both agents edited it
+    // freely. Repository-relative is also the convention every documented claim
+    // already uses - `file:packages/core/**` means one thing in a project.
+    //
+    // A declared config is the exception: its roots are the stated boundary, and
+    // they may deliberately not be the checkout.
+    const root = context.descriptor.source === "git" && context.descriptor.git !== undefined
+      ? context.descriptor.git.worktreeRoot
+      : context.descriptor.roots[0];
     const resolved = await Promise.all(event.targets
-      .map(target => canonicalTarget(context.realpath, target)));
+      .map(target => canonicalTarget(context.realpath, target, event.cwd)));
     const wanted = resolved
       .map(target => resourceFor(root, target))
       .filter(resource => resource !== null);

--- a/tests/security/relative-targets.test.mjs
+++ b/tests/security/relative-targets.test.mjs
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+const repo = path.resolve(import.meta.dirname, "..", "..");
+const acc = path.join(repo, "bin", "acc.mjs");
+const hook = path.join(repo, "bin", "acc-hook.mjs");
+
+/**
+ * A guard that reports guarding and allows every write.
+ *
+ * A hook is a child process, and its working directory belongs to the client
+ * that spawned it. Relative targets were resolved against *that* directory
+ * instead of the session's own, which the payload states. Codex's `apply_patch`
+ * names its files relative to the session, so those paths landed outside the
+ * workspace, `resourceFor` returned null, the target list emptied, and every
+ * write went through while `acc status` said `protection guarded`.
+ *
+ * It worked whenever a client happened to start its hooks in the project
+ * directory, which is most of the time - and that is what kept it invisible.
+ * Measured on the same claim, changing nothing but where the hook process
+ * started: `exit 0` from one directory, `exit 2` from the other.
+ */
+async function repository(t) {
+  const base = await realpath(await mkdtemp(path.join(tmpdir(), "acc-relative-")));
+  t.after(() => rm(base, { recursive: true, force: true }));
+  const env = { ...process.env, ACC_DATA_HOME: path.join(base, "data"),
+    GIT_DIR: "", GIT_WORK_TREE: "" };
+  const bare = { ...process.env };
+  for (const name of ["GIT_DIR", "GIT_WORK_TREE"]) delete bare[name];
+  const git = (...argv) => run("git", argv, { env: bare });
+
+  const main = path.join(base, "repo");
+  await git("-c", "init.defaultBranch=main", "init", "-q", main);
+  await writeFile(path.join(main, "physics.mjs"), "export const y = 0;\n");
+  await git("-C", main, "add", "-A");
+  await git("-C", main, "-c", "user.email=a@b", "-c", "user.name=t",
+    "commit", "-q", "-m", "init");
+  const worktrees = {};
+  for (const branch of ["graphics", "physics"]) {
+    worktrees[branch] = path.join(base, "trees", branch);
+    await git("-C", main, "worktree", "add", "-q", worktrees[branch], "-b", branch);
+  }
+  return { base, main, worktrees, env };
+}
+
+async function attach({ env }, participant, cwd) {
+  const child = run(process.execPath, [hook, "codex"],
+    { env: { ...env, ACC_PARTICIPANT: participant } });
+  child.child.stdin.end(JSON.stringify({ hook_event_name: "SessionStart",
+    session_id: participant, cwd, source: "startup" }));
+  await child;
+}
+
+/** A Codex `apply_patch`, whose targets are relative to the session. */
+function patch(session, cwd, file) {
+  return JSON.stringify({ hook_event_name: "PreToolUse", session_id: session, cwd,
+    tool_name: "apply_patch",
+    tool_input: { command: `*** Begin Patch\n*** Update File: ${file}\n@@\n-a\n+b\n`
+      + "*** End Patch" } });
+}
+
+/** Run the guard with the hook process started in `from`, whatever that is. */
+async function guard({ env }, { session, cwd, file, from }) {
+  const child = run(process.execPath, [hook, "codex"],
+    { env: { ...env, ACC_PARTICIPANT: session }, cwd: from });
+  child.child.stdin.end(patch(session, cwd, file));
+  return child.then(() => ({ decision: "allow", exitCode: 0 }),
+    error => ({ decision: "deny", exitCode: error.code, stderr: error.stderr }));
+}
+
+const claim = ({ env }, cwd, resource) => run(process.execPath,
+  [acc, "claim", "--resource", resource, "--enforcement", "guarded",
+    "--reason", "editing", "--cwd", cwd], { env });
+
+test("a claim is enforced wherever the hook process happens to start", async t => {
+  const place = await repository(t);
+  await attach(place, "graphics", place.worktrees.graphics);
+  await attach(place, "physics", place.worktrees.physics);
+  await claim(place, place.worktrees.graphics, "file:physics.mjs");
+
+  // The client's cwd for the hook is not the session's. Nothing about the claim
+  // changes; only where this process was started.
+  const elsewhere = await guard(place, { session: "physics",
+    cwd: place.worktrees.physics, file: "physics.mjs", from: place.base });
+
+  assert.equal(elsewhere.decision, "deny",
+    "the write was allowed, and status would still have said `protection guarded`");
+  assert.equal(elsewhere.exitCode, 2);
+  assert.match(elsewhere.stderr, /claimed by graphics/);
+});
+
+test("one worktree's claim reaches an agent in another", async t => {
+  const place = await repository(t);
+  await attach(place, "graphics", place.worktrees.graphics);
+  await attach(place, "physics", place.worktrees.physics);
+  await claim(place, place.worktrees.graphics, "file:physics.mjs");
+
+  // Every worktree of a repository is one workspace, so a claim spans them. The
+  // agents are in different directories on different branches; the file they
+  // would both edit is the same file in the project, and one of them said so.
+  const other = await guard(place, { session: "physics",
+    cwd: place.worktrees.physics, file: "physics.mjs", from: place.worktrees.physics });
+
+  assert.equal(other.decision, "deny");
+  assert.match(other.stderr, /claimed by graphics/);
+});
+
+test("the claim holder is not blocked from its own claim", async t => {
+  const place = await repository(t);
+  await attach(place, "graphics", place.worktrees.graphics);
+  await claim(place, place.worktrees.graphics, "file:physics.mjs");
+
+  const own = await guard(place, { session: "graphics",
+    cwd: place.worktrees.graphics, file: "physics.mjs", from: place.base });
+
+  assert.equal(own.decision, "allow");
+});
+
+test("a session started in a subdirectory shares one name for one file", async t => {
+  const place = await repository(t);
+  const inner = path.join(place.worktrees.graphics, "src");
+  await run("mkdir", ["-p", inner]);
+  await attach(place, "graphics", place.worktrees.graphics);
+  // Claimed before the second session exists: both are in this checkout, and
+  // `acc` refuses to guess which of two live sessions is calling it.
+  await claim(place, place.worktrees.graphics, "file:src/physics.mjs");
+  await attach(place, "deep", inner);
+
+  // `deep` calls it `physics.mjs`, `graphics` calls it `src/physics.mjs`, and it
+  // is one file. Relativising to each session's own directory gave it two names
+  // and a claim on either covered neither.
+  const below = await guard(place, { session: "deep", cwd: inner,
+    file: "physics.mjs", from: place.base });
+
+  assert.equal(below.decision, "deny",
+    "the same file has two names, so a claim on it protects nothing");
+  assert.match(below.stderr, /claimed by graphics/);
+});
+
+test("a write outside the claim still goes through", async t => {
+  const place = await repository(t);
+  await attach(place, "graphics", place.worktrees.graphics);
+  await attach(place, "physics", place.worktrees.physics);
+  await claim(place, place.worktrees.graphics, "file:physics.mjs");
+
+  // A guard observed only denying proves as little as one observed only
+  // allowing: either alone is consistent with a guard that is simply stuck.
+  const unrelated = await guard(place, { session: "physics",
+    cwd: place.worktrees.physics, file: "render.mjs", from: place.base });
+
+  assert.equal(unrelated.decision, "allow");
+});


### PR DESCRIPTION
Two ways a **guarded** claim protected nothing while `acc status` reported `protection guarded`. Both are the shape of the symlink defect: the guard says it is guarding, and every write goes through.

## 1. Relative targets were resolved against the hook process's directory

A hook is a child process whose working directory belongs to the client that spawned it. Codex's `apply_patch` names its files **relative to the session** — so those paths were resolved against wherever the hook happened to start, landed outside the workspace, `resourceFor` returned `null`, the target list emptied, and the write was allowed.

Measured on one live claim, changing nothing but the hook process's own directory:

```
--- hook process started somewhere else:
exit 0

--- hook process started in the session's own worktree:
file:src/physics.mjs is claimed by graphics (session session_31mKrLo79DCUbWuP8nTX9A)
exit 2
```

It worked whenever a client happened to start hooks in the project directory — which is most of the time, and is exactly what kept it invisible.

## 2. Resources were named relative to each session's own directory

A session opened in `repo/src` called the file `physics.mjs`; one at `repo` called the same file `src/physics.mjs`. Two names for one file, so a claim on either covered neither and both agents edited it freely.

File resources are now repository-relative, which is the convention every documented claim already used — `file:packages/core/**` means one thing in a project. A declared config is left alone: its roots are the stated boundary and may deliberately not be the checkout.

## What is pinned

`tests/security/relative-targets.test.mjs`, five tests, driving the real hook binary against a real repository with two worktrees:

| | |
|---|---|
| a claim is enforced wherever the hook process happens to start | **fails on `main`** |
| a session started in a subdirectory shares one name for one file | **fails on `main`** |
| one worktree's claim reaches an agent in another | the worktree promise, never measured until now |
| the claim holder is not blocked from its own claim | a guard observed only denying proves as little as one observed only allowing |
| a write outside the claim still goes through | as above |

## Verification

- 682 tests passing, 0 failing · `syntax ok in 149 file(s)`
- Both defects reproduce on `main` and pass here
- `PASS … sha256 d4347217…49d1cc built from 6a94e9a`
