### PR TITLE
fix: let doctor answer on the store it exists to describe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `2e4b57b` |
+| Built from | `196898c` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `6e4c3ae84f15a9f902b06c27c6b8e8e2a668317dc440d1f8bec375a59ad0b6c5` |
-| Tests | 730 passing, 0 failing |
+| sha256 | `a27db53d03b6a067e86bfcc66339cbb41edbc5a3ac13290a8a7316e8dced6a19` |
+| Tests | 735 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -34,6 +34,10 @@ when the working tree is dirty.
 
 Coordinates independent agent sessions in one workspace: presence, intent,
 workspace-global claims, typed messages, handoffs. No session is in charge.
+
+`acc doctor` works on a store nobody can read, which is the only store worth
+running it on. One truncated record used to make it answer "invalid JSON record"
+and name nothing, while the diagnosis it had already built was thrown away.
 
 A hook killed by its client no longer takes the workspace down with it. Every
 client puts a timeout on hooks; one killed mid-write used to leave the writer

--- a/packages/cli/src/doctor-command.mjs
+++ b/packages/cli/src/doctor-command.mjs
@@ -47,8 +47,25 @@ export async function runDoctor({ options, context, runtime }) {
   const report = options.repair === true
     ? await repairFilesystemStore({ root, clock: context.service.clock })
     : await diagnoseFilesystemStore({ root });
-  const status = await context.service.collectStatus({});
   const adapters = await diagnoseAdapters({ options, runtime });
+
+  // Before the store is read for anything else. `collectStatus` reads every
+  // record, so on the store this command exists to describe it threw first and
+  // took the diagnosis with it: one truncated file and `acc doctor` answered
+  // "invalid JSON record", naming nothing, while `inspect` had already found
+  // the file and put it in a list nobody ever saw.
+  if (!report.healthy) {
+    const broken = [...report.blocked, ...report.corrupt];
+    throw new AccError(EXIT.DATA,
+      `store state is ambiguous; repair is blocked. ${broken.length} unreadable:\n  `
+      + `${broken.slice(0, 10).join("\n  ")}`
+      + (broken.length > 10 ? `\n  and ${broken.length - 10} more` : ""),
+      { workspaceId: context.descriptor.id, source: context.descriptor.source,
+        runtimeRoot: root, store: report, adapters,
+        remediation: ["inspect blocked and corrupt paths before repairing"] });
+  }
+
+  const status = await context.service.collectStatus({});
 
   const data = {
     workspaceId: context.descriptor.id,
@@ -59,14 +76,8 @@ export async function runDoctor({ options, context, runtime }) {
     store: report,
     // Capabilities are reported from what is actually installed, never assumed.
     adapters,
-    remediation: [
-      ...(report.healthy ? [] : ["inspect blocked and corrupt paths before repairing"]),
-      ...adapters.flatMap(adapter => adapter.remediation),
-    ],
+    remediation: adapters.flatMap(adapter => adapter.remediation),
   };
-  if (!report.healthy) {
-    throw new AccError(EXIT.DATA, "store state is ambiguous; repair is blocked", data);
-  }
   const installed = adapters.filter(adapter => adapter.installed).length;
   const text = `store healthy; ${status.counts.live} live session(s); `
     + `protection ${status.protection}; ${installed} of ${adapters.length} adapter(s) installed`;

--- a/packages/cli/src/runtime-paths.mjs
+++ b/packages/cli/src/runtime-paths.mjs
@@ -2,11 +2,11 @@ import path from "node:path";
 
 import { AccError, EXIT, assertPortableId } from "@agents-can-communicate/protocol";
 
-const AREAS = ["protocol", "events", "state", "locks", "quarantine", "ephemeral"];
+const AREAS = ["protocol", "events", "state", "locks", "ephemeral"];
 
 /**
  * @typedef {{ root: string, protocol: string, events: string, state: string,
- *   locks: string, quarantine: string, ephemeral: string }} RuntimePaths
+ *   locks: string, ephemeral: string }} RuntimePaths
  */
 
 /**

--- a/packages/cli/test/runtime-paths.test.mjs
+++ b/packages/cli/test/runtime-paths.test.mjs
@@ -13,7 +13,7 @@ test("every runtime location sits under one workspace directory", () => {
   const paths = runtimePaths({ dataHome: DATA_HOME, workspaceId: WORKSPACE });
 
   assert.equal(paths.root, path.join(DATA_HOME, "acc", "workspaces", WORKSPACE));
-  for (const key of ["protocol", "events", "state", "locks", "quarantine", "ephemeral"]) {
+  for (const key of ["protocol", "events", "state", "locks", "ephemeral"]) {
     assert.equal(paths[key].startsWith(`${paths.root}${path.sep}`), true,
       `${key} escaped the workspace runtime root`);
   }

--- a/packages/storage-filesystem/src/atomic-json.mjs
+++ b/packages/storage-filesystem/src/atomic-json.mjs
@@ -93,7 +93,11 @@ export async function readJsonIfPresent(filePath, root) {
   try {
     return { value: JSON.parse(bytes.toString("utf8")), bytes };
   } catch (error) {
-    throw new AccError(EXIT.DATA, "invalid JSON record", { filePath, cause: error.message });
+    // Named in the message, not only in the details: human mode prints the
+    // message alone, and "invalid JSON record" sent a reader looking through a
+    // whole workspace for a file the error already knew.
+    throw new AccError(EXIT.DATA, `invalid JSON record: ${filePath}`,
+      { filePath, cause: error.message });
   }
 }
 

--- a/packages/storage-filesystem/src/store.mjs
+++ b/packages/storage-filesystem/src/store.mjs
@@ -14,7 +14,12 @@ import { withWriterMutex } from "./writer-mutex.mjs";
 
 const SEQUENCE_WIDTH = 16;
 export const ZERO_CURSOR = "0".repeat(SEQUENCE_WIDTH);
-const DIRECTORIES = ["state", "events", "journal", "locks", "quarantine", "ephemeral", "tmp"];
+// No quarantine area. One was created in every workspace, named in the path
+// typedef, and written to by nothing: repair deliberately refuses to move a
+// corrupt record, so nothing ever had a reason to put one aside. An empty
+// directory that reads as a feature is the same mistake as an attention kind
+// with no rule behind it. If quarantining is ever built, it comes back with it.
+const DIRECTORIES = ["state", "events", "journal", "locks", "ephemeral", "tmp"];
 
 const pad = value => String(value).padStart(SEQUENCE_WIDTH, "0");
 

--- a/tests/process/broken-store.test.mjs
+++ b/tests/process/broken-store.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readdir, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import { EXIT } from "@agents-can-communicate/protocol";
+
+const run = promisify(execFile);
+const repo = path.resolve(import.meta.dirname, "..", "..");
+const acc = path.join(repo, "bin", "acc.mjs");
+const hook = path.join(repo, "bin", "acc-hook.mjs");
+
+/**
+ * The command you run when something is wrong has to run when something is
+ * wrong.
+ *
+ * A single truncated record - a writer killed mid-publish, a bad sector - made
+ * `acc status`, `acc sync` and `acc doctor` all answer "invalid JSON record",
+ * naming nothing. The diagnosis had already found the file and put it in a list:
+ * `inspect` walks every record and collects the unreadable ones, and `doctor`
+ * asked `collectStatus` for the roster before looking at that list, so the read
+ * threw and took the diagnosis with it.
+ *
+ * Hooks fail open, which is right, and means the failure is silent from the
+ * agents' side: coordination simply stops.
+ */
+async function broken(t) {
+  const base = await realpath(await mkdtemp(path.join(tmpdir(), "acc-broken-")));
+  t.after(() => rm(base, { recursive: true, force: true }));
+  const project = path.join(base, "project");
+  await mkdir(project, { recursive: true });
+  const env = { ...process.env, ACC_DATA_HOME: path.join(base, "data"),
+    GIT_DIR: "", GIT_WORK_TREE: "" };
+  const cli = (...argv) => run(process.execPath, [acc, ...argv, "--cwd", project], { env });
+
+  for (const participant of ["writer", "reader"]) {
+    const child = run(process.execPath, [hook, "codex"],
+      { env: { ...env, ACC_PARTICIPANT: participant } });
+    child.child.stdin.end(JSON.stringify({ hook_event_name: "SessionStart",
+      session_id: participant, cwd: project, source: "startup" }));
+    await child;
+  }
+  const status = JSON.parse((await cli("status", "--json")).stdout).data;
+  await cli("message", "--session", status.participants[0].sessionId,
+    "--to", "reader", "--subject", "hello", "--body", "world");
+
+  const workspaces = path.join(base, "data", "acc", "workspaces");
+  const [workspaceId] = await readdir(workspaces);
+  const messages = path.join(workspaces, workspaceId, "state", "message");
+  const [name] = await readdir(messages);
+  const file = path.join(messages, name);
+  await writeFile(file, '{ "truncated');
+  return { base, project, env, cli, file, workspaceRoot: path.join(workspaces, workspaceId) };
+}
+
+test("doctor answers on the store it exists to describe", async t => {
+  const place = await broken(t);
+
+  const failure = await place.cli("doctor").then(() => null, error => error);
+
+  assert.notEqual(failure, null, "a corrupt store was reported healthy");
+  assert.equal(failure.code, EXIT.DATA);
+  // Naming the file is the whole job. "invalid JSON record" sent a reader
+  // looking through a workspace for something the error already knew.
+  assert.match(failure.stderr, /repair is blocked/);
+  assert.match(failure.stderr, new RegExp(place.file.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+});
+
+test("doctor in machine mode carries the diagnosis, not just the failure", async t => {
+  const place = await broken(t);
+
+  const failure = await place.cli("doctor", "--json").then(() => null, error => error);
+
+  const body = JSON.parse(failure.stdout);
+  assert.equal(body.ok, false);
+  assert.deepEqual(body.error.details.store.corrupt, [place.file]);
+  // Adapters do not need the store, so their half of the report survives.
+  assert.equal(Array.isArray(body.error.details.adapters), true);
+});
+
+test("a read that cannot parse a record says which record", async t => {
+  const place = await broken(t);
+
+  const failure = await place.cli("status").then(() => null, error => error);
+
+  assert.match(failure.stderr, /invalid JSON record: /);
+  assert.match(failure.stderr, new RegExp(place.file.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+});
+
+test("a hook still refuses to be the reason a session stops", async t => {
+  const place = await broken(t);
+
+  const child = run(process.execPath, [hook, "codex"],
+    { env: { ...place.env, ACC_PARTICIPANT: "reader" } });
+  child.child.stdin.end(JSON.stringify({ hook_event_name: "PreToolUse",
+    session_id: "reader", cwd: place.project, tool_name: "apply_patch",
+    tool_input: { command: "*** Begin Patch\n*** Update File: a.mjs\n@@\n-a\n+b\n"
+      + "*** End Patch" } }));
+
+  // Failing open on a store nobody can read is the right answer and the reason
+  // the failure is invisible from inside a session. Doctor is where it shows.
+  const { stdout } = await child;
+  assert.equal(stdout, "");
+});
+
+test("no directory is created that nothing ever writes to", async t => {
+  const place = await broken(t);
+
+  const areas = await readdir(place.workspaceRoot);
+
+  // A `quarantine` area was created in every workspace and written to by
+  // nothing: repair refuses to move a corrupt record, so nothing ever had a
+  // reason to put one aside. An empty directory that reads as a feature is the
+  // same mistake as an attention kind with no rule behind it.
+  assert.equal(areas.includes("quarantine"), false,
+    "an area exists that no code path writes to");
+});


### PR DESCRIPTION
One truncated record — a writer killed mid-publish, a bad sector — and every command answered the same thing:

```
status:  invalid JSON record
sync:    invalid JSON record
doctor:  invalid JSON record
a turn:  (nothing, exit 0)
```

Hooks fail open, which is right, and means the agents see nothing at all: coordination simply stops.

## The diagnosis already existed

`inspect` walks every record and collects the unreadable ones. `repair` then deliberately refuses to touch a store in that state — *"completing a journal on top of state we cannot even read would turn an ambiguous store into a confidently wrong one."* That stance is right and is unchanged.

What was missing is one line of ordering. `doctor` asked `collectStatus` for the roster **before** looking at the list it had just built, so the read threw and took the diagnosis with it:

```js
const report = await diagnoseFilesystemStore({ root });
const status = await context.service.collectStatus({});   // <- throws here
…
if (!report.healthy) throw new AccError(…, data);          // <- never reached
```

Now:

```
store state is ambiguous; repair is blocked. 1 unreadable:
  <store>/…/state/message/message_Nwh41RXvw2klUleVpDMvfg.json
```

Adapters are diagnosed either way — they do not need the store.

## Two smaller things found alongside

**`invalid JSON record` now names the file.** The path was sitting in the error details, where only `--json` would show it, while human mode prints the message alone and sent a reader hunting through a workspace for something the error already knew.

**The `quarantine` area is gone.** It was created in every workspace, named in the path typedef, and written to by *nothing* — repair refuses to move a corrupt record, so nothing ever had a reason to put one aside. An empty directory that reads as a feature is the same mistake as `nearby_intent`, an attention kind with no rule behind it, which was removed for the same reason. If quarantining is ever built, the directory comes back with it.

## Pinned

Five tests, four failing on `main`. The fifth passes both ways and is the one that must not change: **a hook still refuses to be the reason a session stops.** Failing open on an unreadable store is correct, and is exactly why this was invisible from inside a session — doctor is where it has to show.

## Verification

- 735 tests passing, 0 failing · `syntax ok in 159 file(s)`
- `PASS … sha256 a27db53d…ced6a19 built from 196898c`
