### PR TITLE
fix: tell the agent who asked when nobody is left to answer

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -93,6 +93,7 @@ Computed from explicit rules, never from a hidden classifier. Lower sorts first:
 | 2 | `claim_conflict` | Your declared resource hints overlap a live claim you do not own |
 | 3 | `task_unblocked` | Work addressed to your participant is `pending` — every dependency is `done` |
 | 4 | `coordinator_missing` | An open workstream has no coordinator |
+| 5 | `request_stalled` | You asked for something and nobody is on it: work you requested is held by a session that has gone quiet or addressed to a participant that is not here, or a question of yours needing an answer is addressed to a participant that is not here |
 
 A task with unmet dependencies is `blocked`, and finishing the last one flips its dependents
 to `pending`. So `pending` already means ready, and nothing has to re-evaluate the graph.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -201,9 +201,10 @@ A handoff contains:
 
 ## Sync and attention
 
-Adapters request deltas since a cursor. Core computes attention items from four explicit
-rules — `direct_request`, `claim_conflict`, `task_unblocked`, `coordinator_missing` — listed
-with their exact trigger in [ARCHITECTURE.md](ARCHITECTURE.md).
+Adapters request deltas since a cursor. Core computes attention items from five explicit
+rules — `direct_request`, `claim_conflict`, `task_unblocked`, `coordinator_missing`,
+`request_stalled` — listed with their exact trigger in
+[ARCHITECTURE.md](ARCHITECTURE.md).
 
 Semantic relevance may be assessed by the receiving model, but correctness cannot depend on a hidden central LLM classifier.
 

--- a/packages/adapter-claude-code/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-claude-code/plugin/skills/acc/SKILL.md
@@ -59,6 +59,7 @@ to the command that answers it:
 - [task_unblocked] task_x       work is waiting for you          -> task --take
 - [claim_conflict] claim_x      someone holds what you want      -> ask, or release
 - [request_stalled] task_x      you asked and nobody is on it    -> ask again, or take it back
+- [request_stalled] message_x   you asked and nobody is there    -> ask someone else
 ```
 
 A turn is written to a byte budget, so it can end with

--- a/packages/adapter-codex/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-codex/plugin/skills/acc/SKILL.md
@@ -59,6 +59,7 @@ to the command that answers it:
 - [task_unblocked] task_x       work is waiting for you          -> task --take
 - [claim_conflict] claim_x      someone holds what you want      -> ask, or release
 - [request_stalled] task_x      you asked and nobody is on it    -> ask again, or take it back
+- [request_stalled] message_x   you asked and nobody is there    -> ask someone else
 ```
 
 A turn is written to a byte budget, so it can end with

--- a/packages/adapter-gemini-cli/extension/skills/acc/SKILL.md
+++ b/packages/adapter-gemini-cli/extension/skills/acc/SKILL.md
@@ -59,6 +59,7 @@ to the command that answers it:
 - [task_unblocked] task_x       work is waiting for you          -> task --take
 - [claim_conflict] claim_x      someone holds what you want      -> ask, or release
 - [request_stalled] task_x      you asked and nobody is on it    -> ask again, or take it back
+- [request_stalled] message_x   you asked and nobody is there    -> ask someone else
 ```
 
 A turn is written to a byte budget, so it can end with

--- a/packages/adapter-kimi/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-kimi/plugin/skills/acc/SKILL.md
@@ -59,6 +59,7 @@ to the command that answers it:
 - [task_unblocked] task_x       work is waiting for you          -> task --take
 - [claim_conflict] claim_x      someone holds what you want      -> ask, or release
 - [request_stalled] task_x      you asked and nobody is on it    -> ask again, or take it back
+- [request_stalled] message_x   you asked and nobody is there    -> ask someone else
 ```
 
 A turn is written to a byte budget, so it can end with

--- a/packages/core/src/index.mjs
+++ b/packages/core/src/index.mjs
@@ -2,6 +2,6 @@
 export { createCoordinationService } from "./service.mjs";
 export { assertPorts } from "./ports.mjs";
 export { classifySessionPresence } from "./sessions.mjs";
-export { computeAttention } from "./sync.mjs";
+export { ATTENTION_PRIORITY, computeAttention } from "./sync.mjs";
 export { overlaps } from "./claims.mjs";
 export { wouldCycle } from "./tasks.mjs";

--- a/packages/core/src/sync.mjs
+++ b/packages/core/src/sync.mjs
@@ -70,6 +70,39 @@ function unblockedTasks(snapshot, session, participantId) {
  * one-shot answers a request produces, this repeats until it is resolved,
  * because it stays true until someone picks the work back up.
  */
+/**
+ * A question nobody is left to answer.
+ *
+ * The task rule below tells a requester when work they asked for is going
+ * nowhere. A `requiresAck` message had no such rule, and a message is the other
+ * half of the same act: an agent asked a peer a direct question, the peer's
+ * session ended without answering, and the asker's next turn was empty. Not
+ * "still waiting" - empty. Measured, with the only other agent gone and an
+ * unanswered question standing between them.
+ *
+ * The same kind as the task case, because it is the same fact about the world:
+ * you asked, and there is nobody there.
+ */
+function unansweredQuestions(snapshot, participantId, onlineParticipants) {
+  const senderOf = new Map((snapshot.sessions ?? [])
+    .map(session => [session.sessionId, session.participantId]));
+  const items = [];
+  for (const receipt of snapshot.receipts ?? []) {
+    if (receipt.state === "acknowledged" || receipt.state === "failed") continue;
+    const message = (snapshot.messages ?? [])
+      .find(item => item.messageId === receipt.messageId);
+    if (message === undefined || !message.requiresAck) continue;
+    if (senderOf.get(message.fromSessionId) !== participantId) continue;
+    // Not answered yet by someone who is here is ordinary waiting, and saying so
+    // every turn would be noise the reader learns to skip.
+    if (onlineParticipants.has(receipt.recipientParticipantId)) continue;
+    items.push({ kind: "request_stalled", priority: ATTENTION_PRIORITY.request_stalled,
+      sourceId: message.messageId,
+      summary: `${message.subject} - ${receipt.recipientParticipantId} is not here to answer` });
+  }
+  return items;
+}
+
 function stalledRequests(snapshot, participantId, now) {
   const live = new Map((snapshot.sessions ?? [])
     .map(session => [session.sessionId, classifySessionPresence(session, now)]));
@@ -87,12 +120,15 @@ function stalledRequests(snapshot, participantId, now) {
     return task.state === "pending" && task.assigneeParticipantId !== null
       && !onlineParticipants.has(task.assigneeParticipantId);
   };
-  return (snapshot.tasks ?? [])
-    .filter(task => task.requestedByParticipantId === participantId
-      && goingNowhere(task))
-    .map(task => ({ kind: "request_stalled", priority: ATTENTION_PRIORITY.request_stalled,
-      sourceId: task.taskId,
-      summary: `${task.title} - nobody is working on it` }));
+  return [
+    ...(snapshot.tasks ?? [])
+      .filter(task => task.requestedByParticipantId === participantId
+        && goingNowhere(task))
+      .map(task => ({ kind: "request_stalled", priority: ATTENTION_PRIORITY.request_stalled,
+        sourceId: task.taskId,
+        summary: `${task.title} - nobody is working on it` })),
+    ...unansweredQuestions(snapshot, participantId, onlineParticipants),
+  ];
 }
 
 function coordinatorGaps(snapshot) {

--- a/tests/process/abandoned-work.test.mjs
+++ b/tests/process/abandoned-work.test.mjs
@@ -223,3 +223,70 @@ test("a message not tied to a task can be answered directly", async t => {
   const after = await turn(place, "kimi", "phys", "physics");
   assert.equal(after.includes("[direct_request]"), false, after);
 });
+
+test("a direct question outlives the agent it was put to", async t => {
+  const place = await workspace(t);
+  const asker = await attach(place, "codex", "gfx", "graphics");
+  await attach(place, "kimi", "phys", "physics");
+  await cli(place, "message", "--session", asker.accSessionId,
+    "--generation", asker.generation, "--to", "physics",
+    "--subject", "which way should the hull clamp?",
+    "--body", "It is blocking my rendering work.", "--requires-ack");
+
+  // Ordinary waiting while they are here. Saying so every turn is noise a
+  // reader learns to skip, and then skips the turn that matters.
+  const waiting = await turn(place, "codex", "gfx", "graphics");
+  assert.equal(waiting.includes("request_stalled"), false, waiting);
+
+  await hookEvent(place, "kimi", "phys", "physics", "sessionEnd",
+    { hook_event_name: "SessionEnd", reason: "exit" });
+
+  // The asker's turn was empty here - not "still waiting", empty. A question
+  // requiring an answer, the only agent who could give one gone, and nothing
+  // said. The task path had a rule for this and the message path had none.
+  const alone = await turn(place, "codex", "gfx", "graphics");
+  assert.match(alone, /\[request_stalled\] message_\S+ which way should the hull clamp\?/,
+    `the asker was left waiting on a question nobody can answer:\n${alone}`);
+  assert.match(alone, /physics is not here to answer/);
+});
+
+test("an answered question stops being reported, even once its author leaves", async t => {
+  const place = await workspace(t);
+  const asker = await attach(place, "codex", "gfx", "graphics");
+  const doer = await attach(place, "kimi", "phys", "physics");
+  await cli(place, "message", "--session", asker.accSessionId,
+    "--generation", asker.generation, "--to", "physics",
+    "--subject", "which way should the hull clamp?", "--body", "Blocking me.",
+    "--requires-ack");
+  const [pending] = JSON.parse((await cli(place, "sync", "--session", doer.accSessionId,
+    "--scope", "full", "--json")).stdout).data.snapshot.messages;
+
+  await cli(place, "ack", "--session", doer.accSessionId,
+    "--generation", doer.generation, "--message", pending.messageId);
+  await hookEvent(place, "kimi", "phys", "physics", "sessionEnd",
+    { hook_event_name: "SessionEnd", reason: "exit" });
+
+  // Answered is answered. A rule that fired on every departure would report
+  // every conversation the workspace has ever had.
+  const after = await turn(place, "codex", "gfx", "graphics");
+  assert.equal(after.includes("request_stalled"), false, after);
+});
+
+test("only the agent who asked is told", async t => {
+  const place = await workspace(t);
+  const asker = await attach(place, "codex", "gfx", "graphics");
+  await attach(place, "kimi", "phys", "physics");
+  const bystander = await attach(place, "claude_code", "snd", "sound");
+  await cli(place, "message", "--session", asker.accSessionId,
+    "--generation", asker.generation, "--to", "physics",
+    "--subject", "which way should the hull clamp?", "--body", "Blocking me.",
+    "--requires-ack");
+  await hookEvent(place, "kimi", "phys", "physics", "sessionEnd",
+    { hook_event_name: "SessionEnd", reason: "exit" });
+
+  // Someone else's unanswered question is not this session's problem, and a
+  // turn that carries everyone's is a turn nobody reads.
+  const seen = await turn(place, "claude_code", "snd", "sound");
+  assert.equal(seen.includes("request_stalled"), false, seen);
+  assert.equal(typeof bystander.accSessionId, "string");
+});

--- a/tests/process/surface-coverage.test.mjs
+++ b/tests/process/surface-coverage.test.mjs
@@ -4,7 +4,8 @@ import path from "node:path";
 import test from "node:test";
 
 import { COMMANDS } from "@agents-can-communicate/cli";
-import { createCoordinationService } from "@agents-can-communicate/core";
+import { ATTENTION_PRIORITY, createCoordinationService }
+  from "@agents-can-communicate/core";
 import { PUBLIC_TOOLS } from "../../packages/mcp-server/src/tools.mjs";
 
 import { createFakeClock, createFakeIds, createMemoryStore } from "../helpers/memory-store.mjs";
@@ -109,6 +110,34 @@ test("an operation an agent needs is offered over MCP as well", async () => {
       createTask: "acc_task", createWorkstream: "acc_workstream",
       finishSession: "acc_finish" }[operation];
     assert.equal(names.has(expected), true, `${operation} has no MCP tool`);
+  }
+});
+
+test("every attention rule is documented, and the documentation invents none", async () => {
+  // `request_stalled` was added, shipped, and never written down: the protocol
+  // reference said "four explicit rules" and named four while the code computed
+  // five. A rule an agent is never told about is one it cannot be expected to
+  // act on, and the skills are generated from the same vocabulary.
+  const architecture = await readFile(path.join(repo, "docs", "ARCHITECTURE.md"), "utf8");
+  const protocol = await readFile(path.join(repo, "docs", "PROTOCOL.md"), "utf8");
+  const kinds = Object.keys(ATTENTION_PRIORITY);
+
+  for (const kind of kinds) {
+    assert.match(architecture, new RegExp(`\\\`${kind}\\\``),
+      `${kind} has no row in the architecture table`);
+    assert.match(protocol, new RegExp(`\\\`${kind}\\\``),
+      `${kind} is not named in the protocol reference`);
+  }
+  // The count in the prose is the part that goes stale silently.
+  const counted = ["zero", "one", "two", "three", "four", "five", "six", "seven"][kinds.length];
+  assert.match(protocol, new RegExp(`${counted} explicit\\s+rules`),
+    `the protocol reference does not say there are ${counted} rules`);
+
+  // Only the priority table: the document has other tables, and one of them has
+  // a row called `protocol`.
+  for (const [, named] of architecture.matchAll(/^\| \d+ \| `([a-z_]+)` \|/gm)) {
+    assert.equal(kinds.includes(named), true,
+      `the architecture table describes \`${named}\`, which the core does not compute`);
   }
 });
 


### PR DESCRIPTION
An agent asked a peer a direct question with `--requires-ack`. The peer's session ended without answering. The asker's next turn:

```
   (nothing at all)
```

Not "still waiting" — empty. The question stands, the only agent who could answer it is gone, and ACC says nothing.

## Why this one slipped through

The task path has had a rule for this since the abandoned-work work: `request_stalled` fires when requested work is held by a session that has gone quiet, or is addressed to a participant who is not here. A `--requires-ack` message is the other half of the same act — *"can you take this?"* versus *"which way should the hull clamp?"* — and had no rule at all.

It fires for both now, under the same kind, because it is the same fact about the world: you asked, and there is nobody there.

```
- [request_stalled] message_d_FkHiUD… Which way should the hull clamp? - helper is not here to answer
```

## What stays quiet

| situation | turn says |
|---|---|
| recipient is online, hasn't answered yet | nothing — ordinary waiting |
| recipient left, question unanswered | `request_stalled`, with the message id |
| question answered, then answerer left | nothing — answered is answered |
| someone *else's* unanswered question | nothing |

A rule that spoke every turn would be noise a reader learns to skip — and then they skip the turn that matters. All four are pinned.

## `request_stalled` was itself undocumented

The protocol reference said **"four explicit rules"** and named four. The core computes five. The architecture table had four rows. It shipped that way.

Both corrected, and gated: `surface-coverage.test.mjs` now requires every kind in `ATTENTION_PRIORITY` to have a row and a mention, requires the **count in the prose** to match — that is the part that goes stale without anyone noticing — and rejects a table row for a kind the core does not compute.

Proven by mutation in both directions: removing the row fails with `request_stalled has no row in the architecture table`; changing "five" back to "four" fails with `the protocol reference does not say there are five rules`.

## Verification

- 703 tests passing, 0 failing · `syntax ok in 153 file(s)`
- The new behaviour test fails against `main` with `the asker was left waiting on a question nobody can answer`
- Depends on nothing in #30; the CHANGELOG digest is left for that PR's gate to flag once both land
