### PR TITLE
chore: re-record the candidate, and notice when it goes stale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `e5026ba` |
+| Built from | `d354e0f` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 108 KB, 103 entries |
-| sha256 | `85f1665b3a07918941a28f41dcde555da5d5cbc2dea193c0bff129a75c77fc6d` |
-| Tests | 694 passing, 0 failing |
+| sha256 | `93233ce6a4b34f4ae99b4c79ee2218adaaf0a36de6741b98a89a293d3f798206` |
+| Tests | 699 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -34,6 +34,10 @@ when the working tree is dirty.
 
 Coordinates independent agent sessions in one workspace: presence, intent,
 workspace-global claims, typed messages, handoffs. No session is in charge.
+
+Every line of an injected turn can be acted on. An attention line carries the id
+of the thing it is about — the same id the command that answers it takes — and a
+turn the byte budget truncated says how to read what it withheld.
 
 A peer's message reaches the recipient's turn as a fenced, attributed, escaped
 block, and its receipt advances to `injected` only for what the turn actually

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -53,6 +53,13 @@ the working tree is dirty:
 PASS  agents-can-communicate-0.0.0.tgz  sha256 a5c8bb1d…  built from 39d0dcf
 ```
 
+It went stale four times in a row anyway, each caught by hand and only because
+someone happened to run the script. So `npm test` now checks it:
+`tests/acceptance/recorded-candidate.test.mjs` fails when shipped code has
+changed since the recorded commit, and names the files. A shallow clone that
+does not have the commit reports that instead of failing — the check is of the
+record, not of the checkout depth.
+
 ## Then stop
 
 Publishing, tagging, and cutting a GitHub release are **external mutations**.

--- a/tests/acceptance/recorded-candidate.test.mjs
+++ b/tests/acceptance/recorded-candidate.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+const repo = path.resolve(import.meta.dirname, "..", "..");
+
+/**
+ * The recorded measurement has to describe something that can be built.
+ *
+ * The changelog names a commit and the digest of the tarball built from it, and
+ * points a reader at `scripts/verify-package.mjs` to check. Every change to
+ * shipped code invalidates it, and it went stale four times in a row before
+ * anyone noticed - each time caught by hand, and each time only because someone
+ * happened to run the script.
+ *
+ * A stale digest is worse than none: a reader who checks it and gets a different
+ * number learns nothing except that the project's own evidence does not hold.
+ *
+ * What is compared is history rather than a fresh digest. Re-packing here would
+ * be the stronger check and is not portable: a gzip stream carries mtimes, and
+ * the CI matrix builds on two platforms.
+ */
+const PACKED = Object.freeze(["bin/", "packages/", "README.md", "LICENSE",
+  "docs/CAPABILITIES.md"]);
+
+const git = async (...argv) => {
+  const env = { ...process.env };
+  // Inherited from a hook or a test runner, these describe someone else's
+  // repository. The provenance script strips them for the same reason.
+  for (const name of ["GIT_DIR", "GIT_WORK_TREE"]) delete env[name];
+  return (await run("git", argv, { cwd: repo, env })).stdout.trim();
+};
+
+test("the changelog's digest describes the code that is here now", async () => {
+  const changelog = await readFile(path.join(repo, "CHANGELOG.md"), "utf8");
+  const [, recorded] = /\|\s*Built from\s*\|\s*`([0-9a-f]{7,40})`\s*\|/.exec(changelog) ?? [];
+  assert.equal(typeof recorded, "string", "the changelog records no commit");
+
+  // A shallow clone - which is what `actions/checkout` makes by default - may
+  // not have the recorded commit at all. Saying so is honest; failing would make
+  // this a test of the checkout depth rather than of the record.
+  const known = await git("cat-file", "-e", `${recorded}^{commit}`)
+    .then(() => true, () => false);
+  if (!known) {
+    console.log(`recorded commit ${recorded} is not in this clone; nothing to compare`);
+    return;
+  }
+
+  const changed = (await git("diff", "--name-only", `${recorded}..HEAD`, "--", ...PACKED))
+    .split("\n").filter(Boolean);
+
+  assert.deepEqual(changed, [],
+    `shipped code changed since ${recorded}, so the recorded digest describes nothing `
+    + "that can be built. Re-record with `node scripts/verify-package.mjs`:"
+    + `\n  ${changed.join("\n  ")}`);
+});
+
+test("the packed set this checks is the packed set that ships", async () => {
+  const manifest = JSON.parse(await readFile(path.join(repo, "package.json"), "utf8"));
+
+  // The list above is a copy, and a copy drifts. `packages/` stands in for every
+  // bundled workspace, which npm packs from the dependency list rather than
+  // from `files`.
+  const declared = new Set(manifest.files);
+  for (const entry of PACKED) {
+    if (entry === "packages/") continue;
+    assert.equal(declared.has(entry), true, `${entry} is no longer published`);
+  }
+  for (const entry of declared) {
+    assert.equal(PACKED.includes(entry), true,
+      `${entry} is published and this test would not notice it changing`);
+  }
+  assert.equal((manifest.bundleDependencies ?? []).length > 0, true,
+    "nothing is bundled, so `packages/` no longer stands for anything shipped");
+});


### PR DESCRIPTION
The changelog named `e5026ba` and a digest of `85f1665b…`. The merged tree builds `93233ce6…`. #28 and #29 both changed shipped code, and neither could honestly record the result, because each would land after the other.

Re-recorded from the merge — and gated, because this is the **fifth** time in a row the record went stale. Every previous time it was caught by hand, and only because someone happened to run `verify-package.mjs`.

A stale digest is worse than no digest. A reader who follows the changelog's own instruction, checks the number, and gets a different one learns nothing except that the project's evidence does not hold.

## The gate

`tests/acceptance/recorded-candidate.test.mjs` fails when shipped code has changed since the recorded commit, and names the files:

```
AssertionError: shipped code changed since 6c4c19d, so the recorded digest describes
nothing that can be built. Re-record with `node scripts/verify-package.mjs`:
  packages/adapter-claude-code/plugin/skills/acc/SKILL.md
  packages/adapter-codex/plugin/skills/acc/SKILL.md
```

Two deliberate choices:

- **History, not a fresh digest.** Re-packing would be the stronger check and is not portable — a gzip stream carries mtimes, and the CI matrix builds on macOS and Linux. A gate that fails for the wrong reason on one platform is worse than the weaker one that is always right.
- **A shallow clone reports, it does not fail.** `actions/checkout` defaults to depth 1 and may not have the recorded commit. Failing there would make this a test of the checkout depth rather than of the record.

A second test keeps the packed-set list honest against `package.json`, since it is a copy and copies drift.

## Verification

- 701 tests passing, 0 failing · `syntax ok in 154 file(s)`
- Proven by mutation: pointing the record at the previous merge fails with the two skill files listed above
- Only `CHANGELOG.md`, `docs/RELEASING.md` and a test change here, none of them packed, so the digest recorded in this PR stays true after it lands
