### PR TITLE
fix: take back a lock whose holder was killed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `121f2f9` |
+| Built from | `2e4b57b` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `fcda1defbb0aacca7b3ea9a033b55dd3a9226b16ea0455e75aa00e3132b31420` |
-| Tests | 726 passing, 0 failing |
+| sha256 | `6e4c3ae84f15a9f902b06c27c6b8e8e2a668317dc440d1f8bec375a59ad0b6c5` |
+| Tests | 730 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -34,6 +34,11 @@ when the working tree is dirty.
 
 Coordinates independent agent sessions in one workspace: presence, intent,
 workspace-global claims, typed messages, handoffs. No session is in charge.
+
+A hook killed by its client no longer takes the workspace down with it. Every
+client puts a timeout on hooks; one killed mid-write used to leave the writer
+lock behind and stop every write for the next sixty seconds — silently, since
+hooks fail open and the session simply never appeared.
 
 An agent that asked and got no answer is told so. Work that stalls and a question
 nobody is left to answer raise the same attention item, because they are the same

--- a/packages/storage-filesystem/src/writer-mutex.mjs
+++ b/packages/storage-filesystem/src/writer-mutex.mjs
@@ -27,12 +27,31 @@ async function readOwner(directory, root) {
   return found?.value ?? null;
 }
 
+/**
+ * Reclaim a lock nobody is holding.
+ *
+ * A hook is a process a client is free to kill, and clients do: they all put a
+ * timeout on it. Killed mid-write, it leaves this directory behind with its own
+ * pid in it. Requiring the lock to be *both* dead and a minute old meant that
+ * for the next sixty seconds no write in the workspace could proceed - no
+ * intent, no claim, no message, and no session could attach. Hooks fail open,
+ * so none of it was visible: the session simply never appeared, and `acc
+ * status` went on reporting the ones that had.
+ *
+ * A dead owner is reclaimed at once. There is nothing to wait for: the lock
+ * holds no state beyond its own owner file, and the process that would have
+ * finished the write is gone.
+ *
+ * The age still matters for the one case liveness cannot answer. A pid is
+ * recycled, so a dead owner's number can come back attached to something
+ * unrelated, and then `pidIsAlive` says yes forever. Sixty seconds is far longer
+ * than any write here takes - the hook budget is five - so a holder that old is
+ * not a writer that is still going.
+ */
 async function takeStaleOwnership(directory, root, owner, now, pidIsAlive) {
   if (owner === null) return false;
   const age = Date.parse(now) - Date.parse(owner.acquiredAt);
-  if (!(age > STALE_MS) || pidIsAlive(owner.pid)) return false;
-  // The owner is both old and gone. Removing the whole directory is safe
-  // because the lock holds no state beyond its own owner file.
+  if (pidIsAlive(owner.pid) && !(age > STALE_MS)) return false;
   await rm(directory, { recursive: true, force: true });
   return true;
 }

--- a/tests/process/leaked-writer-lock.test.mjs
+++ b/tests/process/leaked-writer-lock.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readdir, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import { EXIT } from "@agents-can-communicate/protocol";
+import { withWriterMutex } from "../../packages/storage-filesystem/src/writer-mutex.mjs";
+
+const run = promisify(execFile);
+const repo = path.resolve(import.meta.dirname, "..", "..");
+const acc = path.join(repo, "bin", "acc.mjs");
+const hook = path.join(repo, "bin", "acc-hook.mjs");
+
+/**
+ * A lock left behind by a process that was killed.
+ *
+ * Every client puts a timeout on its hooks and kills them when it expires. A
+ * hook killed mid-write leaves the writer lock behind with its own pid in it,
+ * and reclaiming it required the lock to be *both* dead and a minute old. So one
+ * killed hook stopped every write in the workspace for the next sixty seconds:
+ * no intent, no claim, no message - and no session could attach.
+ *
+ * Measured, with a genuinely dead pid and a fresh timestamp: `acc work` failed
+ * after 1149ms with "another writer holds the store lock", and a new session
+ * took 1147ms to not attach. Hooks fail open, so nothing said so; the session
+ * simply never appeared and `acc status` went on reporting the ones that had.
+ */
+async function locked(t, owner) {
+  const base = await realpath(await mkdtemp(path.join(tmpdir(), "acc-lock-")));
+  t.after(() => rm(base, { recursive: true, force: true }));
+  const paths = { locks: path.join(base, "locks"), tmp: path.join(base, "tmp") };
+  await mkdir(paths.locks, { recursive: true });
+  await mkdir(paths.tmp, { recursive: true });
+  const directory = path.join(paths.locks, "writer.lock");
+  await mkdir(directory);
+  // The owner record is the file's whole content. Wrapping it in `{ value }`
+  // parses, reads as an owner with no pid and no timestamp, and makes the
+  // liveness test pass without ever reaching the code it is about.
+  await writeFile(path.join(directory, "owner.json"), `${JSON.stringify(owner)}\n`);
+  return { base, paths, directory };
+}
+
+const clockAt = now => ({ now: () => now });
+const NOW = "2026-08-23T12:00:00.000Z";
+const held = (pid, acquiredAt) => ({ pid, token: "leaked", acquiredAt });
+
+test("a lock whose holder is gone is taken back at once", async t => {
+  const place = await locked(t, held(4242, NOW));
+
+  const result = await withWriterMutex(place.paths,
+    { root: place.base, clock: clockAt(NOW), pidIsAlive: () => false, attempts: 3, waitMs: 1 },
+    async () => "written");
+
+  assert.equal(result, "written",
+    "a workspace stayed unwritable because a killed process still owned the lock");
+});
+
+test("a lock whose holder is running is left alone", async t => {
+  const place = await locked(t, held(process.pid, NOW));
+
+  const failure = await withWriterMutex(place.paths,
+    { root: place.base, clock: clockAt(NOW), pidIsAlive: () => true, attempts: 3, waitMs: 1 },
+    async () => "written").then(() => null, error => error);
+
+  // The whole point of the lock. Reclaiming faster must not mean reclaiming
+  // from someone who is still writing.
+  assert.notEqual(failure, null, "the lock was taken from a live writer");
+  assert.equal(failure.code, EXIT.CONFLICT);
+});
+
+test("a pid that has been recycled does not hold the lock forever", async t => {
+  const place = await locked(t, held(process.pid, "2026-08-23T11:00:00.000Z"));
+
+  // Liveness cannot answer this one: a dead owner's number comes back attached
+  // to something unrelated and `pidIsAlive` says yes from then on. An hour is
+  // not a write in progress - the hook budget is five seconds.
+  const result = await withWriterMutex(place.paths,
+    { root: place.base, clock: clockAt(NOW), pidIsAlive: () => true, attempts: 3, waitMs: 1 },
+    async () => "written");
+
+  assert.equal(result, "written");
+});
+
+/** The same thing through the real binaries, with a pid that is really gone. */
+async function workspace(t) {
+  const base = await realpath(await mkdtemp(path.join(tmpdir(), "acc-leak-")));
+  t.after(() => rm(base, { recursive: true, force: true }));
+  const project = path.join(base, "project");
+  await mkdir(project, { recursive: true });
+  const env = { ...process.env, ACC_DATA_HOME: path.join(base, "data"),
+    GIT_DIR: "", GIT_WORK_TREE: "" };
+  const attach = async participant => {
+    const child = run(process.execPath, [hook, "codex"],
+      { env: { ...env, ACC_PARTICIPANT: participant } });
+    child.child.stdin.end(JSON.stringify({ hook_event_name: "SessionStart",
+      session_id: participant, cwd: project, source: "startup" }));
+    await child;
+  };
+  const cli = (...argv) => run(process.execPath, [acc, ...argv, "--cwd", project], { env });
+  return { base, env, project, attach, cli };
+}
+
+/** A pid that existed and does not any more. */
+async function departed() {
+  const child = run(process.execPath, ["--eval", "0"]);
+  const { pid } = child.child;
+  await child;
+  return pid;
+}
+
+test("a session can still attach after a hook was killed holding the lock", async t => {
+  const place = await workspace(t);
+  await place.attach("first");
+  // Materialise, so the writes that follow are the durable ones that take the lock.
+  const status = JSON.parse((await place.cli("status", "--json")).stdout).data;
+  await place.cli("claim", "--session", status.participants[0].sessionId,
+    "--resource", "file:x", "--reason", "editing");
+
+  const workspaces = path.join(place.base, "data", "acc", "workspaces");
+  const [workspaceId] = await readdir(workspaces);
+  const directory = path.join(workspaces, workspaceId, "locks", "writer.lock");
+  await mkdir(directory, { recursive: true });
+  await writeFile(path.join(directory, "owner.json"), `${JSON.stringify({
+    pid: await departed(), token: "leaked", acquiredAt: new Date().toISOString(),
+  })}\n`);
+
+  await place.attach("second");
+
+  const after = JSON.parse((await place.cli("status", "--json")).stdout).data;
+  assert.equal(after.counts.live, 2,
+    "the second session never joined, and nothing said so");
+});


### PR DESCRIPTION
Every client puts a timeout on its hooks and kills them when it runs out. A hook killed mid-write leaves the writer lock behind with its own pid in it — and reclaiming that lock required it to be **both** dead **and** a minute old.

So one killed hook stopped every write in the workspace for the next sixty seconds. No intent, no claim, no message, and **no session could attach**.

None of it was visible. Hooks fail open, so the session simply never appeared and `acc status` went on reporting the ones that had:

```
--- lock left by a killed hook, pid 86633 is gone
another writer holds the store lock
    acc work: 1149ms
    a new session attaching: 1147ms
1 live; 1 claim(s); protection advisory        <- should have been 2 live
```

## The fix

```diff
-  if (!(age > STALE_MS) || pidIsAlive(owner.pid)) return false;
+  if (pidIsAlive(owner.pid) && !(age > STALE_MS)) return false;
```

A dead owner is reclaimed at once. There is nothing to wait for: the lock holds no state beyond its own owner file, and the process that would have finished the write is gone.

The age still decides the one case liveness cannot answer — **a pid is recycled**, so a dead owner's number can come back attached to something unrelated and look alive from then on. Sixty seconds is far longer than any write here takes; the hook budget is five.

A live holder is still left alone. That is the point of the lock, and it is pinned as its own test.

## Pinned

| test | on `main` |
|---|---|
| a lock whose holder is gone is taken back at once | **fails** |
| a lock whose holder is running is left alone | passes — the guard against the fix going too far |
| a pid that has been recycled does not hold the lock forever | **fails** |
| a session can still attach after a hook was killed holding the lock | **fails** |

The end-to-end one kills a real process to get a pid that is genuinely gone, rather than asserting against an injected answer.

## One note on the tests themselves

The first test passed before its fixture was right. The owner record is the file's whole content, and I had wrapped it in `{ value }` — which parses, reads as an owner with no pid and no timestamp, and takes the same branch for entirely the wrong reason. Caught because the recycled-pid case *didn't* pass and the two shared the fixture.

## Verification

- 730 tests passing, 0 failing · `syntax ok in 158 file(s)`
- `PASS … sha256 6e4c3ae8…0b6c5 built from 2e4b57b`
