### PR TITLE
fix: refuse a claim that cannot match anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `9fd4542` |
-| Tarball | `agents-can-communicate-0.0.0.tgz`, 107 KB, 103 entries |
-| sha256 | `0d46d8b54b28e1f7c87965438f4143cfd1c236d62c715d461a066677deb21048` |
-| Tests | 689 passing, 0 failing |
+| Built from | `e5026ba` |
+| Tarball | `agents-can-communicate-0.0.0.tgz`, 108 KB, 103 entries |
+| sha256 | `85f1665b3a07918941a28f41dcde555da5d5cbc2dea193c0bff129a75c77fc6d` |
+| Tests | 694 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -81,6 +81,10 @@ agent that names it opened at the root, in `src/`, or in another worktree of the
 repository. One name for one file is what makes a claim mean anything — two agents calling
 it two things is the same as no claim at all.
 
+A directory is claimed as `file:src/**`. Only that trailing glob is understood, so
+`file:src`, `file:src/`, `file:src/*` and `file:src/*.mjs` are refused rather than stored:
+each of them used to be accepted and cover nothing, which reads like protection and is not.
+
 The spelling is settled for you. `./src/a.mjs`, `src//a.mjs` and `src/x/../a.mjs` are
 stored as `file:src/a.mjs`, and letter case is resolved by asking the filesystem rather
 than by a rule: where `src/A.mjs` and `src/a.mjs` are one file they become one resource,

--- a/packages/cli/src/claim-spelling.mjs
+++ b/packages/cli/src/claim-spelling.mjs
@@ -1,7 +1,7 @@
-import { realpath } from "node:fs/promises";
+import { realpath, stat } from "node:fs/promises";
 import path from "node:path";
 
-import { normaliseResource } from "@agents-can-communicate/protocol";
+import { AccError, EXIT, normaliseResource } from "@agents-can-communicate/protocol";
 
 /**
  * The spelling the filesystem itself uses.
@@ -58,6 +58,19 @@ export async function canonicalClaim(resource, descriptor) {
   if (body === "") return normalised;
 
   const resolved = await onDisk(path.resolve(root, body));
+  // A directory claimed without the glob covers exactly itself, which is to say
+  // nothing anyone writes. Saying so beats storing a claim that reads like
+  // protection and is not.
+  //
+  // The protocol refuses the shapes a string alone can condemn - a trailing
+  // slash, a `*` that is not the understood glob - so that a surface with no
+  // filesystem still refuses them. This is the half only the filesystem knows:
+  // whether `file:src` happens to be a directory.
+  if (!glob && await stat(resolved).then(entry => entry.isDirectory(), () => false)) {
+    throw new AccError(EXIT.USAGE,
+      `${normalised} is a directory; claim ${normalised}/** to cover what is in it`,
+      { resource });
+  }
   const relative = path.relative(await onDisk(root), resolved);
   if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
     return normalised;

--- a/packages/core/src/claims.mjs
+++ b/packages/core/src/claims.mjs
@@ -1,5 +1,5 @@
-import { AccError, EXIT, SCHEMA_VERSION, createId, normaliseResource, validateRecord }
-  from "@agents-can-communicate/protocol";
+import { AccError, EXIT, SCHEMA_VERSION, assertMatchableResource, createId,
+  normaliseResource, validateRecord } from "@agents-can-communicate/protocol";
 
 import { ensureMaterialised } from "./materialisation.mjs";
 import { classifySessionPresence } from "./sessions.mjs";
@@ -66,7 +66,11 @@ export function createClaimService(ports, sessions) {
   async function acquireClaim(input) {
     const session = await requireOwner(input, "claim");
     // One name for one file, decided here rather than at each surface, so a
-    // claim taken over MCP and one taken from the CLI mean the same thing.
+    // claim taken over MCP and one taken from the CLI mean the same thing - and
+    // a shape that could never match is refused rather than stored.
+    assertMatchableResource(input.resource, message => {
+      throw new AccError(EXIT.USAGE, message, { resource: input.resource });
+    });
     const resource = normaliseResource(input.resource);
     const workspaceId = session.workspaceId;
     await ensureMaterialised(ports, { workspaceId, descriptor: input.descriptor,

--- a/packages/protocol/src/index.mjs
+++ b/packages/protocol/src/index.mjs
@@ -6,4 +6,4 @@ export { RECORD_KINDS, SCHEMA_VERSION, validateRecord } from "./schema.mjs";
 export { CONFIG_FILENAME, CONFIG_SCHEMA_VERSION, RUNTIME_KEYS, defaultProjectConfig,
   validateProjectConfig } from "./config.mjs";
 export { DELIVERY_STATES, TASK_STATES, advanceDelivery, transitionTask } from "./states.mjs";
-export { normaliseResource } from "./resources.mjs";
+export { assertMatchableResource, normaliseResource } from "./resources.mjs";

--- a/packages/protocol/src/resources.mjs
+++ b/packages/protocol/src/resources.mjs
@@ -30,6 +30,32 @@ function normalisePath(value) {
   return segments.join("/");
 }
 
+/**
+ * A claim that cannot match anything is worse than no claim.
+ *
+ * Only a trailing `/**` is understood. Every other shape an agent reaches for -
+ * `file:src` for a directory, `file:src/`, `file:src/*.mjs`, `file:src/*` - was
+ * accepted, stored, and reported by `acc status` as `protection guarded`, and
+ * covered nothing at all. Measured: four spellings, four claims taken, four
+ * writes allowed, and only `file:src/**` denied.
+ *
+ * Refusing is the honest answer. The claim was going to be useless either way;
+ * this way its author finds out, and is told the form that works.
+ */
+export function assertMatchableResource(resource, fail) {
+  if (typeof resource !== "string" || !resource.startsWith("file:")) return resource;
+  const rest = resource.slice("file:".length);
+  if (rest.endsWith("/") && rest !== "/") {
+    fail(`${resource} names a directory; claim ${resource}** to cover what is in it`);
+  }
+  const body = rest.endsWith(GLOB) ? rest.slice(0, -GLOB.length) : rest;
+  if (body.includes("*")) {
+    fail(`${resource} matches nothing: only a trailing /** is understood, `
+      + `so a directory is claimed as file:<path>/**`);
+  }
+  return resource;
+}
+
 export function normaliseResource(resource) {
   if (typeof resource !== "string") return resource;
   const colon = resource.indexOf(":");

--- a/tests/security/claim-spelling.test.mjs
+++ b/tests/security/claim-spelling.test.mjs
@@ -115,6 +115,35 @@ test("a glob keeps its meaning through normalisation", async t => {
   assert.equal(await place.write("README.md"), "allow");
 });
 
+for (const [spelling, expected] of [
+  ["file:src", /is a directory; claim file:src\/\*\* to cover/],
+  ["file:src/", /is a directory; claim file:src\/\*\* to cover/],
+  ["file:src/*.mjs", /matches nothing: only a trailing \/\*\* is understood/],
+  ["file:src/*", /matches nothing: only a trailing \/\*\* is understood/],
+]) {
+  test(`${spelling} is refused rather than stored as protection`, async t => {
+    const place = await project(t);
+
+    // Each of these was accepted, stored, and reported as `protection guarded`
+    // while covering nothing at all. The claim was useless either way; refusing
+    // is how its author finds out.
+    const failure = await place.claim(spelling).then(() => null, error => error);
+
+    assert.notEqual(failure, null, `${spelling} was stored and protects nothing`);
+    assert.match(failure.stderr, expected);
+  });
+}
+
+test("a path that does not exist yet can still be claimed", async t => {
+  const place = await project(t);
+
+  // Claiming before creating is the point of a claim, so an absent path is not
+  // evidence of a mistake the way a directory is.
+  const { stdout } = await place.claim("file:src/renderer.mjs");
+
+  assert.match(stdout, /claimed file:src\/renderer\.mjs/);
+});
+
 test("a resource that is not a file is left exactly as it is", async t => {
   const place = await project(t);
 


### PR DESCRIPTION
Four spellings an agent reaches for naturally were accepted, stored, and reported by `acc status` as `protection guarded` — and covered nothing. Measured, same file, same guard:

```
file:src           -> claimed file:src          write: exit 0
file:src/          -> claimed file:src          write: exit 0
file:src/*.mjs     -> claimed file:src/*.mjs    write: exit 0
file:src/*         -> claimed file:src/*        write: exit 0
file:src/**        -> claimed file:src/**       write: exit 2
```

Only the last one ever worked.

## The fix

They are refused now, and told the form that works:

```
file:src is a directory; claim file:src/** to cover what is in it
file:src/*.mjs matches nothing: only a trailing /** is understood, so a
  directory is claimed as file:<path>/**
```

The claim was going to be useless either way. This way its author finds out.

The split is by what each layer can know:

| Layer | Refuses | Why there |
|---|---|---|
| protocol, inside `acquireClaim` | a trailing slash, a `*` outside the understood glob | a string alone convicts these, so a surface with no filesystem refuses them too |
| CLI, in `canonicalClaim` | `file:src` when `src` is a directory | only the filesystem knows that |

A path that does not exist **yet** is still claimable — claiming before creating is the point of a claim, so an absent path is not evidence of a mistake the way a directory is. Non-`file:` schemes are untouched.

## Verification

- 694 tests passing, 0 failing · `syntax ok in 152 file(s)`
- The four new refusal tests fail against `main`, where each spelling is silently stored
- `PASS … sha256 85f1665b…7fc6d built from e5026ba`
