### PR TITLE
fix: one name for one file, on the claim side too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `6a94e9a` |
-| Tarball | `agents-can-communicate-0.0.0.tgz`, 105 KB, 101 entries |
-| sha256 | `d4347217a21e9f3551043e2060950e7a664b99ddd0827f02ecdb4d4fa449d1cc` |
-| Tests | 682 passing, 0 failing |
+| Built from | `9fd4542` |
+| Tarball | `agents-can-communicate-0.0.0.tgz`, 107 KB, 103 entries |
+| sha256 | `0d46d8b54b28e1f7c87965438f4143cfd1c236d62c715d461a066677deb21048` |
+| Tests | 689 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -81,6 +81,12 @@ agent that names it opened at the root, in `src/`, or in another worktree of the
 repository. One name for one file is what makes a claim mean anything — two agents calling
 it two things is the same as no claim at all.
 
+The spelling is settled for you. `./src/a.mjs`, `src//a.mjs` and `src/x/../a.mjs` are
+stored as `file:src/a.mjs`, and letter case is resolved by asking the filesystem rather
+than by a rule: where `src/A.mjs` and `src/a.mjs` are one file they become one resource,
+and where they are two files they stay two. `acc claim` echoes back the name it stored,
+which is the name peers will see.
+
 ## When coordination starts
 
 ```mermaid

--- a/packages/cli/src/claim-spelling.mjs
+++ b/packages/cli/src/claim-spelling.mjs
@@ -1,0 +1,66 @@
+import { realpath } from "node:fs/promises";
+import path from "node:path";
+
+import { normaliseResource } from "@agents-can-communicate/protocol";
+
+/**
+ * The spelling the filesystem itself uses.
+ *
+ * `normaliseResource` settles `./`, `//` and `..`, which is all a string can
+ * settle. Letter case it cannot: on the filesystem this project is certified on,
+ * `src/Physics.mjs` and `src/physics.mjs` are the same file, and a claim on one
+ * did not cover a write to the other. Measured - the claim was taken, `acc
+ * status` said `protection guarded`, and the write went through.
+ *
+ * Asking the filesystem answers it on both kinds of machine at once, with no
+ * case rule anywhere: macOS `realpath` returns the name as stored, so both
+ * spellings arrive at the same resource, and on Linux they are genuinely two
+ * files and stay two resources. The guard canonicalises its targets the same
+ * way, so the two sides meet.
+ *
+ * The path usually does not exist yet - claiming before creating is the point -
+ * so the deepest existing ancestor is resolved and the rest appended.
+ */
+async function onDisk(absolute) {
+  let current = absolute;
+  const trailing = [];
+  for (;;) {
+    try {
+      return path.join(await realpath(current), ...trailing);
+    } catch (error) {
+      if (error.code !== "ENOENT" && error.code !== "ENOTDIR") return absolute;
+      const parent = path.dirname(current);
+      if (parent === current) return absolute;
+      trailing.unshift(path.basename(current));
+      current = parent;
+    }
+  }
+}
+
+const GLOB = "/**";
+
+/**
+ * A `file:` claim, spelled the way the project spells it. Anything the
+ * filesystem cannot answer for - another scheme, a path outside the workspace -
+ * comes back as it went in rather than being invented into something else.
+ */
+export async function canonicalClaim(resource, descriptor) {
+  const normalised = normaliseResource(resource);
+  if (typeof normalised !== "string" || !normalised.startsWith("file:")) return normalised;
+  const root = descriptor?.source === "git" && descriptor.git !== undefined
+    ? descriptor.git.worktreeRoot
+    : descriptor?.roots?.[0];
+  if (typeof root !== "string") return normalised;
+
+  const rest = normalised.slice("file:".length);
+  const glob = rest.endsWith(GLOB);
+  const body = glob ? rest.slice(0, -GLOB.length) : rest;
+  if (body === "") return normalised;
+
+  const resolved = await onDisk(path.resolve(root, body));
+  const relative = path.relative(await onDisk(root), resolved);
+  if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+    return normalised;
+  }
+  return `file:${relative.split(path.sep).join("/")}${glob ? GLOB : ""}`;
+}

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -12,6 +12,7 @@ import { runConfigCommand } from "./config-command.mjs";
 import { runInstallCommand } from "./install-command.mjs";
 import { runDoctor } from "./doctor-command.mjs";
 import { createGitProbe } from "./git-probe.mjs";
+import { canonicalClaim } from "./claim-spelling.mjs";
 import { platformDataHome, runtimePaths } from "./runtime-paths.mjs";
 import { resolveOwner } from "./session-owner.mjs";
 import { discoverWorkspace } from "./workspace-discovery.mjs";
@@ -99,7 +100,8 @@ const HANDLERS = Object.freeze({
 
   claim: async ({ options, context }) => {
     const claim = await context.service.acquireClaim({ sessionId: options.session,
-      generation: options.generation, resource: options.resource,
+      generation: options.generation,
+      resource: await canonicalClaim(options.resource, context.descriptor),
       mode: options.mode ?? "exclusive", enforcement: options.enforcement ?? "advisory",
       reason: options.reason ?? "unspecified",
       leaseSeconds: options.lease ? positiveNumber(options.lease, "lease") : undefined,

--- a/packages/core/src/claims.mjs
+++ b/packages/core/src/claims.mjs
@@ -1,4 +1,4 @@
-import { AccError, EXIT, SCHEMA_VERSION, createId, validateRecord }
+import { AccError, EXIT, SCHEMA_VERSION, createId, normaliseResource, validateRecord }
   from "@agents-can-communicate/protocol";
 
 import { ensureMaterialised } from "./materialisation.mjs";
@@ -65,6 +65,9 @@ export function createClaimService(ports, sessions) {
 
   async function acquireClaim(input) {
     const session = await requireOwner(input, "claim");
+    // One name for one file, decided here rather than at each surface, so a
+    // claim taken over MCP and one taken from the CLI mean the same thing.
+    const resource = normaliseResource(input.resource);
     const workspaceId = session.workspaceId;
     await ensureMaterialised(ports, { workspaceId, descriptor: input.descriptor,
       reason: "durable_object" });
@@ -77,8 +80,8 @@ export function createClaimService(ports, sessions) {
     await store.transaction(async tx => {
       const live = tx.list("claim", claim => isLive(claim, now));
       const mine = live.find(claim => claim.ownerSessionId === session.sessionId
-        && claim.resource === input.resource);
-      const blocking = live.find(claim => overlaps(claim.resource, input.resource)
+        && claim.resource === resource);
+      const blocking = live.find(claim => overlaps(claim.resource, resource)
         && claim.ownerSessionId !== session.sessionId
         && (claim.mode === "exclusive" || input.mode === "exclusive"));
       if (blocking !== undefined) throw conflictWith(blocking, session, now, snapshot.sessions);
@@ -89,7 +92,7 @@ export function createClaimService(ports, sessions) {
         claimId,
         workspaceId,
         ownerSessionId: session.sessionId,
-        resource: input.resource,
+        resource,
         mode: input.mode ?? "exclusive",
         enforcement: input.enforcement ?? "advisory",
         reason: input.reason,
@@ -101,7 +104,7 @@ export function createClaimService(ports, sessions) {
       tx.append({ schemaVersion: SCHEMA_VERSION, eventId: ids.next("event"), workspaceId,
         actorSessionId: session.sessionId, type: mine === undefined ? "claim.acquired"
           : "claim.renewed", occurredAt: now,
-        payload: { claimId, resource: input.resource, mode: record.mode } });
+        payload: { claimId, resource, mode: record.mode } });
     });
     return record;
   }

--- a/packages/protocol/src/index.mjs
+++ b/packages/protocol/src/index.mjs
@@ -6,3 +6,4 @@ export { RECORD_KINDS, SCHEMA_VERSION, validateRecord } from "./schema.mjs";
 export { CONFIG_FILENAME, CONFIG_SCHEMA_VERSION, RUNTIME_KEYS, defaultProjectConfig,
   validateProjectConfig } from "./config.mjs";
 export { DELIVERY_STATES, TASK_STATES, advanceDelivery, transitionTask } from "./states.mjs";
+export { normaliseResource } from "./resources.mjs";

--- a/packages/protocol/src/resources.mjs
+++ b/packages/protocol/src/resources.mjs
@@ -1,0 +1,48 @@
+/**
+ * One name for one file.
+ *
+ * A claim is a string, and a file has many spellings: `src/a.mjs`,
+ * `./src/a.mjs`, `src//a.mjs`, `src/x/../a.mjs`. All four name the same file and
+ * none of them matched the others, so a claim written one way protected nothing
+ * against a write spelled another - the claim was taken, `acc status` reported
+ * `protection guarded`, and the write went through.
+ *
+ * Only the path part of a `file:` resource is touched. Other schemes are opaque
+ * identifiers, and rewriting one would be inventing meaning ACC does not have.
+ * A trailing `/**` is a glob and is preserved: the segments before it are
+ * normalised, the marker is put back.
+ */
+const GLOB = "/**";
+
+function normalisePath(value) {
+  const segments = [];
+  for (const segment of value.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    // `..` climbing past the start is kept, not swallowed: the result would name
+    // something outside the workspace, and a resource that cannot be relativised
+    // must stay visibly wrong rather than quietly become a different file.
+    if (segment === ".." && segments.length > 0 && segments.at(-1) !== "..") {
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  return segments.join("/");
+}
+
+export function normaliseResource(resource) {
+  if (typeof resource !== "string") return resource;
+  const colon = resource.indexOf(":");
+  if (colon === -1 || resource.slice(0, colon) !== "file") return resource;
+
+  const rest = resource.slice(colon + 1);
+  const glob = rest.endsWith(GLOB);
+  const body = glob ? rest.slice(0, -GLOB.length) : rest;
+  // An absolute path keeps its leading slash: it names a different thing from
+  // the relative path with the same spelling, and pretending otherwise would
+  // merge two resources that are not the same.
+  const absolute = body.startsWith("/");
+  const normalised = normalisePath(body);
+  if (normalised === "" && !glob) return resource;
+  return `file:${absolute ? "/" : ""}${normalised}${glob ? GLOB : ""}`;
+}

--- a/tests/security/claim-spelling.test.mjs
+++ b/tests/security/claim-spelling.test.mjs
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+const repo = path.resolve(import.meta.dirname, "..", "..");
+const acc = path.join(repo, "bin", "acc.mjs");
+const hook = path.join(repo, "bin", "acc-hook.mjs");
+
+/**
+ * A claim is a string, and a file has many spellings.
+ *
+ * `src/a.mjs`, `./src/a.mjs`, `src//a.mjs`, `src/x/../a.mjs` name one file, and
+ * on the filesystem this project is certified on so does `src/A.mjs`. None of
+ * them matched the others. The claim was taken, `acc status` reported
+ * `protection guarded`, and the write went through - the same silent-allow as
+ * the symlink and the relative-target defects, arrived at from the claim side
+ * instead of the target side.
+ */
+async function project(t) {
+  const base = await realpath(await mkdtemp(path.join(tmpdir(), "acc-spelling-")));
+  t.after(() => rm(base, { recursive: true, force: true }));
+  const env = { ...process.env, ACC_DATA_HOME: path.join(base, "data"),
+    GIT_DIR: "", GIT_WORK_TREE: "" };
+  const bare = { ...process.env };
+  for (const name of ["GIT_DIR", "GIT_WORK_TREE"]) delete bare[name];
+
+  const root = path.join(base, "repo");
+  await run("mkdir", ["-p", path.join(root, "src")]);
+  await writeFile(path.join(root, "src", "physics.mjs"), "export const y = 0;\n");
+  await run("git", ["-c", "init.defaultBranch=main", "init", "-q", root], { env: bare });
+  await run("git", ["-C", root, "add", "-A"], { env: bare });
+  await run("git", ["-C", root, "-c", "user.email=a@b", "-c", "user.name=t",
+    "commit", "-q", "-m", "init"], { env: bare });
+
+  for (const participant of ["holder", "writer"]) {
+    const child = run(process.execPath, [hook, "codex"],
+      { env: { ...env, ACC_PARTICIPANT: participant } });
+    child.child.stdin.end(JSON.stringify({ hook_event_name: "SessionStart",
+      session_id: participant, cwd: root, source: "startup" }));
+    await child;
+  }
+  const status = JSON.parse((await run(process.execPath,
+    [acc, "status", "--cwd", root, "--json"], { env })).stdout).data;
+  const holder = status.participants.find(item => item.participantId === "holder");
+
+  const claim = resource => run(process.execPath, [acc, "claim", "--cwd", root,
+    "--session", holder.sessionId, "--resource", resource,
+    "--enforcement", "guarded", "--reason", "editing"], { env });
+
+  const write = file => {
+    const child = run(process.execPath, [hook, "codex"],
+      { env: { ...env, ACC_PARTICIPANT: "writer" }, cwd: base });
+    child.child.stdin.end(JSON.stringify({ hook_event_name: "PreToolUse",
+      session_id: "writer", cwd: root, tool_name: "apply_patch",
+      tool_input: { command: `*** Begin Patch\n*** Update File: ${file}\n@@\n-a\n+b\n`
+        + "*** End Patch" } }));
+    return child.then(() => "allow", () => "deny");
+  };
+  return { root, env, claim, write };
+}
+
+/** Whether this filesystem treats two spellings as one file. Asked, not assumed. */
+async function caseInsensitive(root) {
+  return stat(path.join(root, "src", "PHYSICS.mjs")).then(() => true, () => false);
+}
+
+for (const spelling of ["file:./src/physics.mjs", "file:src//physics.mjs",
+  "file:src/x/../physics.mjs"]) {
+  test(`a claim written as ${spelling} still covers the file`, async t => {
+    const place = await project(t);
+    await place.claim(spelling);
+
+    assert.equal(await place.write("src/physics.mjs"), "deny",
+      "the claim was taken and protected nothing");
+  });
+}
+
+test("the claim is stored under the one name, whatever it was typed as", async t => {
+  const place = await project(t);
+
+  const { stdout } = await place.claim("file:./src//physics.mjs");
+
+  // What is echoed back is what a peer will see in `acc status`, so a claim that
+  // reads differently from the file everyone else names is a claim nobody can
+  // reason about.
+  assert.match(stdout, /^claimed file:src\/physics\.mjs$/m);
+});
+
+test("case follows the filesystem, because that is what decides it", async t => {
+  const place = await project(t);
+  const merged = await caseInsensitive(place.root);
+  await place.claim("file:src/Physics.mjs");
+
+  const decision = await place.write("src/physics.mjs");
+
+  // Where the two spellings are one file, a claim on either has to cover both.
+  // Where they are two files, they are two resources and must stay so. No case
+  // rule appears anywhere in ACC: `realpath` answers it on each machine.
+  assert.equal(decision, merged ? "deny" : "allow",
+    merged
+      ? "one file on this filesystem, and the claim covered only one spelling"
+      : "two files on this filesystem, and a claim on one blocked the other");
+});
+
+test("a glob keeps its meaning through normalisation", async t => {
+  const place = await project(t);
+  await place.claim("file:./src/**");
+
+  assert.equal(await place.write("src/physics.mjs"), "deny");
+  assert.equal(await place.write("README.md"), "allow");
+});
+
+test("a resource that is not a file is left exactly as it is", async t => {
+  const place = await project(t);
+
+  // Other schemes are opaque identifiers. Rewriting one would be inventing
+  // meaning ACC does not have.
+  const { stdout } = await place.claim("url:https://example.test/./a//b");
+
+  assert.match(stdout, /claimed url:https:\/\/example\.test\/\.\/a\/\/b/);
+});


### PR DESCRIPTION
A claim is a string, and a file has many spellings. Each of these was accepted as a claim, reported by `acc status` as `protection guarded`, and protected nothing:

```
A. claim written as 'file:./src/physics.mjs'
   claimed file:./src/physics.mjs
   exit 0                                  <- the write went through

B. same file, differing only in case
   claimed file:src/Physics.mjs
   exit 0                                  <- the write went through

C. control: exact spelling
   claimed file:src/physics.mjs
   file:src/physics.mjs is claimed by holder …
   exit 2
```

The control matters: the mechanism works, and these two spellings walked past it. This is the same silent-allow as the symlink and relative-target defects, reached from the other side — the target was canonicalised and the claim was not.

## What a string can settle

`normaliseResource` handles `.`, `//`, `..` and preserves a trailing `/**`. It runs inside `acquireClaim`, so a claim taken over MCP means the same as one taken from the CLI — one place, not one per surface.

An absolute path keeps its leading slash: it names something else, and merging the two would invent a fact. Other schemes are left exactly as they are; they are opaque identifiers and rewriting one would be inventing meaning ACC does not have.

## What a string cannot settle

Letter case is the filesystem's answer and it differs by machine, so no case rule belongs anywhere in ACC. `acc claim` asks, through the same `realpath` walk the guard already uses on its targets:

- **macOS** — `realpath('src/Physics.mjs')` returns `src/physics.mjs`, so both spellings arrive at one resource.
- **Linux** — they are genuinely two files and stay two resources.

The test asserts whichever the filesystem it is running on reports, so **both branches are exercised by the CI matrix** rather than one being assumed:

```js
assert.equal(decision, merged ? "deny" : "allow", …)
```

`acc claim` now echoes the name it stored — which is the name peers will see in `acc status`.

## Verification

- 689 tests passing, 0 failing · `syntax ok in 152 file(s)`
- 6 of the 7 new tests fail against `main`; the seventh (other schemes are untouched) passes both ways by design
- `PASS … sha256 0d46d8b5…b21048 built from 9fd4542`
