### PR TITLE
fix: stop the write guard reading the whole store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `7096118` |
+| Built from | `add6d30` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `715ec12757f05f8e564bd779e9b14523f302bf749b70d3cdeffba3fee59dce8e` |
-| Tests | 705 passing, 0 failing |
+| sha256 | `efa2083a53ea9db5f1436c887f533fa73db6798e64d6be15bcd6a051a8803c24` |
+| Tests | 710 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -120,6 +120,12 @@ Full matrix and what the `yes` values do **not** promise:
   and `O_NOFOLLOW` does not refuse a symlinked config the way it does on POSIX —
   so the symlink defence does not hold. macOS and Linux are supported; Windows
   is future work.
+- **Writing does not scale the way reading now does.** Every write opens a
+  transaction that reads the whole store, so the cost of `acc message` or
+  `acc task` grows with everything the workspace already holds: 400 messages
+  written one after another took 163 seconds, the last of them about 0.5s each.
+  The write guard no longer works this way and the write path still does. Fine
+  for a project's worth of coordination, not for an archive; nothing prunes yet.
 - **Client capabilities were certified on macOS only.** Linux runs the suite in
   CI, but no adapter was exercised against a real client there.
 

--- a/packages/core/src/service.mjs
+++ b/packages/core/src/service.mjs
@@ -3,7 +3,7 @@ import { createCommunicationService } from "./communication.mjs";
 import { createIntentService } from "./intents.mjs";
 import { assertPorts } from "./ports.mjs";
 import { createSessionService } from "./sessions.mjs";
-import { createStatusService } from "./status.mjs";
+import { createGuardStateService, createStatusService } from "./status.mjs";
 import { createSyncService } from "./sync.mjs";
 import { createTaskService } from "./tasks.mjs";
 import { createWorkstreamService } from "./workstreams.mjs";
@@ -25,6 +25,7 @@ export function createCoordinationService({ store, clock, ids, policies = {} }) 
   const communication = createCommunicationService(ports, sessions, claims);
   const sync = createSyncService(ports, sessions);
   const status = createStatusService(ports, sessions);
+  const guardState = createGuardStateService(ports);
   return Object.freeze({
     store,
     clock,
@@ -38,5 +39,6 @@ export function createCoordinationService({ store, clock, ids, policies = {} }) 
     ...communication,
     ...sync,
     ...status,
+    guardState,
   });
 }

--- a/packages/core/src/status.mjs
+++ b/packages/core/src/status.mjs
@@ -17,6 +17,43 @@ function protectionOf(claims, live) {
   return claims.every(claim => claim.enforcement === "guarded") ? "guarded" : "advisory";
 }
 
+/**
+ * The two things the write guard has to know, and nothing else.
+ *
+ * `collectStatus` answers a person's question and reads the whole store to do
+ * it. The guard asks a much smaller one - who holds a live claim, and what is
+ * that owner called - in front of *every file an agent writes*. Reading
+ * everything there made the cost grow with the number of messages the workspace
+ * had ever carried: measured at about 1.4ms per stored record, so a workspace
+ * with a few thousand crosses the hook's five-second budget, after which it
+ * fails open and the write goes through unguarded.
+ *
+ * Sessions and claims are bounded by what is live. Messages, receipts, tasks and
+ * events are not bounded by anything, and none of them decides whether a write
+ * is allowed.
+ */
+export function createGuardStateService(ports) {
+  const { store, clock } = ports;
+
+  return async function guardState(input = {}) {
+    const workspaceId = input.workspaceId ?? store.workspaceId;
+    const now = clock.now();
+    const snapshot = await store.snapshot(workspaceId, { kinds: ["workspace", "session", "claim"] });
+    const sessions = snapshot.workspace !== null
+      ? snapshot.sessions
+      : await store.ephemeral.list("session");
+
+    return {
+      claims: snapshot.claims
+        .filter(claim => Date.parse(claim.expiresAt) > Date.parse(now)),
+      participants: sessions.map(session => ({
+        sessionId: session.sessionId,
+        participantId: session.participantId,
+      })),
+    };
+  };
+}
+
 export function createStatusService(ports, sessions) {
   const { store, clock } = ports;
 

--- a/packages/hook-runner/src/runner.mjs
+++ b/packages/hook-runner/src/runner.mjs
@@ -255,7 +255,12 @@ const HANDLERS = {
       return { decision: "allow", unguarded: true };
     }
 
-    const status = await context.service.collectStatus({
+    // The narrow read: who holds a live claim, and what that owner is called.
+    // `collectStatus` answers a person's question and reads the whole store,
+    // which put the cost of guarding one write in proportion to every message
+    // the workspace had ever carried. This runs in front of every file an agent
+    // writes, and the budget that keeps it from failing open is five seconds.
+    const status = await context.service.guardState({
       workspaceId: context.descriptor.id });
     // Anchored to the repository, not to wherever this session was started. A
     // session opened in `repo/src` relativised the same file to

--- a/packages/storage-filesystem/src/store.mjs
+++ b/packages/storage-filesystem/src/store.mjs
@@ -194,10 +194,23 @@ export async function openFilesystemStore({ root, clock, ids, workspaceId, failA
     return { cursor: events.at(-1)?.sequence ?? after, events };
   }
 
-  async function snapshot(workspace) {
-    const of = async kind => (await listState(paths, root, kind))
-      .map(envelope => envelope.record)
-      .filter(record => record.workspaceId === workspace);
+  /**
+   * Read the durable state, or the part of it a caller actually needs.
+   *
+   * Every kind is read by default, which is what most callers want and what
+   * this always did. `kinds` exists because one caller runs in front of every
+   * file an agent writes: reading the whole store there made the write guard
+   * cost grow with the number of messages the workspace had ever carried, and
+   * the hook budget is five seconds after which it allows the write.
+   */
+  async function snapshot(workspace, { kinds } = {}) {
+    const wanted = kinds === undefined ? null : new Set(kinds);
+    const of = async kind => {
+      if (wanted !== null && !wanted.has(kind)) return [];
+      return (await listState(paths, root, kind))
+        .map(envelope => envelope.record)
+        .filter(record => record.workspaceId === workspace);
+    };
     return {
       workspace: (await of("workspace"))[0] ?? null,
       participants: await of("participant"),

--- a/tests/helpers/memory-store.mjs
+++ b/tests/helpers/memory-store.mjs
@@ -76,14 +76,19 @@ export function createMemoryStore({ clock, ids, workspaceId }) {
     return { cursor: page.at(-1)?.sequence ?? after, events: page };
   }
 
-  async function snapshot(workspaceId) {
-    const of = kind => [...committed.values()]
+  // `kinds` narrows the read, exactly as the filesystem store does. A double
+  // that ignores an option the real store honours lets a caller pass its tests
+  // and behave differently in the only place that matters.
+  async function snapshot(workspaceId, { kinds } = {}) {
+    const wanted = kinds === undefined ? null : new Set(kinds);
+    const of = kind => (wanted !== null && !wanted.has(kind) ? [] : [...committed.values()]
       .filter(entry => entry.kind === kind && entry.record.workspaceId === workspaceId)
-      .map(entry => entry.record);
+      .map(entry => entry.record));
     return {
-      workspace: [...committed.values()]
-        .find(entry => entry.kind === "workspace" && entry.record.workspaceId === workspaceId)
-        ?.record ?? null,
+      workspace: (wanted !== null && !wanted.has("workspace") ? null
+        : [...committed.values()]
+          .find(entry => entry.kind === "workspace"
+            && entry.record.workspaceId === workspaceId)?.record ?? null),
       participants: of("participant"),
       sessions: of("session"),
       intents: of("intent"),

--- a/tests/process/guard-read-scope.test.mjs
+++ b/tests/process/guard-read-scope.test.mjs
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import { createCoordinationService } from "@agents-can-communicate/core";
+
+import { createFakeClock, createFakeIds, createMemoryStore } from "../helpers/memory-store.mjs";
+
+const run = promisify(execFile);
+const repo = path.resolve(import.meta.dirname, "..", "..");
+const acc = path.join(repo, "bin", "acc.mjs");
+const hook = path.join(repo, "bin", "acc-hook.mjs");
+
+/**
+ * What guarding one write is allowed to cost.
+ *
+ * The guard ran `collectStatus`, which reads every record the workspace holds,
+ * in front of every file an agent writes. Measured at about 1.4ms per stored
+ * record: a workspace carrying 400 messages took 207ms to answer "is this file
+ * claimed", and the cost grows with every message ever sent. The hook's budget
+ * is five seconds, and past it the hook fails open - so a workspace that had
+ * been used enough would stop enforcing claims, silently, with `acc status`
+ * still reporting `protection guarded`.
+ *
+ * Sessions and claims are bounded by what is live. Messages, receipts, tasks and
+ * events are bounded by nothing, and none of them decides whether a write is
+ * allowed. The same read now takes 2ms and does not grow.
+ *
+ * These assert the shape rather than the clock: a timing test on shared CI
+ * measures the machine.
+ */
+function spyStore() {
+  const clock = createFakeClock("2026-08-23T00:00:00.000Z");
+  const store = createMemoryStore({ clock, ids: createFakeIds(), workspaceId: "workspace_a" });
+  const asked = [];
+  const wrapped = { ...store,
+    snapshot: (workspaceId, options) => {
+      asked.push(options?.kinds ?? "everything");
+      return store.snapshot(workspaceId, options);
+    } };
+  return { asked, clock,
+    service: createCoordinationService({ store: wrapped, clock, ids: createFakeIds() }) };
+}
+
+const UNBOUNDED = Object.freeze(["message", "receipt", "task", "event", "decision", "handoff"]);
+
+test("the guard's read asks for nothing that grows without limit", async () => {
+  const { asked, service } = spyStore();
+
+  await service.guardState({ workspaceId: "workspace_a" });
+
+  assert.equal(asked.length, 1);
+  assert.notEqual(asked[0], "everything", "the guard still reads the whole store");
+  for (const kind of UNBOUNDED) {
+    assert.equal(asked[0].includes(kind), false,
+      `the guard reads every ${kind} the workspace has ever held`);
+  }
+});
+
+test("the read a person asks for is still the whole store", async () => {
+  const { asked, service } = spyStore();
+
+  await service.collectStatus({ workspaceId: "workspace_a" });
+
+  // `acc status` reports counts of everything, and narrowing it would be
+  // answering a different question than the one asked.
+  assert.deepEqual(asked, ["everything"]);
+});
+
+test("a kinds-scoped snapshot returns those kinds and leaves the rest empty", async () => {
+  const { service } = spyStore();
+  const session = await service.openSession({ workspaceId: "workspace_a",
+    participantId: "solo", displayName: "solo", harness: "cli",
+    heartbeatCadenceMs: 30_000,
+    descriptor: { id: "workspace_a", roots: ["/tmp/x"], source: "directory" } });
+  await service.sendMessage({ sessionId: session.sessionId, generation: session.generation,
+    toParticipantIds: ["solo"], type: "note", subject: "s", body: "b",
+    descriptor: { id: "workspace_a", roots: ["/tmp/x"], source: "directory" } });
+
+  const narrow = await service.store.snapshot("workspace_a",
+    { kinds: ["workspace", "session", "claim"] });
+  const whole = await service.store.snapshot("workspace_a");
+
+  assert.equal(whole.messages.length, 1);
+  assert.deepEqual(narrow.messages, [], "a kind nobody asked for was read anyway");
+  assert.equal(narrow.sessions.length, whole.sessions.length);
+});
+
+/** The narrowing must not have changed what the guard decides. */
+async function workspace(t) {
+  const base = await realpath(await mkdtemp(path.join(tmpdir(), "acc-scope-")));
+  t.after(() => rm(base, { recursive: true, force: true }));
+  const project = path.join(base, "project");
+  await run("mkdir", ["-p", project]);
+  const env = { ...process.env, ACC_DATA_HOME: path.join(base, "data"),
+    GIT_DIR: "", GIT_WORK_TREE: "" };
+  const attach = async participant => {
+    const child = run(process.execPath, [hook, "codex"],
+      { env: { ...env, ACC_PARTICIPANT: participant } });
+    child.child.stdin.end(JSON.stringify({ hook_event_name: "SessionStart",
+      session_id: participant, cwd: project, source: "startup" }));
+    await child;
+  };
+  const write = participant => {
+    const child = run(process.execPath, [hook, "codex"],
+      { env: { ...env, ACC_PARTICIPANT: participant } });
+    child.child.stdin.end(JSON.stringify({ hook_event_name: "PreToolUse",
+      session_id: participant, cwd: project, tool_name: "apply_patch",
+      tool_input: { command: "*** Begin Patch\n*** Update File: src/a.mjs\n@@\n-a\n+b\n"
+        + "*** End Patch" } }));
+    return child.then(() => "allow", () => "deny");
+  };
+  const cli = (args, who) => run(process.execPath, [acc, ...args, "--cwd", project],
+    { env: { ...env, CLAUDE_CODE_SESSION_ID: who } });
+  return { project, env, attach, write, cli };
+}
+
+test("a claim is still enforced in a workspace full of messages", async t => {
+  const place = await workspace(t);
+  await place.attach("holder");
+  await place.attach("writer");
+  await place.cli(["claim", "--resource", "file:src/**", "--enforcement", "guarded",
+    "--reason", "editing"], "holder");
+  for (let index = 0; index < 20; index += 1) {
+    await place.cli(["message", "--to", "writer", "--subject", `note ${index}`,
+      "--body", "x".repeat(100)], "holder");
+  }
+
+  // The records the guard no longer reads are exactly the ones piled up here.
+  assert.equal(await place.write("writer"), "deny");
+});
+
+test("a claim is enforced before the workspace has materialised", async t => {
+  const place = await workspace(t);
+  await place.attach("holder");
+  await place.attach("writer");
+
+  // Sessions live in the ephemeral area until something durable is written, and
+  // a narrow read that forgot them would guard nothing at the very start.
+  await place.cli(["claim", "--resource", "file:src/**", "--enforcement", "guarded",
+    "--reason", "editing"], "holder");
+
+  assert.equal(await place.write("writer"), "deny");
+  assert.equal(await place.write("holder"), "allow");
+});

--- a/tests/process/surface-coverage.test.mjs
+++ b/tests/process/surface-coverage.test.mjs
@@ -70,6 +70,9 @@ const INTERNAL = Object.freeze({
   acquireCoordinator: "no workstream coordination surface yet - tracked, not forgotten",
   releaseCoordinator: "same",
   recordDecision: "no decision surface yet - tracked, not forgotten",
+  guardState: "the write guard's own read, kept narrow on purpose: `collectStatus` "
+    + "answers the same question and reads the whole store, which put the cost of "
+    + "guarding one write in proportion to every message the workspace had carried",
 });
 
 test("every core operation is reachable, or named as internal on purpose", () => {


### PR DESCRIPTION
The guard ran `collectStatus` in front of **every file an agent writes**, and that reads every record the workspace holds.

Measured, writing messages one at a time through the real service:

```
after   50 messages:  85ms per write
after  200 messages: 286ms per write
after  400 messages: 553ms per write     <- linear, ~1.4ms per stored record

whole store (what collectStatus reads): 207ms
guard's kinds only:                       2ms
```

The hook budget is five seconds, and past it the hook **fails open**. So a workspace used enough would stop enforcing claims — silently, with `acc status` still reporting `protection guarded`. Same family as the four path defects, arrived at by accumulation instead of a wrong path.

## The fix

The guard asks a much smaller question than a person does: *who holds a live claim, and what is that owner called.*

| kind | bounded by |
|---|---|
| sessions, claims | what is live — the guard reads these |
| messages, receipts, tasks, events | **nothing** — and none of them decides whether a write is allowed |

`store.snapshot` takes an optional `kinds`; `guardState` asks for three. `collectStatus` is untouched — it reports counts of everything, and narrowing it would answer a different question than the one asked.

## Pinned by shape, not by the clock

A timing assertion on shared CI measures the machine. Instead a spy records what the guard asks for and fails if any unbounded kind appears in it:

```
✖ the guard's read asks for nothing that grows without limit
  the guard still reads the whole store
```

Two end-to-end tests hold the *decision* steady, since narrowing a read is exactly how you break one: a claim is still enforced in a workspace full of messages, and still enforced **before the workspace has materialised**, when sessions live in the ephemeral area and a careless narrow read would have found none.

The memory store honours `kinds` too. A double that ignores an option the real store implements lets a caller pass its tests and behave differently in the only place that matters.

## What this does not fix

Writing still reads the whole store: every transaction does, for its generation checks. **400 messages written one after another took 163 seconds**, the last of them about half a second each. Recorded under known limitations rather than left for someone to find in a busy workspace. Fine for a project's worth of coordination, not for an archive, and nothing prunes yet.

## Verification

- 710 tests passing, 0 failing · `syntax ok in 155 file(s)`
- `PASS … sha256 efa2083a…03c24 built from e442797`
- Overlaps #32, which is a CHANGELOG-only re-record; whichever lands second needs the digest resolved, and the gate from #30 will say so
