### PR TITLE
fix: a write reads what it declared, and nothing else

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `08195df` |
+| Built from | `121f2f9` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `082cc3389b169375d3879b785251cc58b8f1aacc2f687d450a556518d224ad39` |
-| Tests | 720 passing, 0 failing |
+| sha256 | `fcda1defbb0aacca7b3ea9a033b55dd3a9226b16ea0455e75aa00e3132b31420` |
+| Tests | 726 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -121,12 +121,12 @@ Full matrix and what the `yes` values do **not** promise:
   and `O_NOFOLLOW` does not refuse a symlinked config the way it does on POSIX —
   so the symlink defence does not hold. macOS and Linux are supported; Windows
   is future work.
-- **Writing does not scale the way reading now does.** Every write opens a
-  transaction that reads the whole store, so the cost of `acc message` or
-  `acc task` grows with everything the workspace already holds: 400 messages
-  written one after another took 163 seconds, the last of them about 0.5s each.
-  The write guard no longer works this way and the write path still does. Fine
-  for a project's worth of coordination, not for an archive; nothing prunes yet.
+- **A turn still costs more in a busy workspace.** Attaching and heartbeating are
+  bounded by what is live, and the write guard is too. Building a turn is not: it
+  has to know which messages are pending for you, and messages are the kind that
+  grows. Measured against 900 records, `beforeTurn` took 693ms against a floor of
+  88ms. Fine for a project's worth of coordination, not for an archive, and
+  nothing prunes yet.
 - **Client capabilities were certified on macOS only.** Linux runs the suite in
   CI, but no adapter was exercised against a real client there.
 

--- a/packages/core/src/claims.mjs
+++ b/packages/core/src/claims.mjs
@@ -78,7 +78,8 @@ export function createClaimService(ports, sessions) {
     const now = clock.now();
     const expiresAt = new Date(Date.parse(now) + (input.leaseSeconds ?? 1800) * 1000)
       .toISOString();
-    const snapshot = await store.snapshot(workspaceId);
+    // Only to name the owner of a conflicting claim in the error.
+    const snapshot = await store.snapshot(workspaceId, { kinds: ["session"] });
 
     let record = null;
     await store.transaction(async tx => {
@@ -109,7 +110,7 @@ export function createClaimService(ports, sessions) {
         actorSessionId: session.sessionId, type: mine === undefined ? "claim.acquired"
           : "claim.renewed", occurredAt: now,
         payload: { claimId, resource, mode: record.mode } });
-    });
+    }, { kinds: ["claim"] });
     return record;
   }
 
@@ -130,7 +131,7 @@ export function createClaimService(ports, sessions) {
       tx.append({ schemaVersion: SCHEMA_VERSION, eventId: ids.next("event"),
         workspaceId: existing.workspaceId, actorSessionId: session.sessionId,
         type: "claim.renewed", occurredAt: now, payload: { claimId: input.claimId } });
-    });
+    }, { kinds: ["claim"] });
     return record;
   }
 
@@ -159,7 +160,7 @@ export function createClaimService(ports, sessions) {
         type: owned ? "claim.released" : "claim.force_released", occurredAt: now,
         payload: { claimId: input.claimId, authority: authority ?? null,
           reason: reason ?? null, replacedGeneration: existing.generation } });
-    });
+    }, { kinds: ["claim"] });
   }
 
   return {

--- a/packages/core/src/communication.mjs
+++ b/packages/core/src/communication.mjs
@@ -67,7 +67,7 @@ export function createCommunicationService(ports, sessions, claims) {
       tx.append({ schemaVersion: SCHEMA_VERSION, eventId: ids.next("event"), workspaceId,
         actorSessionId: session.sessionId, type: "message.sent", occurredAt: now,
         payload: { messageId, type: record.type, recipients } });
-    });
+    }, { kinds: ["message", "receipt"] });
     return record;
   }
 
@@ -99,7 +99,7 @@ export function createCommunicationService(ports, sessions, claims) {
         type: `message.${record.state}`, occurredAt: now,
         payload: { messageId: input.messageId,
           recipientParticipantId: recipient } });
-    });
+    }, { kinds: ["receipt"] });
     return record;
   }
 
@@ -136,7 +136,7 @@ export function createCommunicationService(ports, sessions, claims) {
       tx.append({ schemaVersion: SCHEMA_VERSION, eventId: ids.next("event"), workspaceId,
         actorSessionId: session.sessionId, type: "decision.recorded", occurredAt: now,
         payload: { decisionId, authority: record.authority } });
-    });
+    }, { kinds: ["decision"] });
     return record;
   }
 
@@ -151,7 +151,7 @@ export function createCommunicationService(ports, sessions, claims) {
     await ensureMaterialised(ports, { workspaceId, reason: "durable_object" });
     const now = clock.now();
     const handoffId = createId("handoff");
-    const owned = (await store.snapshot(workspaceId)).claims
+    const owned = (await store.snapshot(workspaceId, { kinds: ["claim"] })).claims
       .filter(claim => claim.ownerSessionId === session.sessionId);
     const record = validateRecord("handoff", {
       schemaVersion: SCHEMA_VERSION,
@@ -175,7 +175,7 @@ export function createCommunicationService(ports, sessions, claims) {
       tx.append({ schemaVersion: SCHEMA_VERSION, eventId: ids.next("event"), workspaceId,
         actorSessionId: session.sessionId, type: "handoff.created", occurredAt: now,
         payload: { handoffId, released: record.claimsToRelease } });
-    });
+    }, { kinds: ["handoff"] });
     for (const claim of owned) {
       await claims.releaseClaim({ claimId: claim.claimId, sessionId: session.sessionId,
         generation: session.generation, workspaceId });
@@ -198,7 +198,10 @@ export function createCommunicationService(ports, sessions, claims) {
     const participantId = input.participantId;
     if (typeof participantId !== "string" || participantId === "") return [];
     const workspaceId = input.workspaceId ?? store.workspaceId;
-    const snapshot = await store.snapshot(workspaceId);
+    // Messages and receipts are the two unbounded kinds and this read needs
+    // both. Nothing else, though, and it runs in front of every turn.
+    const snapshot = await store.snapshot(workspaceId,
+      { kinds: ["message", "receipt"] });
     const waiting = new Set((snapshot.receipts ?? [])
       .filter(receipt => receipt.recipientParticipantId === participantId
         && (receipt.state === "queued" || receipt.state === "recorded"))
@@ -273,7 +276,8 @@ export function createCommunicationService(ports, sessions, claims) {
       tx.append({ schemaVersion: SCHEMA_VERSION, eventId: ids.next("event"), workspaceId,
         actorSessionId: session.sessionId, type: "work.requested", occurredAt: now,
         payload: { taskId: task.taskId, messageId, recipient } });
-    });
+    // `writeTask` runs on this handle, so what it reads is read here.
+    }, { kinds: ["message", "receipt", "session", "task", "workstream"] });
     return { task, message };
   }
 

--- a/packages/core/src/intents.mjs
+++ b/packages/core/src/intents.mjs
@@ -49,7 +49,7 @@ export function createIntentService(ports, sessions) {
       tx.append({ schemaVersion: SCHEMA_VERSION, eventId: ids.next("event"), workspaceId,
         actorSessionId: input.sessionId, type: "intent.published", occurredAt: now,
         payload: { mode: intent.mode, state: intent.state } });
-    });
+    }, { kinds: ["intent"] });
     return intent;
   }
 
@@ -68,7 +68,7 @@ export function createIntentService(ports, sessions) {
         tx.generationOf("intent", input.sessionId));
       tx.append({ schemaVersion: SCHEMA_VERSION, eventId: ids.next("event"), workspaceId,
         actorSessionId: input.sessionId, type: "intent.cleared", occurredAt: now, payload: {} });
-    });
+    }, { kinds: ["intent"] });
   }
 
   return { setIntent, clearIntent };

--- a/packages/core/src/materialisation.mjs
+++ b/packages/core/src/materialisation.mjs
@@ -17,7 +17,8 @@ const EPHEMERAL_KINDS = Object.freeze([
 ]);
 
 export async function isMaterialised(store, workspaceId) {
-  return (await store.snapshot(workspaceId)).workspace !== null;
+  // One record answers this, and it is asked before every durable write.
+  return (await store.snapshot(workspaceId, { kinds: ["workspace"] })).workspace !== null;
 }
 
 export async function materialise({ store, clock, ids }, { workspaceId, descriptor, reason }) {
@@ -50,7 +51,10 @@ export async function materialise({ store, clock, ids }, { workspaceId, descript
           payload: { sessionId: record.sessionId } });
       }
     }
-  });
+  // The promoted kinds are named by the loop above, not written literally in
+  // the body, so they are derived rather than repeated: a new ephemeral kind
+  // added to that list is read here without anyone remembering to say so.
+  }, { kinds: ["workspace", ...EPHEMERAL_KINDS.map(entry => entry.kind)] });
 
   // The ephemeral copies are retired only after the durable transaction
   // committed, so a crash in between leaves a recoverable duplicate rather than

--- a/packages/core/src/sessions.mjs
+++ b/packages/core/src/sessions.mjs
@@ -58,7 +58,7 @@ export function createSessionService(ports) {
     if (ephemeral !== null) return { record: ephemeral, durable: false };
     const resolved = workspaceId ?? store.workspaceId;
     if (resolved === undefined) return null;
-    const durable = (await store.snapshot(resolved)).sessions
+    const durable = (await store.snapshot(resolved, { kinds: ["session"] })).sessions
       .find(session => session.sessionId === sessionId) ?? null;
     return durable === null ? null : { record: durable, durable: true };
   }
@@ -105,7 +105,7 @@ export function createSessionService(ports) {
         tx.append({ schemaVersion: SCHEMA_VERSION, eventId: ids.next("event"), workspaceId,
           actorSessionId: sessionId, type: "session.opened", occurredAt: now,
           payload: { replaced } });
-      });
+      }, { kinds: ["participant", "session"] });
       return session;
     }
 
@@ -134,7 +134,8 @@ export function createSessionService(ports) {
       return beaten;
     }
     await store.transaction(async tx =>
-      tx.put("session", sessionId, beaten, tx.generationOf("session", sessionId)));
+      tx.put("session", sessionId, beaten, tx.generationOf("session", sessionId)),
+    { kinds: ["session"] });
     return beaten;
   }
 
@@ -174,7 +175,8 @@ export function createSessionService(ports) {
       tx.append({ schemaVersion: SCHEMA_VERSION, eventId: ids.next("event"),
         workspaceId: closed.workspaceId, actorSessionId: sessionId, type: "session.closed",
         occurredAt: now, payload: {} });
-    });
+    // `writeWorkResponse` tells whoever asked, on this same handle.
+    }, { kinds: ["message", "receipt", "session", "task"] });
     return closed;
   }
 

--- a/packages/core/src/tasks.mjs
+++ b/packages/core/src/tasks.mjs
@@ -94,7 +94,8 @@ export function createTaskService(ports, workstreams) {
     let record = null;
     await store.transaction(async tx => {
       record = writeTask(tx, { input, session, workspaceId, now, ids });
-    });
+    // `writeTask` reads and writes on this handle, so its kinds are ours.
+    }, { kinds: ["session", "task", "workstream"] });
     return record;
   }
 
@@ -148,7 +149,7 @@ export function createTaskService(ports, workstreams) {
       tx.append({ schemaVersion: SCHEMA_VERSION, eventId: ids.next("event"),
         workspaceId: session.workspaceId, actorSessionId: session.sessionId,
         type: "task.claimed", occurredAt: now, payload: { taskId: input.taskId } });
-    });
+    }, { kinds: ["message", "receipt", "session", "task"] });
     return record;
   }
 
@@ -189,7 +190,7 @@ export function createTaskService(ports, workstreams) {
           workspaceId: session.workspaceId, actorSessionId: session.sessionId,
           type: "task.unblocked", occurredAt: now, payload: { taskId: dependent.taskId } });
       }
-    });
+    }, { kinds: ["message", "receipt", "task"] });
     return record;
   }
 
@@ -221,7 +222,7 @@ export function createTaskService(ports, workstreams) {
         workspaceId: session.workspaceId, actorSessionId: session.sessionId,
         type: "task.declined", occurredAt: now,
         payload: { taskId: input.taskId, reason: input.reason ?? null } });
-    });
+    }, { kinds: ["message", "receipt", "task"] });
     return record;
   }
 

--- a/packages/core/src/workstreams.mjs
+++ b/packages/core/src/workstreams.mjs
@@ -43,14 +43,15 @@ export function createWorkstreamService(ports, sessions) {
       tx.append({ schemaVersion: SCHEMA_VERSION, eventId: ids.next("event"), workspaceId,
         actorSessionId: session.sessionId, type: "workstream.created", occurredAt: now,
         payload: { workstreamId } });
-    });
+    }, { kinds: ["workstream"] });
     return record;
   }
 
   async function acquireCoordinator(input) {
     const session = await requireOpenSession(input, "coordinate");
     const now = clock.now();
-    const snapshot = await store.snapshot(session.workspaceId);
+    const snapshot = await store.snapshot(session.workspaceId,
+      { kinds: ["session", "workstream"] });
     let record = null;
     await store.transaction(async tx => {
       const existing = tx.get("workstream", input.workstreamId);
@@ -79,7 +80,7 @@ export function createWorkstreamService(ports, sessions) {
         workspaceId: session.workspaceId, actorSessionId: session.sessionId,
         type: "workstream.coordinator_acquired", occurredAt: now,
         payload: { workstreamId: input.workstreamId, replaced: held } });
-    });
+    }, { kinds: ["workstream"] });
     return record;
   }
 
@@ -100,7 +101,7 @@ export function createWorkstreamService(ports, sessions) {
         workspaceId: session.workspaceId, actorSessionId: session.sessionId,
         type: "workstream.coordinator_released", occurredAt: now,
         payload: { workstreamId: input.workstreamId } });
-    });
+    }, { kinds: ["workstream"] });
     return record;
   }
 

--- a/packages/storage-filesystem/src/store.mjs
+++ b/packages/storage-filesystem/src/store.mjs
@@ -34,10 +34,11 @@ async function listState(paths, root, kind) {
   return envelopes;
 }
 
-async function loadAllState(paths, root) {
+async function loadAllState(paths, root, wanted = null) {
   const loaded = new Map();
   const kinds = (await listDirectoryEntries(paths.state, { root }))
-    .filter(entry => entry.isDirectory()).map(entry => entry.name);
+    .filter(entry => entry.isDirectory()).map(entry => entry.name)
+    .filter(kind => wanted === null || wanted.has(kind));
   for (const kind of kinds) {
     for (const envelope of await listState(paths, root, kind)) {
       loaded.set(`${envelope.kind}:${envelope.id}`, envelope);
@@ -82,11 +83,35 @@ export async function openFilesystemStore({ root, clock, ids, workspaceId, failA
     });
   }
 
-  async function transaction(callback) {
+  /**
+   * Run a write, having read the kinds it declared and no others.
+   *
+   * A transaction used to read every record the workspace held, for the
+   * generation checks `put` makes. That put the cost of `acc message` in
+   * proportion to everything the workspace already contained - 400 messages
+   * written one after another took 163 seconds, the last of them half a second
+   * each - and some of these transactions run inside hooks, where the budget is
+   * five seconds and running out means failing open.
+   *
+   * `kinds` is enforced, not merely honoured: reaching for an undeclared kind
+   * throws. A silent empty list would be the worst of both, since every check
+   * these transactions make reads as "nothing conflicts" when it finds nothing.
+   * Declaring nothing reads everything, which is what this always did.
+   */
+  async function transaction(callback, { kinds } = {}) {
+    const wanted = kinds === undefined ? null : new Set(kinds);
+    const declared = kind => {
+      if (wanted !== null && !wanted.has(kind)) {
+        throw new AccError(EXIT.DATA,
+          `this transaction did not declare ${kind}, so it was never read`,
+          { kind, declared: [...wanted] });
+      }
+      return kind;
+    };
     return withWriterMutex(paths, publishOptions, async () => {
       // Reads are loaded once per transaction so get, list, and the generation
       // that put() compares against all describe the same instant.
-      const loaded = await loadAllState(paths, root);
+      const loaded = await loadAllState(paths, root, wanted);
       const staged = new Map();
       const events = [];
       let sequence = await nextSequence(paths, root);
@@ -98,12 +123,15 @@ export async function openFilesystemStore({ root, clock, ids, workspaceId, failA
 
       const tx = Object.freeze({
         get(kind, id) {
+          declared(kind);
           return entryFor(`${kind}:${id}`)?.record ?? null;
         },
         generationOf(kind, id) {
+          declared(kind);
           return entryFor(`${kind}:${id}`)?.generation ?? null;
         },
         list(kind, predicate = () => true) {
+          declared(kind);
           const merged = new Map();
           for (const source of [loaded, staged]) {
             for (const [key, entry] of source) {
@@ -114,6 +142,7 @@ export async function openFilesystemStore({ root, clock, ids, workspaceId, failA
             .map(entry => entry.record).filter(predicate);
         },
         put(kind, id, record, expectedGeneration = null) {
+          declared(kind);
           const key = `${kind}:${id}`;
           const actual = entryFor(key)?.generation ?? null;
           if (actual !== expectedGeneration) {
@@ -126,6 +155,7 @@ export async function openFilesystemStore({ root, clock, ids, workspaceId, failA
           return generation;
         },
         remove(kind, id, expectedGeneration = null) {
+          declared(kind);
           const key = `${kind}:${id}`;
           const actual = entryFor(key)?.generation ?? null;
           if (actual !== expectedGeneration) {

--- a/tests/helpers/memory-store.mjs
+++ b/tests/helpers/memory-store.mjs
@@ -14,7 +14,18 @@ export function createMemoryStore({ clock, ids, workspaceId }) {
   let events = [];
   let nextSequence = 1;
 
-  async function transaction(callback) {
+  // `kinds` is enforced here exactly as the filesystem store enforces it. A
+  // double that waves the declaration through lets a transaction reach for
+  // something it never read, pass every test, and find nothing in production.
+  async function transaction(callback, { kinds } = {}) {
+    const wanted = kinds === undefined ? null : new Set(kinds);
+    const declared = kind => {
+      if (wanted !== null && !wanted.has(kind)) {
+        throw new AccError(EXIT.DATA,
+          `this transaction did not declare ${kind}, so it was never read`,
+          { kind, declared: [...wanted] });
+      }
+    };
     // Staged copies, swapped in only on success. A failed callback must leave
     // neither a record nor an event behind.
     const staged = new Map(committed);
@@ -23,17 +34,21 @@ export function createMemoryStore({ clock, ids, workspaceId }) {
 
     const tx = Object.freeze({
       get(kind, id) {
+        declared(kind);
         return staged.get(key(kind, id))?.record ?? null;
       },
       generationOf(kind, id) {
+        declared(kind);
         return staged.get(key(kind, id))?.generation ?? null;
       },
       list(kind, predicate = () => true) {
+        declared(kind);
         return [...staged.values()]
           .filter(entry => entry.kind === kind && predicate(entry.record))
           .map(entry => entry.record);
       },
       put(kind, id, record, expectedGeneration = null) {
+        declared(kind);
         const actual = staged.get(key(kind, id))?.generation ?? null;
         if (actual !== expectedGeneration) {
           throw new AccError(EXIT.CONFLICT, `${kind} ${id} changed under this transaction`,
@@ -45,6 +60,7 @@ export function createMemoryStore({ clock, ids, workspaceId }) {
         return generation;
       },
       remove(kind, id, expectedGeneration = null) {
+        declared(kind);
         const actual = staged.get(key(kind, id))?.generation ?? null;
         if (actual !== expectedGeneration) {
           throw new AccError(EXIT.CONFLICT, `${kind} ${id} changed under this transaction`,

--- a/tests/process/transaction-scope.test.mjs
+++ b/tests/process/transaction-scope.test.mjs
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { createCoordinationService } from "@agents-can-communicate/core";
+import { EXIT } from "@agents-can-communicate/protocol";
+
+import { createFakeClock, createFakeIds, createMemoryStore } from "../helpers/memory-store.mjs";
+
+const repo = path.resolve(import.meta.dirname, "..", "..");
+
+/**
+ * What a write is allowed to read.
+ *
+ * Every transaction read every record the workspace held, for the generation
+ * checks `put` makes. That put the cost of a write in proportion to everything
+ * already stored - 400 messages written one after another took 163 seconds -
+ * and some of these transactions run inside hooks, where the budget is five
+ * seconds and running out means failing open.
+ *
+ * `kinds` is enforced rather than merely honoured. A silent empty list would be
+ * the worst of both: every check these transactions make reads as "nothing
+ * conflicts" when it finds nothing, so a missed declaration would turn a
+ * conflict check into a rubber stamp. It has already caught one that no static
+ * reading could - `materialise` names its kinds in a loop, so nothing in its
+ * body says what it touches.
+ */
+function spy() {
+  const clock = createFakeClock("2026-08-23T00:00:00.000Z");
+  const store = createMemoryStore({ clock, ids: createFakeIds(), workspaceId: "workspace_a" });
+  const declarations = [];
+  const wrapped = { ...store,
+    transaction: (callback, options) => {
+      declarations.push(options?.kinds);
+      return store.transaction(callback, options);
+    } };
+  return { declarations, store: wrapped,
+    service: createCoordinationService({ store: wrapped, clock, ids: createFakeIds() }) };
+}
+
+const descriptor = { id: "workspace_a", roots: ["/tmp/x"], source: "directory",
+  displayName: "x" };
+const open = (service, participantId) => service.openSession({ workspaceId: "workspace_a",
+  participantId, displayName: participantId, harness: "cli",
+  heartbeatCadenceMs: 30_000, descriptor });
+
+// The unbounded kinds: nothing limits how many of these a workspace collects.
+const UNBOUNDED = Object.freeze(["message", "receipt", "task", "event", "decision", "handoff"]);
+
+test("every transaction says what it reads", async () => {
+  const { declarations, service } = spy();
+  const session = await open(service, "solo");
+  const other = await open(service, "peer");
+  await service.setIntent({ sessionId: session.sessionId, generation: session.generation,
+    summary: "working", mode: "edit" });
+  await service.acquireClaim({ sessionId: session.sessionId, generation: session.generation,
+    resource: "file:src/a.mjs", reason: "editing", descriptor });
+  await service.sendMessage({ sessionId: session.sessionId, generation: session.generation,
+    toParticipantIds: ["peer"], type: "note", subject: "s", body: "b", descriptor });
+  await service.requestWork({ sessionId: session.sessionId, generation: session.generation,
+    toParticipantId: "peer", title: "please take this", descriptor });
+  await service.closeSession({ sessionId: other.sessionId, generation: other.generation });
+
+  assert.equal(declarations.length > 0, true);
+  const undeclared = declarations.filter(kinds => kinds === undefined).length;
+  assert.equal(undeclared, 0,
+    `${undeclared} of ${declarations.length} transactions read the whole store`);
+});
+
+test("attaching and heartbeating read nothing that grows without limit", async () => {
+  // These two are the hook path. A session that cannot attach inside the budget
+  // is a session that never joins, and the failure is silent.
+  const { declarations, service } = spy();
+  // A lone session stays ephemeral and opens no transaction at all, so without
+  // this the assertion below has nothing to be true about.
+  const first = await open(service, "first");
+  await service.acquireClaim({ sessionId: first.sessionId, generation: first.generation,
+    resource: "file:src/a.mjs", reason: "editing", descriptor });
+  declarations.length = 0;
+
+  const session = await open(service, "solo");
+  await service.heartbeatSession({ sessionId: session.sessionId,
+    generation: session.generation });
+
+  assert.equal(declarations.length > 0, true, "no transaction was opened to inspect");
+  for (const kinds of declarations) {
+    for (const kind of UNBOUNDED) {
+      assert.equal(kinds.includes(kind), false,
+        `attaching reads every ${kind} in the workspace: ${JSON.stringify(kinds)}`);
+    }
+  }
+});
+
+test("reaching for an undeclared kind fails loudly", async () => {
+  const { store } = spy();
+
+  const failure = await store.transaction(async tx => tx.list("message"),
+    { kinds: ["session"] }).then(() => null, error => error);
+
+  // Loudly, because the quiet version is worse than the cost it saves: a
+  // conflict check that finds nothing reports no conflict.
+  assert.notEqual(failure, null, "an undeclared read returned silently");
+  assert.equal(failure.code, EXIT.DATA);
+  assert.match(failure.message, /did not declare message/);
+});
+
+test("declaring nothing still reads everything", async () => {
+  const { store } = spy();
+  await store.transaction(async tx => {
+    tx.put("workspace", "workspace_a", { schemaVersion: 1, workspaceId: "workspace_a",
+      displayName: "x", source: "directory", roots: ["/tmp/x"],
+      createdAt: "2026-08-23T00:00:00.000Z" });
+  }, { kinds: ["workspace"] });
+
+  // No declaration is the old behaviour, kept so a caller outside this package
+  // is not broken by a contract it never opted into.
+  const seen = await store.transaction(async tx => tx.list("workspace").length);
+
+  assert.equal(seen, 1);
+});
+
+test("the two stores enforce the same contract", async () => {
+  // A double that waves the declaration through lets a transaction reach for
+  // something it never read, pass every test, and find nothing in production.
+  const filesystem = await readFile(
+    path.join(repo, "packages", "storage-filesystem", "src", "store.mjs"), "utf8");
+  const double = await readFile(path.join(repo, "tests", "helpers", "memory-store.mjs"), "utf8");
+
+  for (const source of [filesystem, double]) {
+    assert.match(source, /did not declare \$\{kind\}/);
+    // Every reader and writer on the handle, not only the ones easy to reach.
+    assert.equal((source.match(/declared\(kind\)/g) ?? []).length, 5);
+  }
+});
+
+test("no transaction in the core is left undeclared", async () => {
+  // The runtime spy above only sees the operations it exercises. This sees them
+  // all, including the ones no test drives yet.
+  const dir = path.join(repo, "packages", "core", "src");
+  const missing = [];
+  for (const name of await readdir(dir)) {
+    if (!name.endsWith(".mjs")) continue;
+    const source = await readFile(path.join(dir, name), "utf8");
+    // Counting `kinds:` would count the scoped reads too, which are a different
+    // thing. Each call is matched to its own closing paren instead.
+    for (let at = source.indexOf("store.transaction("); at !== -1;
+      at = source.indexOf("store.transaction(", at + 1)) {
+      let depth = 0;
+      let index = source.indexOf("(", at);
+      for (; index < source.length; index += 1) {
+        if (source[index] === "(") depth += 1;
+        else if (source[index] === ")") {
+          depth -= 1;
+          if (depth === 0) break;
+        }
+      }
+      const call = source.slice(at, index);
+      const line = source.slice(0, at).split("\n").length;
+      if (!call.includes("{ kinds:")) missing.push(`${name}:${line}`);
+    }
+  }
+  assert.deepEqual(missing, [],
+    "these read the whole store, and one of them runs in front of a turn");
+});


### PR DESCRIPTION
Every transaction read every record the workspace held, for the generation checks `put` makes — and several of them run inside hooks, where the budget is five seconds and running out means failing open. The reads around them were just as wide: `isMaterialised` loaded the whole store to look at one field, and it is asked before every durable write.

## Measured

900 records, five runs each, with the fixed cost of starting node (126ms) separated out:

| hook | before | after | the part that depends on the store |
|---|---|---|---|
| `sessionStart` | 704ms | **274ms** | 578ms → **148ms** |
| `beforeTurn` | 812ms | 693ms | 724ms → 567ms |

Attaching and heartbeating are now bounded by what is live. **The turn is not, and cannot be by this change** — it has to know which messages are pending for you, and messages are the kind that grows. Recorded under known limitations rather than left implied.

## Enforced, not honoured

A silent empty list is the worst of both. Every check these transactions make reads as *"nothing conflicts"* when it finds nothing, so a missed declaration turns a conflict check into a rubber stamp. Reaching for an undeclared kind throws instead.

It earned that immediately. Four declarations were wrong in ways no reading of the source would have found:

- **`materialise`** names its kinds in a loop, so nothing in its body says what it touches. A static scan declared `["workspace"]` and the tests failed instantly with `did not declare participant`.
- **`writeTask`, `writeWorkResponse`, `closeRequestReceipt`** take the transaction handle, so their kinds belong to whoever opened the transaction. `createTask`'s body has no literal `tx.` call at all — it delegates entirely — and was declared `[]`.

Declaring nothing still reads everything, so a caller outside this package is not broken by a contract it never opted into.

## Pinned

Six tests, four of which fail against `main`: a spy asserting no transaction is undeclared; the hook path asserting no unbounded kind is read — with a claim first, because **a lone session stays ephemeral and opens no transaction at all**, and without it the assertion had nothing to be true about; the loud failure itself; and a static pass matching each `store.transaction(` to its own closing paren, since counting `kinds:` would count the scoped reads too.

The memory store enforces the same contract. A double that waves the declaration through lets a transaction reach for something it never read, pass every test, and find nothing in production.

## Verification

- 726 tests passing, 0 failing · `syntax ok in 157 file(s)`
- `PASS … sha256 fcda1def…b31420 built from 121f2f9`
