### PR TITLE
fix: make the injected turn something an agent can act on

### DIFF
--- a/packages/adapter-claude-code/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-claude-code/plugin/skills/acc/SKILL.md
@@ -49,6 +49,27 @@ One call records the work and tells them why. `--to` is a participant from the r
 `acc status --json` lists who is here. They are told at their next turn and may take it,
 leave it, or reply. It is a request, not an order.
 
+## Reading your turn
+
+Every attention line carries the id of the thing it is about, and that id is the argument
+to the command that answers it:
+
+```text
+- [direct_request] message_x    someone addressed this to you    -> ack
+- [task_unblocked] task_x       work is waiting for you          -> task --take
+- [claim_conflict] claim_x      someone holds what you want      -> ask, or release
+- [request_stalled] task_x      you asked and nobody is on it    -> ask again, or take it back
+```
+
+A turn is written to a byte budget, so it can end with
+
+```text
+- +2 not shown, over budget; read them with `acc sync --scope full --json`
+```
+
+Run that. Two things were addressed to you and the turn had no room for them; they are
+not gone, and nobody will repeat them.
+
 ## Work someone asked of you
 
 A turn that opens with `[task_unblocked] task_x ...` means work is addressed to you and

--- a/packages/adapter-codex/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-codex/plugin/skills/acc/SKILL.md
@@ -49,6 +49,27 @@ One call records the work and tells them why. `--to` is a participant from the r
 `acc status --json` lists who is here. They are told at their next turn and may take it,
 leave it, or reply. It is a request, not an order.
 
+## Reading your turn
+
+Every attention line carries the id of the thing it is about, and that id is the argument
+to the command that answers it:
+
+```text
+- [direct_request] message_x    someone addressed this to you    -> ack
+- [task_unblocked] task_x       work is waiting for you          -> task --take
+- [claim_conflict] claim_x      someone holds what you want      -> ask, or release
+- [request_stalled] task_x      you asked and nobody is on it    -> ask again, or take it back
+```
+
+A turn is written to a byte budget, so it can end with
+
+```text
+- +2 not shown, over budget; read them with `acc sync --scope full --json`
+```
+
+Run that. Two things were addressed to you and the turn had no room for them; they are
+not gone, and nobody will repeat them.
+
 ## Work someone asked of you
 
 A turn that opens with `[task_unblocked] task_x ...` means work is addressed to you and

--- a/packages/adapter-gemini-cli/extension/skills/acc/SKILL.md
+++ b/packages/adapter-gemini-cli/extension/skills/acc/SKILL.md
@@ -49,6 +49,27 @@ One call records the work and tells them why. `--to` is a participant from the r
 `acc status --json` lists who is here. They are told at their next turn and may take it,
 leave it, or reply. It is a request, not an order.
 
+## Reading your turn
+
+Every attention line carries the id of the thing it is about, and that id is the argument
+to the command that answers it:
+
+```text
+- [direct_request] message_x    someone addressed this to you    -> ack
+- [task_unblocked] task_x       work is waiting for you          -> task --take
+- [claim_conflict] claim_x      someone holds what you want      -> ask, or release
+- [request_stalled] task_x      you asked and nobody is on it    -> ask again, or take it back
+```
+
+A turn is written to a byte budget, so it can end with
+
+```text
+- +2 not shown, over budget; read them with `acc sync --scope full --json`
+```
+
+Run that. Two things were addressed to you and the turn had no room for them; they are
+not gone, and nobody will repeat them.
+
 ## Work someone asked of you
 
 A turn that opens with `[task_unblocked] task_x ...` means work is addressed to you and

--- a/packages/adapter-kimi/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-kimi/plugin/skills/acc/SKILL.md
@@ -49,6 +49,27 @@ One call records the work and tells them why. `--to` is a participant from the r
 `acc status --json` lists who is here. They are told at their next turn and may take it,
 leave it, or reply. It is a request, not an order.
 
+## Reading your turn
+
+Every attention line carries the id of the thing it is about, and that id is the argument
+to the command that answers it:
+
+```text
+- [direct_request] message_x    someone addressed this to you    -> ack
+- [task_unblocked] task_x       work is waiting for you          -> task --take
+- [claim_conflict] claim_x      someone holds what you want      -> ask, or release
+- [request_stalled] task_x      you asked and nobody is on it    -> ask again, or take it back
+```
+
+A turn is written to a byte budget, so it can end with
+
+```text
+- +2 not shown, over budget; read them with `acc sync --scope full --json`
+```
+
+Run that. Two things were addressed to you and the turn had no room for them; they are
+not gone, and nobody will repeat them.
+
 ## Work someone asked of you
 
 A turn that opens with `[task_unblocked] task_x ...` means work is addressed to you and

--- a/packages/adapter-sdk/src/context-projector.mjs
+++ b/packages/adapter-sdk/src/context-projector.mjs
@@ -2,7 +2,11 @@ const DEFAULT_BUDGET_BYTES = 6_000;
 // Held back from the required lines so the "not shown" note can always be
 // written. A projection that silently drops what it could not fit is how an
 // agent ends up confidently unaware.
-const NOTE_RESERVE = 48;
+// Enough for the note *and* the command that reads what the note is about. It
+// said only that something had been withheld, and nothing anywhere - not the
+// skills, not the docs - said how to see it. A turn that reports a thing the
+// reader cannot reach is how an agent ends up inventing its own way in.
+const NOTE_RESERVE = 80;
 const FENCE = "```";
 // A peer cannot close a block it cannot name. The fence carries a marker that
 // is stripped from peer content, so forged delimiters stay inside the block.
@@ -49,10 +53,14 @@ function truncate(line, limit) {
  * agent that is told to act and not told on what improvises, which in this
  * project has already meant one hand-editing the store rather than admitting it
  * could not name the task.
+ *
+ * Every kind carries such an id and every one is the argument to a command:
+ * a message to `acc ack --message`, a task to `acc task --task`, a claim to
+ * `acc release --claim`. So they are all shown, not only the ones that happened
+ * to be noticed first.
  */
 function attentionLines(attention) {
-  return attention.map(item => (typeof item.sourceId === "string"
-    && item.sourceId.startsWith("task_")
+  return attention.map(item => (typeof item.sourceId === "string" && item.sourceId !== ""
     ? `- [${item.kind}] ${item.sourceId} ${item.summary}`
     : `- [${item.kind}] ${item.summary}`));
 }
@@ -187,7 +195,8 @@ export function projectContext(sync, { budgetBytes = DEFAULT_BUDGET_BYTES } = {}
     used += size;
   }
   if (dropped > 0) {
-    const note = `- +${dropped} not shown, over budget`;
+    const note = `- +${dropped} not shown, over budget; read them with `
+      + "`acc sync --scope full --json`";
     lines.push(note);
     used += bytes(note) + 1;
   }

--- a/tests/process/abandoned-work.test.mjs
+++ b/tests/process/abandoned-work.test.mjs
@@ -186,7 +186,7 @@ test("finishing the work answers the request it came from", async t => {
   const { place, doer, task } = await inFlight(t);
 
   const before = await turn(place, "kimi", "phys", "physics");
-  assert.match(before, /\[direct_request\] tank sinks into mud/);
+  assert.match(before, /\[direct_request\] message_\S+ tank sinks into mud/);
 
   await cli(place, "task", "--session", doer.accSessionId, "--generation", doer.generation,
     "--task", task.taskId, "--state", "done");
@@ -215,7 +215,8 @@ test("a message not tied to a task can be answered directly", async t => {
     "--subject", "scale", "--body", "Is the tank scale settled?", "--requires-ack");
   const messageId = stdout.trim().replace(/^sent /, "");
 
-  assert.match(await turn(place, "kimi", "phys", "physics"), /\[direct_request\] scale/);
+  assert.match(await turn(place, "kimi", "phys", "physics"),
+    /\[direct_request\] message_\S+ scale/);
   await cli(place, "ack", "--session", doer.accSessionId, "--generation", doer.generation,
     "--message", messageId);
 

--- a/tests/process/turn-is-actionable.test.mjs
+++ b/tests/process/turn-is-actionable.test.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, readdir, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+const repo = path.resolve(import.meta.dirname, "..", "..");
+const acc = path.join(repo, "bin", "acc.mjs");
+const hook = path.join(repo, "bin", "acc-hook.mjs");
+
+/**
+ * A turn that reports something the reader cannot reach.
+ *
+ * The whole point of the injected turn is that an agent acts on it without being
+ * asked twice. Two things in it could not be acted on. `[direct_request] The
+ * physics review` named no message, and `acc ack` takes one - so an agent told
+ * that something was addressed to it could not answer. And `+1 not shown, over
+ * budget` said something had been withheld while nothing anywhere, skills and
+ * documentation included, said how to see it.
+ *
+ * Both are the shape this project keeps finding: an instruction an agent cannot
+ * carry out reads exactly like one it can, and the agent improvises. One of them
+ * has already written to the store by hand rather than admit it was stuck.
+ */
+async function workspace(t, { budgetBytes }) {
+  const base = await realpath(await mkdtemp(path.join(tmpdir(), "acc-turn-")));
+  t.after(() => rm(base, { recursive: true, force: true }));
+  const root = path.join(base, "repo");
+  await run("mkdir", ["-p", root]);
+  const env = { ...process.env, ACC_DATA_HOME: path.join(base, "data"),
+    GIT_DIR: "", GIT_WORK_TREE: "" };
+  if (budgetBytes !== undefined) {
+    await writeFile(path.join(root, "acc.workspace.json"), `${JSON.stringify({
+      schemaVersion: 1, workspaceId: "workspace_turn_budget", displayName: "turn",
+      roots: ["."], policy: { claimMode: "advisory", contextBudgetBytes: budgetBytes },
+      requiredAdapters: [],
+    }, null, 2)}\n`);
+  }
+  for (const [participant, harness] of [["sender", "codex"], ["reader", "claude_code"]]) {
+    const child = run(process.execPath, [hook, harness],
+      { env: { ...env, ACC_PARTICIPANT: participant } });
+    child.child.stdin.end(JSON.stringify({ hook_event_name: "SessionStart",
+      session_id: participant, cwd: root, source: "startup" }));
+    await child;
+  }
+  const cli = (args, who) => run(process.execPath, [acc, ...args, "--cwd", root],
+    { env: { ...env, CLAUDE_CODE_SESSION_ID: who } });
+  const turn = async () => {
+    const child = run(process.execPath, [hook, "claude_code"],
+      { env: { ...env, ACC_PARTICIPANT: "reader" } });
+    child.child.stdin.end(JSON.stringify({ hook_event_name: "UserPromptSubmit",
+      session_id: "reader", cwd: root, prompt: "go" }));
+    const { stdout } = await child;
+    if (stdout.trim() === "") return "";
+    return JSON.parse(stdout).hookSpecificOutput.additionalContext;
+  };
+  return { root, env, cli, turn };
+}
+
+test("a message addressed to you arrives with the id that answers it", async t => {
+  const place = await workspace(t, {});
+  await place.cli(["message", "--to", "reader", "--subject", "The physics review",
+    "--body", "Which way should the hull clamp?", "--requires-ack"], "sender");
+
+  const shown = await place.turn();
+
+  const [, messageId] = /\[direct_request\] (message_\S+)/.exec(shown) ?? [];
+  assert.equal(typeof messageId, "string",
+    `the reader cannot name what was addressed to it:\n${shown}`);
+  // The id is worth showing only if it is the one the command takes.
+  const { stdout } = await place.cli(["ack", "--message", messageId], "reader");
+  assert.match(stdout, /acknowledged/);
+});
+
+test("what the budget withheld comes with the way to read it", async t => {
+  const place = await workspace(t, { budgetBytes: 200 });
+  await place.cli(["message", "--to", "reader", "--subject", "The physics review",
+    "--body", "Here is a long explanation of the sinking tank. ".repeat(8)], "sender");
+
+  const shown = await place.turn();
+
+  assert.match(shown, /not shown, over budget/);
+  assert.match(shown, /acc sync --scope full --json/,
+    `something was withheld and nothing said how to see it:\n${shown}`);
+});
+
+test("the note always fits, however tight the budget", async t => {
+  const place = await workspace(t, { budgetBytes: 200 });
+  for (let index = 0; index < 6; index += 1) {
+    await place.cli(["message", "--to", "reader", "--subject", `Note ${index}`,
+      "--body", "x".repeat(400)], "sender");
+  }
+
+  const shown = await place.turn();
+
+  // The reserve exists so the projection never runs out of room to say that it
+  // ran out of room - including room for the command that recovers what it lost.
+  assert.match(shown, /acc sync --scope full --json/);
+});
+
+test("what the turn withheld is still there to be read", async t => {
+  const place = await workspace(t, { budgetBytes: 200 });
+  await place.cli(["message", "--to", "reader", "--subject", "The physics review",
+    "--body", "Here is a long explanation of the sinking tank. ".repeat(8)], "sender");
+  await place.turn();
+
+  // Withheld, not delivered: a receipt that advanced here would tell the sender
+  // it landed when the reader never saw a word of it.
+  const { stdout } = await place.cli(["sync", "--scope", "full", "--json"], "reader");
+  const payload = JSON.parse(stdout).data;
+  const subjects = payload.snapshot.messages.map(item => item.subject);
+  assert.deepEqual(subjects, ["The physics review"]);
+});
+
+test("every skill teaches the two lines a turn can end with", async () => {
+  // The turn's vocabulary is only useful if the reader was taught it, and the
+  // skill is the only place an agent reads.
+  const skills = [];
+  for (const entry of await readdir(path.join(repo, "packages"), { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    for (const bundle of ["plugin", "extension"]) {
+      const file = path.join(repo, "packages", entry.name, bundle,
+        "skills", "acc", "SKILL.md");
+      const text = await readFile(file, "utf8").catch(() => null);
+      if (text !== null) skills.push({ file, text });
+    }
+  }
+  assert.equal(skills.length, 4);
+  for (const { file, text } of skills) {
+    assert.match(text, /\[direct_request\] message_x/, `${file} does not say what to do`);
+    assert.match(text, /not shown, over budget/, `${file} never mentions the budget line`);
+    assert.match(text, /sync --scope full --json/, `${file} does not say how to read them`);
+  }
+});


### PR DESCRIPTION
Two things a turn reported that its reader could not reach. Measured on a real turn:

```
2 session(s); cursor 0000000000000004
- [direct_request] The physics review
- +1 not shown, over budget
- sender on main (codex, online)
- reader on main (claude_code, online)
```

Something is addressed to you — **which thing?** `acc ack` takes a message id. Something was withheld — **how do you see it?** Nothing anywhere said, not the four skills and not the documentation.

## The ids were already there

The message id is in the attention item and always was. It was rendered only for tasks, because tasks were what got noticed the last time this was looked at. Every kind carries one, and every one is the argument to the command that answers it:

| line | answered by |
|---|---|
| `[direct_request] message_x` | `acc ack --message` |
| `[task_unblocked] task_x` | `acc task --take --task` |
| `[claim_conflict] claim_x` | `acc release --claim`, or ask |
| `[request_stalled] task_x` | ask again, or take it back |

The test does not just look for an id — it takes the one from the line and runs `acc ack` with it, because an id is worth printing only if it is the one the command accepts.

## The way back

```
- +2 not shown, over budget; read them with `acc sync --scope full --json`
```

`NOTE_RESERVE` grew from 48 to 80 bytes to fit it. The projection must never run out of room to say that it ran out of room — and the way back is part of saying it. Pinned by a test that floods a 200-byte budget with six 400-byte messages and still expects the command to survive.

The four skills gained the turn's vocabulary, which is the only place an agent reads.

## Verification

- 694 tests passing, 0 failing · `syntax ok in 153 file(s)`
- 4 of the 5 new tests fail against `main`; the fifth (withheld messages are still readable) passes both ways and pins what must not change
- **The CHANGELOG digest is deliberately not touched here.** #28 also changes shipped code and is still open; re-recording for a commit that will land after it would record a measurement of nothing. One housekeeping PR re-records once both are in.
