### PR TITLE
fix: put every client's home back, not just the two that were tested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `d716956` |
+| Built from | `08195df` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `17795c2ab191e5b652eadaa15160d8ba37c5c8f48b55b5e8929e40fc889a1bb0` |
-| Tests | 713 passing, 0 failing |
+| sha256 | `082cc3389b169375d3879b785251cc58b8f1aacc2f687d450a556518d224ad39` |
+| Tests | 720 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `add6d30` |
+| Built from | `d716956` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `efa2083a53ea9db5f1436c887f533fa73db6798e64d6be15bcd6a051a8803c24` |
-| Tests | 710 passing, 0 failing |
+| sha256 | `17795c2ab191e5b652eadaa15160d8ba37c5c8f48b55b5e8929e40fc889a1bb0` |
+| Tests | 713 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -68,8 +68,9 @@ workspace identity, so writing one moved the project to a different workspace an
 left every running session heartbeating the old one, invisible to everyone and
 not recovering until its client restarted.
 
-Installing edits configuration for four other tools, so uninstall removes the
-entries ACC recorded writing and nothing else. A settings key ACC had to create
+Installing edits configuration for four other tools, and every one of their homes
+comes back as it was found — byte for byte, with nothing left behind and nothing
+reformatted. Uninstall removes the entries ACC recorded writing and nothing else. A settings key ACC had to create
 goes only when it is empty: plugins the user enabled afterwards live in that same
 key, and taking it outright took them too.
 

--- a/packages/adapter-claude-code/src/install.mjs
+++ b/packages/adapter-claude-code/src/install.mjs
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { bakeSkillCommand, mergeOwnedEntries, ownedEntries, removeInstalledTree,
-  removeOwnedEntries, writeHookShim }
+  removeOwnedEntries, writeForeignJson, writeHookShim }
   from "@agents-can-communicate/adapter-sdk";
 
 const bundle = fileURLToPath(new URL("../plugin", import.meta.url));
@@ -84,6 +84,26 @@ const writeClientJson = async (file, value) => {
   await writeFile(file, text);
 };
 
+// Settings are the user's own file. The two registries above are the client's
+// and keep the convention measured from it; this one keeps whatever the user
+// has.
+const writeSettings = (file, value) =>
+  writeForeignJson(file, value, { readFile, writeFile, mkdir });
+
+/**
+ * Put a registry back, or take it away if ACC is all that was ever in it.
+ *
+ * These two files exist because a plugin was installed. Removing the last entry
+ * and leaving `{}` behind is litter in a home that had neither file before -
+ * measured: an uninstall left both, holding nothing. An empty registry and an
+ * absent one mean the same thing to this client, which defaults to exactly what
+ * removing the entry produced.
+ */
+const writeRegistry = async (file, value, remaining) => {
+  if (remaining > 0) return writeClientJson(file, value);
+  return rm(file, { force: true });
+};
+
 const pluginVersion = async () => (await readJson(manifest, {})).version ?? "0.0.0";
 
 /** The marketplace manifest, in the shape the client's own directory sources use. */
@@ -130,19 +150,24 @@ export async function installClaudePlugin({ configDir, runner, node, now = new D
     [MARKETPLACE]: {
       source: { source: "directory", path: marketplaceDir(configDir) },
       installLocation: marketplaceDir(configDir),
-      lastUpdated: stamp,
+      lastUpdated: known[MARKETPLACE]?.lastUpdated ?? stamp,
     },
   });
 
   const installed = await readJson(installedPluginsPath(configDir),
     { version: 2, plugins: {} });
+  // A re-install of the same version from the same path is not an event, and
+  // stamping it moved bytes in a file ACC only borrows. The comment above
+  // promised a no-op install touched nothing; the timestamps made that false.
+  const [recorded] = installed.plugins?.[QUALIFIED] ?? [];
+  const unchanged = recorded?.installPath === cached && recorded?.version === version;
   await writeClientJson(installedPluginsPath(configDir), {
     ...installed,
     version: 2,
     plugins: {
       ...installed.plugins,
-      [QUALIFIED]: [{ scope: "user", installPath: cached, version,
-        installedAt: stamp, lastUpdated: stamp }],
+      [QUALIFIED]: [unchanged ? recorded : { scope: "user", installPath: cached, version,
+        installedAt: recorded?.installedAt ?? stamp, lastUpdated: stamp }],
     },
   });
 
@@ -151,7 +176,7 @@ export async function installClaudePlugin({ configDir, runner, node, now = new D
   // Entry-level ownership: `enabledPlugins` holds every plugin the user has, so
   // taking the whole key would destroy them and handing it back on uninstall
   // would destroy them again.
-  await writeJson(file, mergeOwnedEntries(existing, {
+  await writeSettings(file, mergeOwnedEntries(existing, {
     extraKnownMarketplaces: {
       [MARKETPLACE]: { source: { source: "directory", path: marketplaceDir(configDir) } },
     },
@@ -170,20 +195,21 @@ export async function uninstallClaudePlugin({ configDir, keep = [] }) {
   const settings = await readJson(file, null);
   if (settings !== null) {
     changes.push(...ownedEntries(settings).map(pair => pair.join("/")));
-    await writeJson(file, removeOwnedEntries(settings));
+    await writeSettings(file, removeOwnedEntries(settings));
   }
 
   // The registries belong to the client. Only ACC's own entry is taken out.
   const known = await readJson(knownMarketplacesPath(configDir), null);
   if (known !== null && Object.hasOwn(known, MARKETPLACE)) {
     const { [MARKETPLACE]: _removed, ...rest } = known;
-    await writeClientJson(knownMarketplacesPath(configDir), rest);
+    await writeRegistry(knownMarketplacesPath(configDir), rest, Object.keys(rest).length);
     changes.push(MARKETPLACE);
   }
   const installed = await readJson(installedPluginsPath(configDir), null);
   if (installed !== null && Object.hasOwn(installed.plugins ?? {}, QUALIFIED)) {
     const { [QUALIFIED]: _gone, ...rest } = installed.plugins;
-    await writeClientJson(installedPluginsPath(configDir), { ...installed, plugins: rest });
+    await writeRegistry(installedPluginsPath(configDir), { ...installed, plugins: rest },
+      Object.keys(rest).length);
     changes.push(QUALIFIED);
   }
 

--- a/packages/adapter-codex/src/install.mjs
+++ b/packages/adapter-codex/src/install.mjs
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { bakeSkillCommand, removeInstalledTree, removeTomlBlock, stripBlock, tomlString,
-  writeHookShim, writeTomlBlock }
+  writeForeignJson, writeHookShim, writeTomlBlock }
   from "@agents-can-communicate/adapter-sdk";
 import { AccError, EXIT } from "@agents-can-communicate/protocol";
 
@@ -62,6 +62,11 @@ const writeJson = async (file, value) => {
   await writeFile(file, `${JSON.stringify(value, null, 2)}\n`);
 };
 
+// The marketplace manifest is the user's: their own plugins are listed beside
+// ACC's. Re-emitting it in ACC's style changed bytes nobody asked to change.
+const writeMarketplace = (file, value) =>
+  writeForeignJson(file, value, { readFile, writeFile, mkdir });
+
 /**
  * The marketplace entry, in the shape this client's parser accepts.
  *
@@ -104,7 +109,7 @@ export async function installCodexPlugin({ home, agentsHome = home,
   // plugins - which is what this used to do - puts a nameless entry into a
   // sequence the client then tries to load.
   const others = (existing.plugins ?? []).filter(entry => entry.name !== PLUGIN_NAME);
-  await writeJson(file, { ...existing, plugins: [...others, entryFor()] });
+  await writeMarketplace(file, { ...existing, plugins: [...others, entryFor()] });
 
   const config = configPath(codexHome);
   // A marketplace declared twice makes this client refuse the whole config, and
@@ -148,7 +153,7 @@ export async function uninstallCodexPlugin({ home, agentsHome = home,
   if (existing !== null) {
     const kept = (existing.plugins ?? []).filter(entry => entry.name !== PLUGIN_NAME);
     if (kept.length !== (existing.plugins ?? []).length) changes.push(PLUGIN_NAME);
-    await writeJson(file, { ...existing, plugins: kept });
+    await writeMarketplace(file, { ...existing, plugins: kept });
   }
   if (await removeTomlBlock(configPath(codexHome))) changes.push(configPath(codexHome));
   // The marketplace directory is ACC's too, so it goes rather than being left

--- a/packages/adapter-gemini-cli/src/install.mjs
+++ b/packages/adapter-gemini-cli/src/install.mjs
@@ -2,7 +2,7 @@ import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { bakeSkillCommand, removeInstalledTree, writeHookShim }
+import { bakeSkillCommand, removeInstalledTree, writeForeignJson, writeHookShim }
   from "@agents-can-communicate/adapter-sdk";
 
 const bundle = fileURLToPath(new URL("../extension", import.meta.url));
@@ -21,10 +21,9 @@ async function readJson(file, fallback) {
   }
 }
 
-const writeJson = async (file, value) => {
-  await mkdir(path.dirname(file), { recursive: true });
-  await writeFile(file, `${JSON.stringify(value, null, 2)}\n`);
-};
+// Settings are the user's file, with their own hooks and their own formatting.
+const writeJson = (file, value) => writeForeignJson(file, value,
+  { readFile, writeFile, mkdir });
 
 const isOurs = hook => typeof hook?.name === "string" && hook.name.startsWith(OWNER_PREFIX);
 

--- a/packages/adapter-kimi/src/install.mjs
+++ b/packages/adapter-kimi/src/install.mjs
@@ -2,7 +2,8 @@ import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { assertRunner, bakeSkillCommand, defaultRunner, removeInstalledTree, runnerExists }
+import { assertRunner, bakeSkillCommand, defaultRunner, removeInstalledTree,
+  runnerExists, writeForeignJson }
   from "@agents-can-communicate/adapter-sdk";
 
 const bundle = fileURLToPath(new URL("../plugin", import.meta.url));
@@ -129,9 +130,9 @@ export async function installKimiPlugin({ home, runner = defaultRunner(), node }
 
   const registry = registryPath(home);
   await mkdir(path.dirname(registry), { recursive: true });
-  await writeFile(registry, `${JSON.stringify(
+  await writeForeignJson(registry,
     registerPlugin(await readJson(registry, { version: 1, plugins: [] }), target),
-    null, 2)}\n`);
+    { readFile, writeFile, mkdir });
 
   return { ok: true, changes: [target, file, registry], diagnostics: [] };
 }
@@ -151,7 +152,16 @@ export async function uninstallKimiPlugin({ home, keep = [] }) {
   if (loaded !== null) {
     const plugins = (loaded.plugins ?? []).filter(entry => entry.id !== PLUGIN_NAME);
     if (plugins.length !== (loaded.plugins ?? []).length) changes.push(registry);
-    await writeFile(registry, `${JSON.stringify({ ...loaded, plugins }, null, 2)}\n`);
+    // The registry exists because a plugin was installed. Leaving an empty one
+    // behind is litter in a home that had no such file - measured after an
+    // uninstall that was otherwise clean. An empty registry and an absent one
+    // mean the same thing to this client.
+    if (plugins.length > 0) {
+      await writeForeignJson(registry, { ...loaded, plugins },
+        { readFile, writeFile, mkdir });
+    } else {
+      await rm(registry, { force: true });
+    }
   }
 
   await removeInstalledTree(pluginPath(home), keep);

--- a/packages/adapter-sdk/src/config-merge.mjs
+++ b/packages/adapter-sdk/src/config-merge.mjs
@@ -120,9 +120,19 @@ export function ownedEntries(existing, { entryOwner = ENTRY_MARKER } = {}) {
  */
 export function jsonStyleOf(text) {
   if (typeof text !== "string") return { indent: 2, trailingNewline: true };
-  const indented = /\n(\s+)\S/.exec(text);
+  // The whitespace itself, not a count of it. `JSON.stringify` takes a string
+  // for its indent, so a tab-indented file stays tab-indented; measuring the
+  // length instead turned one tab into one space and reformatted every line of
+  // a file this exists to leave alone. Matched without `\s`, which would span
+  // the blank line before an indented one and report its own newline as indent.
+  const indented = /\n([ \t]+)\S/.exec(text);
+  // A file written on one line was written that way on purpose, and expanding it
+  // is the same unasked-for rewrite as changing its indent.
+  const oneLine = !text.trimEnd().includes("\n");
+  // Ten is what `JSON.stringify` itself honours; more is silently truncated,
+  // and truncating here keeps what is written equal to what was measured.
   return {
-    indent: indented === null ? 2 : indented[1].replace(/\n/g, "").length,
+    indent: oneLine ? 0 : (indented === null ? 2 : indented[1].slice(0, 10)),
     trailingNewline: text.endsWith("\n"),
   };
 }
@@ -144,7 +154,9 @@ export async function writeForeignJson(file, value, { readFile, writeFile, mkdir
 }
 
 export function formatJsonAs(value, style) {
-  const indent = Number.isInteger(style?.indent) && style.indent > 0 ? style.indent : 2;
+  const measured = style?.indent;
+  const indent = typeof measured === "string" && measured !== "" ? measured
+    : (Number.isInteger(measured) && measured >= 0 ? measured : 2);
   const text = JSON.stringify(value, null, indent);
   return style?.trailingNewline === false ? text : `${text}\n`;
 }

--- a/packages/adapter-sdk/src/config-merge.mjs
+++ b/packages/adapter-sdk/src/config-merge.mjs
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 const MARKER = "acc:owned";
 // Ownership of single entries inside a container someone else also writes to.
 // `enabledPlugins` in a Claude Code settings file holds every plugin the user
@@ -99,4 +101,50 @@ export function removeOwnedEntries(existing,
 
 export function ownedEntries(existing, { entryOwner = ENTRY_MARKER } = {}) {
   return (existing?.[entryOwner] ?? []).map(pair => [...pair]);
+}
+
+/**
+ * Write JSON back into someone else's file, in that file's own style.
+ *
+ * ACC re-emits what it edits, and re-emitting with a fixed style rewrites bytes
+ * it was not asked to touch. Measured after an install and uninstall that
+ * changed nothing else: three clients' configs came back one byte longer, a
+ * trailing newline appended to files that had none. It is the same defect that
+ * was found once in Claude Code's registries and fixed there by hand - fixed for
+ * two files rather than for the shape, so the other three kept doing it.
+ *
+ * The style is read from the file rather than declared per client: what a client
+ * writes is a fact about the client, and asking the file cannot go stale.
+ * Absent file, absent style: a file ACC creates is its own, and gets the
+ * conventional trailing newline.
+ */
+export function jsonStyleOf(text) {
+  if (typeof text !== "string") return { indent: 2, trailingNewline: true };
+  const indented = /\n(\s+)\S/.exec(text);
+  return {
+    indent: indented === null ? 2 : indented[1].replace(/\n/g, "").length,
+    trailingNewline: text.endsWith("\n"),
+  };
+}
+
+/**
+ * Write a file ACC did not create, keeping the shape of what was there.
+ *
+ * Unchanged content is not rewritten at all, so a second install touches
+ * nothing. A file that does not exist yet is ACC's to create, and gets the
+ * conventional trailing newline.
+ */
+export async function writeForeignJson(file, value, { readFile, writeFile, mkdir }) {
+  const current = await readFile(file, "utf8").catch(() => null);
+  const text = formatJsonAs(value, jsonStyleOf(current));
+  if (current === text) return false;
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFile(file, text);
+  return true;
+}
+
+export function formatJsonAs(value, style) {
+  const indent = Number.isInteger(style?.indent) && style.indent > 0 ? style.indent : 2;
+  const text = JSON.stringify(value, null, indent);
+  return style?.trailingNewline === false ? text : `${text}\n`;
 }

--- a/packages/adapter-sdk/src/index.mjs
+++ b/packages/adapter-sdk/src/index.mjs
@@ -8,8 +8,8 @@ export { assertRunner, bakeSkillCommand, defaultCli, defaultRunner, removeInstal
 export { BEGIN, END, removeTomlBlock, renderBlock, stripBlock, tomlString, writeTomlBlock }
   from "./toml-block.mjs";
 export { projectContext } from "./context-projector.mjs";
-export { mergeOwnedConfig, mergeOwnedEntries, ownedEntries, ownedKeys,
-  removeOwnedConfig, removeOwnedEntries } from "./config-merge.mjs";
+export { formatJsonAs, jsonStyleOf, mergeOwnedConfig, mergeOwnedEntries, ownedEntries, ownedKeys,
+  removeOwnedConfig, removeOwnedEntries, writeForeignJson } from "./config-merge.mjs";
 export { clearSessionBinding, listSessionBindings, loadSessionBinding,
   storeSessionBinding }
   from "./session-binding.mjs";

--- a/tests/security/restore-every-client.test.mjs
+++ b/tests/security/restore-every-client.test.mjs
@@ -111,3 +111,35 @@ for (const adapterId of ["codex", "claude_code", "gemini_cli", "kimi"]) {
       `${adapterId} writes something different the second time: ${differing.join(", ")}`);
   });
 }
+
+/**
+ * The style is read from the file, so every style a file can be in has to
+ * survive being read and written back. Counting the indent characters instead
+ * of keeping them turned one tab into one space and reformatted every line of a
+ * file this exists to leave alone.
+ */
+test("a foreign file keeps its own formatting, whatever that is", async t => {
+  const { formatJsonAs, jsonStyleOf } = await import("@agents-can-communicate/adapter-sdk");
+  const shapes = {
+    "tab indented": "{\n\t\"a\": 1\n}",
+    "two spaces": "{\n  \"a\": 1\n}",
+    "four spaces, trailing newline": "{\n    \"a\": 1\n}\n",
+    "all on one line": "{\"a\":1}",
+    "one line, trailing newline": "{\"a\":1}\n",
+    "empty": "{}",
+  };
+
+  for (const [label, text] of Object.entries(shapes)) {
+    const written = formatJsonAs(JSON.parse(text), jsonStyleOf(text));
+    assert.equal(written, text, `${label} came back as ${JSON.stringify(written)}`);
+  }
+  assert.equal(t.name.length > 0, true);
+});
+
+test("a file ACC creates gets the conventional shape", async () => {
+  const { formatJsonAs, jsonStyleOf } = await import("@agents-can-communicate/adapter-sdk");
+
+  // No file, no style to preserve. Two spaces and a trailing newline is what
+  // everything else in this repository writes.
+  assert.equal(formatJsonAs({ a: 1 }, jsonStyleOf(null)), '{\n  "a": 1\n}\n');
+});

--- a/tests/security/restore-every-client.test.mjs
+++ b/tests/security/restore-every-client.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, readdir, realpath, rm, writeFile }
+  from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { ALL_ADAPTERS, clientContext } from "@agents-can-communicate/cli";
+
+/**
+ * Every client's home, put back exactly as it was found.
+ *
+ * The installer edits configuration for four other tools. Two of them were held
+ * to this - Kimi by `installer.test.mjs`, Claude Code after it was caught
+ * leaving a one-byte difference in a file it had only borrowed - and the other
+ * two were not held to it at all.
+ *
+ * The user's settings are the asset here. A tool that edits them has to be able
+ * to prove it can put them back, for every client it touches and not only the
+ * ones someone happened to write a test for.
+ */
+const digest = async file => createHash("sha256").update(await readFile(file)).digest("hex");
+
+/** Every file under a directory, with its digest. Missing directory reads empty. */
+async function fingerprint(root) {
+  const entries = await readdir(root, { recursive: true, withFileTypes: true })
+    .catch(() => []);
+  const files = new Map();
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const file = path.join(entry.parentPath ?? entry.path, entry.name);
+    files.set(path.relative(root, file), await digest(file));
+  }
+  return files;
+}
+
+/**
+ * A home that already looks lived in.
+ *
+ * An empty home proves the weakest version of this: everything ACC wrote can be
+ * deleted outright and the result is still "as found". These are the files
+ * uninstall has to leave alone while removing its own from beside them.
+ */
+async function livedIn(t) {
+  const home = await realpath(await mkdtemp(path.join(tmpdir(), "acc-restore-")));
+  t.after(() => rm(home, { recursive: true, force: true }));
+
+  const write = async (relative, content) => {
+    const file = path.join(home, relative);
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(file, content);
+  };
+  await write(".codex/config.toml",
+    'model = "o3"\n\n[model_providers.mine]\nname = "mine"\n');
+  // Written the way these clients write their own files - two-space JSON - so
+  // that "as found" is a standard about the files a user will actually have.
+  // ACC re-emits what it edits, so a hand-compacted object comes back expanded:
+  // every value survives and the whitespace does not. Recorded as a limitation
+  // rather than asserted here, where it would only be testing the fixture.
+  const clientJson = value => JSON.stringify(value, null, 2);
+  await write(".agents/plugins/marketplace.json",
+    clientJson({ plugins: [{ name: "their-plugin", source: "./x" }] }));
+  await write(".gemini/settings.json",
+    clientJson({ theme: "Dracula", extensions: { "their-extension": true } }));
+  await write(".gemini/extensions/their-extension/gemini-extension.json",
+    clientJson({ name: "x" }));
+  await write(".claude/settings.json",
+    clientJson({ enabledPlugins: { "their-plugin@their-market": true } }));
+  await write(".kimi-code/config.toml", 'default_model = "k3"\n');
+  return home;
+}
+
+for (const adapterId of ["codex", "claude_code", "gemini_cli", "kimi"]) {
+  test(`${adapterId}: install then uninstall leaves the home as it was found`, async t => {
+    const home = await livedIn(t);
+    const adapter = ALL_ADAPTERS().find(item => item.id === adapterId);
+    const before = await fingerprint(home);
+
+    await adapter.install(clientContext(home));
+    const during = await fingerprint(home);
+    assert.notDeepEqual([...during.keys()].sort(), [...before.keys()].sort(),
+      "the install wrote nothing, so this proves nothing about removing it");
+
+    await adapter.uninstall(clientContext(home));
+    const after = await fingerprint(home);
+
+    const changed = [...before]
+      .filter(([file, hash]) => after.get(file) !== hash)
+      .map(([file]) => file);
+    const left = [...after.keys()].filter(file => !before.has(file));
+    assert.deepEqual(changed, [], `${adapterId} did not restore: ${changed.join(", ")}`);
+    assert.deepEqual(left, [], `${adapterId} left files behind: ${left.join(", ")}`);
+  });
+
+  test(`${adapterId}: installing twice is the same as installing once`, async t => {
+    const home = await livedIn(t);
+    const adapter = ALL_ADAPTERS().find(item => item.id === adapterId);
+
+    await adapter.install(clientContext(home));
+    const once = await fingerprint(home);
+    await adapter.install(clientContext(home));
+    const twice = await fingerprint(home);
+
+    // A second install that appends rather than replaces is how a client ends
+    // up registering the same hook twice and firing it twice per event - which
+    // Gemini did, and which showed up as `2 succeeded, 1 failed` on every event.
+    const differing = [...twice].filter(([file, hash]) => once.get(file) !== hash)
+      .map(([file]) => file);
+    assert.deepEqual(differing, [],
+      `${adapterId} writes something different the second time: ${differing.join(", ")}`);
+  });
+}


### PR DESCRIPTION
The installer edits configuration for four other tools and promises to leave it as it found it. **Two clients were held to that** — Kimi by an existing test, Claude Code after it was caught leaving a one-byte difference. The other two were not held to it at all.

Holding all four to it found five things.

| | |
|---|---|
| codex, gemini_cli, claude_code | appended a trailing newline to files that had none |
| claude_code | left `known_marketplaces.json` and `installed_plugins.json` behind, empty |
| kimi | left `plugins/installed.json` behind, empty |
| claude_code | rewrote both registries on a second install |

## The newline, again

```
before: "{\n  \"theme\": \"Dracula\",\n  \"extensions\": {…}\n}"
after:  "{\n  \"theme\": \"Dracula\",\n  \"extensions\": {…}\n}\n"
```

Content identical, one byte appended. This is the **same defect** found once in Claude Code's registries and fixed there by hand — fixed for two files rather than for the shape, so the other three kept doing it.

`writeForeignJson` reads the style out of the file it is about to write, rather than declaring it per client: what a client writes is a fact about the client, and asking the file cannot go stale.

## Empty registries left behind

Both clients' registry files exist *because* a plugin was installed. Removing the last entry and leaving `{}` is litter in a home that had no such file. An empty registry and an absent one mean the same thing to these clients — they default to exactly what removing the entry produced — so the file goes.

## A second install is not an event

Claude Code stamped `lastUpdated` and `installedAt` afresh every time, while the code beside it claimed *"a no-op install touches nothing"*. It did touch something. A re-install of the same version from the same path now keeps the stamps it found.

## The fixtures

The test seeds a home the way these clients write their own files — two-space JSON — so *"as found"* is a standard about files a user will actually have. It also checks the **second** install, not only the uninstall: appending rather than replacing is how Gemini once registered the same hook twice and fired it twice on every event.

A hand-compacted config still comes back expanded — every value survives, the inline whitespace does not. Noted in the test rather than asserted there, where it would only be testing the fixture.

## Verification

- 713 tests passing, 0 failing · `syntax ok in 155 file(s)`
- All five failures reproduce on `main`: 3 pass / 5 fail there, 8 / 0 here
- `PASS … sha256 17795c2a…a1bb0 built from d716956`
- Independent of #33; both touch the CHANGELOG digest line, and the gate from #30 will flag whichever lands second
