### PR TITLE
fix: an install that failed is a command that failed — and the package could not install at all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `3f7293d` |
+| Built from | `e81aae2` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `ed4288a2412273705d19a26deb294931a9ae4ab17394bd95e72ca3615c86fa3f` |
-| Tests | 739 passing, 0 failing |
+| sha256 | `d020b9bb50e055a7b848cd26478d2391af1b6e0c4ee93ab7ea1fe97f1448a8cd` |
+| Tests | 747 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -34,6 +34,13 @@ when the working tree is dirty.
 
 Coordinates independent agent sessions in one workspace: presence, intent,
 workspace-global claims, typed messages, handoffs. No session is in charge.
+
+`acc install` works from a published package, and says so when it does not. The
+hook runner was located by counting directories up from the SDK, which is right
+in a development checkout and one level short once the workspaces are bundled —
+so every install refused, for every client, from a clean install of the package.
+Nothing caught it: the command counted its failures in a line beginning with a
+success, exited 0, and the release check threw that output away.
 
 `acc status` lists who is here. Closed sessions are kept — the roster is the only
 place that answers which checkout an agent was working in — and `acc status --all`

--- a/packages/adapter-claude-code/src/install.mjs
+++ b/packages/adapter-claude-code/src/install.mjs
@@ -1,5 +1,7 @@
 import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
+
+import { AccError, EXIT } from "@agents-can-communicate/protocol";
 import { fileURLToPath } from "node:url";
 
 import { bakeSkillCommand, mergeOwnedEntries, ownedEntries, removeInstalledTree,
@@ -52,12 +54,26 @@ const cacheRoot = configDir => path.join(pluginsDir(configDir), "cache", MARKETP
 const cachePath = (configDir, version) =>
   path.join(cacheRoot(configDir), PLUGIN_NAME, version);
 
+/**
+ * Read a client's own JSON, and say which file when it will not parse.
+ *
+ * A malformed config is the user's to fix, and the message they get has to name
+ * it. `Unexpected end of JSON input` arrived with no path attached, from an
+ * install that touches four clients' homes, and left them to guess which.
+ */
 async function readJson(file, fallback) {
+  let source;
   try {
-    return JSON.parse(await readFile(file, "utf8"));
+    source = await readFile(file, "utf8");
   } catch (error) {
     if (error.code === "ENOENT") return fallback;
     throw error;
+  }
+  try {
+    return JSON.parse(source);
+  } catch (error) {
+    throw new AccError(EXIT.DATA, `${file} is not valid JSON: ${error.message}`,
+      { file, cause: error.message });
   }
 }
 
@@ -132,6 +148,17 @@ async function layOutPlugin(target, { runner, node }) {
 }
 
 export async function installClaudePlugin({ configDir, runner, node, now = new Date() }) {
+  // Everything this will merge into, read before a byte is written. A settings
+  // file that will not parse used to be discovered after the plugin tree was
+  // already on disk, and the install then failed with nineteen files left
+  // behind, no ownership recorded, and an uninstall that hit the same file and
+  // refused. What the user had to do about it was delete a directory by hand
+  // that nothing had told them the name of.
+  const settings = await readJson(settingsPath(configDir), {});
+  const known = await readJson(knownMarketplacesPath(configDir), {});
+  const installed = await readJson(installedPluginsPath(configDir),
+    { version: 2, plugins: {} });
+
   const version = await pluginVersion();
   const stamp = now.toISOString();
   const source = sourceDir(configDir);
@@ -144,7 +171,6 @@ export async function installClaudePlugin({ configDir, runner, node, now = new D
   // command's only effect is this copy plus the two registry entries below.
   await layOutPlugin(cached, { runner, node });
 
-  const known = await readJson(knownMarketplacesPath(configDir), {});
   await writeClientJson(knownMarketplacesPath(configDir), {
     ...known,
     [MARKETPLACE]: {
@@ -154,8 +180,6 @@ export async function installClaudePlugin({ configDir, runner, node, now = new D
     },
   });
 
-  const installed = await readJson(installedPluginsPath(configDir),
-    { version: 2, plugins: {} });
   // A re-install of the same version from the same path is not an event, and
   // stamping it moved bytes in a file ACC only borrows. The comment above
   // promised a no-op install touched nothing; the timestamps made that false.
@@ -172,7 +196,7 @@ export async function installClaudePlugin({ configDir, runner, node, now = new D
   });
 
   const file = settingsPath(configDir);
-  const existing = await readJson(file, {});
+  const existing = settings;
   // Entry-level ownership: `enabledPlugins` holds every plugin the user has, so
   // taking the whole key would destroy them and handing it back on uninstall
   // would destroy them again.

--- a/packages/adapter-codex/src/install.mjs
+++ b/packages/adapter-codex/src/install.mjs
@@ -38,12 +38,26 @@ const cachePath = codexHome => path.join(cacheRoot(codexHome), PLUGIN_NAME);
 const cachedVersionPath = (codexHome, version) =>
   path.join(cachePath(codexHome), version);
 
+/**
+ * Read a client's own JSON, and say which file when it will not parse.
+ *
+ * A malformed config is the user's to fix, and the message they get has to name
+ * it. `Unexpected end of JSON input` arrived with no path attached, from an
+ * install that touches four clients' homes, and left them to guess which.
+ */
 async function readJson(file, fallback) {
+  let source;
   try {
-    return JSON.parse(await readFile(file, "utf8"));
+    source = await readFile(file, "utf8");
   } catch (error) {
     if (error.code === "ENOENT") return fallback;
     throw error;
+  }
+  try {
+    return JSON.parse(source);
+  } catch (error) {
+    throw new AccError(EXIT.DATA, `${file} is not valid JSON: ${error.message}`,
+      { file, cause: error.message });
   }
 }
 
@@ -92,6 +106,12 @@ const entryFor = () => ({
  */
 export async function installCodexPlugin({ home, agentsHome = home,
   codexHome = path.join(home, ".codex"), runner, node }) {
+  // Read before writing, so a manifest that will not parse is found before a
+  // plugin tree is laid down that nothing will then be able to remove.
+  const existing = await readJson(marketplacePath(agentsHome), { name: MARKETPLACE,
+    interface: { displayName: "Agents Can Communicate" }, plugins: [] });
+  const before = await readFile(configPath(codexHome), "utf8").catch(() => "");
+
   const target = pluginPath(agentsHome);
   await rm(target, { recursive: true, force: true });
   await cp(bundle, target, { recursive: true });
@@ -103,8 +123,6 @@ export async function installCodexPlugin({ home, agentsHome = home,
     withShim(await readJson(path.join(bundle, "hooks.json"), { hooks: {} }), shim));
 
   const file = marketplacePath(agentsHome);
-  const existing = await readJson(file, { name: MARKETPLACE,
-    interface: { displayName: "Agents Can Communicate" }, plugins: [] });
   // Ownership is the entry's own name. Recording it as an extra key beside the
   // plugins - which is what this used to do - puts a nameless entry into a
   // sequence the client then tries to load.
@@ -115,7 +133,6 @@ export async function installCodexPlugin({ home, agentsHome = home,
   // A marketplace declared twice makes this client refuse the whole config, and
   // then every plugin the user has stops working. If they registered it
   // themselves, say so rather than appending a duplicate table.
-  const before = await readFile(config, "utf8").catch(() => "");
   if (stripBlock(before).includes(`[marketplaces.${MARKETPLACE}]`)) {
     throw new AccError(EXIT.CONFLICT,
       `marketplace ${MARKETPLACE} is already registered in this config; `

--- a/packages/adapter-gemini-cli/src/install.mjs
+++ b/packages/adapter-gemini-cli/src/install.mjs
@@ -1,5 +1,7 @@
 import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
+
+import { AccError, EXIT } from "@agents-can-communicate/protocol";
 import { fileURLToPath } from "node:url";
 
 import { bakeSkillCommand, removeInstalledTree, writeForeignJson, writeHookShim }
@@ -12,12 +14,26 @@ const OWNER_PREFIX = "acc-";
 const settingsPath = home => path.join(home, ".gemini", "settings.json");
 const extensionPath = home => path.join(home, ".gemini", "extensions", EXTENSION_NAME);
 
+/**
+ * Read a client's own JSON, and say which file when it will not parse.
+ *
+ * A malformed config is the user's to fix, and the message they get has to name
+ * it. `Unexpected end of JSON input` arrived with no path attached, from an
+ * install that touches four clients' homes, and left them to guess which.
+ */
 async function readJson(file, fallback) {
+  let source;
   try {
-    return JSON.parse(await readFile(file, "utf8"));
+    source = await readFile(file, "utf8");
   } catch (error) {
     if (error.code === "ENOENT") return fallback;
     throw error;
+  }
+  try {
+    return JSON.parse(source);
+  } catch (error) {
+    throw new AccError(EXIT.DATA, `${file} is not valid JSON: ${error.message}`,
+      { file, cause: error.message });
   }
 }
 
@@ -45,6 +61,10 @@ const withShim = (wiring, shim) => ({ hooks: Object.fromEntries(
  * it needs; secrets stay where the user put them.
  */
 export async function installGeminiExtension({ home, runner, node }) {
+  // Read before writing: a settings file that will not parse must not be found
+  // out after the extension tree is already on disk.
+  const existing = await readJson(settingsPath(home), {});
+
   const target = extensionPath(home);
   await rm(target, { recursive: true, force: true });
   await cp(bundle, target, { recursive: true });
@@ -66,7 +86,6 @@ export async function installGeminiExtension({ home, runner, node }) {
   const ours = withShim(await readJson(path.join(bundle, "hooks", "hooks.json"),
     { hooks: {} }), shim);
   const file = settingsPath(home);
-  const existing = await readJson(file, {});
   const merged = { ...existing, hooks: { ...(existing.hooks ?? {}) } };
   for (const [event, entries] of Object.entries(ours.hooks)) {
     const foreign = (merged.hooks[event] ?? [])

--- a/packages/adapter-kimi/src/install.mjs
+++ b/packages/adapter-kimi/src/install.mjs
@@ -1,5 +1,7 @@
 import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
+
+import { AccError, EXIT } from "@agents-can-communicate/protocol";
 import { fileURLToPath } from "node:url";
 
 import { assertRunner, bakeSkillCommand, defaultRunner, removeInstalledTree,
@@ -55,10 +57,22 @@ async function readText(file, fallback) {
   }
 }
 
+/**
+ * Read a client's own JSON, and say which file when it will not parse.
+ *
+ * A malformed config is the user's to fix, and the message they get has to name
+ * it. `Unexpected end of JSON input` arrived with no path attached, from an
+ * install that touches four clients' homes, and left them to guess which.
+ */
 async function readJson(file, fallback) {
   const source = await readText(file, null);
   if (source === null) return fallback;
-  return JSON.parse(source);
+  try {
+    return JSON.parse(source);
+  } catch (error) {
+    throw new AccError(EXIT.DATA, `${file} is not valid JSON: ${error.message}`,
+      { file, cause: error.message });
+  }
 }
 
 /**
@@ -111,6 +125,9 @@ export async function installKimiPlugin({ home, runner = defaultRunner(), node }
   // long as it stays installed: the client reports nothing and ACC simply never
   // sees a session. Writing that entry and hoping is worse than refusing.
   await assertRunner(runner);
+  // Read before writing: a registry that will not parse must be found before a
+  // plugin tree is laid down that nothing will then be able to remove.
+  const registered = await readJson(registryPath(home), { version: 1, plugins: [] });
 
   const target = pluginPath(home);
   await rm(target, { recursive: true, force: true });
@@ -130,8 +147,7 @@ export async function installKimiPlugin({ home, runner = defaultRunner(), node }
 
   const registry = registryPath(home);
   await mkdir(path.dirname(registry), { recursive: true });
-  await writeForeignJson(registry,
-    registerPlugin(await readJson(registry, { version: 1, plugins: [] }), target),
+  await writeForeignJson(registry, registerPlugin(registered, target),
     { readFile, writeFile, mkdir });
 
   return { ok: true, changes: [target, file, registry], diagnostics: [] };

--- a/packages/adapter-sdk/src/hook-shim.mjs
+++ b/packages/adapter-sdk/src/hook-shim.mjs
@@ -1,5 +1,6 @@
 import { access, chmod, mkdir, readFile, readdir, rm, writeFile }
   from "node:fs/promises";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -10,8 +11,38 @@ import { AccError, EXIT } from "@agents-can-communicate/protocol";
  * up on PATH. A hook's environment does not reliably carry the user's PATH, and
  * a command that cannot be found fails silently on every event.
  */
-export const defaultRunner = () =>
-  fileURLToPath(new URL("../../../bin/acc-hook.mjs", import.meta.url));
+/**
+ * The hook runner, found rather than counted to.
+ *
+ * `../../../bin/acc-hook.mjs` is the answer in a development checkout and only
+ * there. Published, this module sits at
+ * `<package>/node_modules/@agents-can-communicate/adapter-sdk/src/`, which is one
+ * level deeper, so the path resolved to `node_modules/bin/acc-hook.mjs` and
+ * every install refused: `the hook runner does not exist`, for every client on
+ * the machine, from a clean `npm install` of the package.
+ *
+ * Nothing caught it. `acc install` exited 0 with the failures counted in a line
+ * that began with a success, and the release check threw that output away - so
+ * the gate reported PASS on a package whose main command could not run.
+ *
+ * Walking up for it holds in both layouts and in whatever a future one is: the
+ * nearest `bin/acc-hook.mjs` above this file is the one that belongs to this
+ * copy of the package.
+ */
+export const defaultRunner = () => {
+  let directory = fileURLToPath(new URL(".", import.meta.url));
+  for (;;) {
+    const candidate = path.join(directory, "bin", "acc-hook.mjs");
+    if (existsSync(candidate)) return candidate;
+    const parent = path.dirname(directory);
+    // Reached the root without finding one. The development answer is returned
+    // so the refusal that follows names a path a reader can recognise.
+    if (parent === directory) {
+      return fileURLToPath(new URL("../../../bin/acc-hook.mjs", import.meta.url));
+    }
+    directory = parent;
+  }
+};
 
 export const runnerExists = async runner => {
   try {

--- a/packages/cli/src/install-command.mjs
+++ b/packages/cli/src/install-command.mjs
@@ -52,6 +52,34 @@ function selectAdapters(requested) {
  * the plan and stops - so what an operator approves is the same object that is
  * then carried out, not a description of it produced somewhere else.
  */
+/**
+ * What the command says it did.
+ *
+ * `installed 0 adapter(s)` was the whole report whether four clients were
+ * absent, one refused, or nothing was asked for. The reasons existed - the plan
+ * carries one per skipped adapter and the result one per failure - and only
+ * `--json` ever showed them.
+ */
+export function describeOutcome({ action, acted, failed = [], skipped = [] }) {
+  return [`${action}ed ${acted} adapter(s)`
+    + (failed.length > 0 ? `; ${failed.length} failed` : ""),
+  ...skipped.map(entry => `  skip ${entry.adapterId}: ${entry.reason}`),
+  ...failed.map(entry => `  ${entry.adapterId}: ${entry.error}`)].join("\n");
+}
+
+/**
+ * A failed adapter ends the command.
+ *
+ * It used to be counted in a line that began with a success and exit 0, which is
+ * what a malformed `~/.claude/settings.json` produced: the adapter refused,
+ * correctly, and the script that ran the installer was told it had worked.
+ */
+export function failureOf({ action, acted, failed = [] }) {
+  if (failed.length === 0) return null;
+  return new AccError(EXIT.DATA,
+    describeOutcome({ action, acted, failed }), { failed });
+}
+
 export async function runInstallCommand({ options, runtime, action = "install" }) {
   const adapters = selectAdapters(options.adapter);
   const home = options.home ?? runtime.env?.HOME ?? homedir();
@@ -66,11 +94,14 @@ export async function runInstallCommand({ options, runtime, action = "install" }
   const result = await applyPlan({ plan, adapters, context, dataHome, dryRun });
 
   const acted = result.operations.filter(operation => operation.applied).length;
-  const text = dryRun
-    ? [`would ${action}:`, ...plan.operations.flatMap(operation => operation.summary),
-      ...plan.skipped.map(entry => `skip ${entry.adapterId}: ${entry.reason}`)].join("\n")
-    : `${action}ed ${acted} adapter(s)`
-      + (result.failed.length > 0 ? `; ${result.failed.length} failed` : "");
+  if (dryRun) {
+    return { data: { ...result, plan, dataHome },
+      text: [`would ${action}:`, ...plan.operations.flatMap(operation => operation.summary),
+        ...plan.skipped.map(entry => `skip ${entry.adapterId}: ${entry.reason}`)].join("\n") };
+  }
 
-  return { data: { ...result, plan, dataHome }, text };
+  return { data: { ...result, plan, dataHome },
+    text: describeOutcome({ action, acted, failed: result.failed,
+      skipped: plan.skipped }),
+    error: failureOf({ action, acted, failed: result.failed }) };
 }

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -260,7 +260,12 @@ export async function main(argv, runtime) {
     const options = context === null ? parsed.options
       : await resolveOwner({ command: parsed.command, options: parsed.options,
         context, env: runtime.env });
-    const { data, text } = await HANDLERS[parsed.command]({ options, context, runtime });
+    const { data, text, error: outcome } = await HANDLERS[parsed.command](
+      { options, context, runtime });
+    // A handler may have done real work and still failed: `acc install` writes
+    // for the clients it could and reports the one it could not. The data is
+    // printed either way, and the command still fails.
+    if (outcome != null) throw Object.assign(outcome, { details: { ...outcome.details, ...data } });
     // Machine mode writes exactly one JSON object to stdout and nothing else.
     if (parsed.options.json === true) await write(runtime.stdout, `${JSON.stringify(ok(data))}\n`);
     else if (text !== "") await write(runtime.stdout, `${human(text)}\n`);

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -149,8 +149,13 @@ async function main() {
     step("install and uninstall");
     await writeFile(path.join(clientHome, "config.toml"), 'default_model = "k3"\n');
     const before = await readFile(path.join(clientHome, "config.toml"), "utf8");
-    await acc("install", "--home", clientHome);
-    await acc("uninstall", "--home", clientHome);
+    // `acc install` fails the command when an adapter fails, so its output is
+    // the diagnosis rather than something to discard.
+    const installed = await acc("install", "--home", clientHome)
+      .catch(error => { fail("install failed", error.stdout || error.message); });
+    const removed = await acc("uninstall", "--home", clientHome)
+      .catch(error => { fail("uninstall failed", error.stdout || error.message); });
+    void installed; void removed;
     const after = await readFile(path.join(clientHome, "config.toml"), "utf8");
     if (after !== before) fail("uninstall did not restore the client config");
     ok("client config restored byte for byte");

--- a/tests/acceptance/packaging.test.mjs
+++ b/tests/acceptance/packaging.test.mjs
@@ -5,6 +5,7 @@ import { mkdir, mkdtemp, readFile, readdir, realpath, rm, writeFile }
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 
 const run = promisify(execFile);
@@ -171,6 +172,36 @@ test("the committed lockfile is the one these manifests produce", async t => {
   assert.equal(await readFile(path.join(into, "package-lock.json"), "utf8"),
     await readFile(path.join(repo, "package-lock.json"), "utf8"),
     "`npm install` rewrites the lockfile, so a clone is dirty before anyone edits it");
+});
+
+test("the installed package can find its own hook runner", async t => {
+  const { tarball } = await packed(t);
+  const consumer = await realpath(await mkdtemp(path.join(tmpdir(), "acc-runner-")));
+  t.after(() => rm(consumer, { recursive: true, force: true }));
+  await writeFile(path.join(consumer, "package.json"),
+    '{"name":"consumer","version":"1.0.0","private":true}\n');
+  await runNpm(["install", "--silent", tarball], { cwd: consumer });
+
+  // Every adapter writes a shim that runs this file, and refuses to install
+  // when it is missing. The path was counted out in `../` from the SDK's own
+  // directory, which is one level shallower once the workspaces are bundled -
+  // so `acc install` refused for every client on the machine, from a clean
+  // install of the package, and said so while exiting 0.
+  // Imported by path from inside the package: the workspaces are bundled, so
+  // they are nested under it rather than hoisted where a consumer could name
+  // them - which is the whole layout difference this is about.
+  const sdk = path.join(consumer, "node_modules", "agents-can-communicate",
+    "node_modules", "@agents-can-communicate", "adapter-sdk", "src", "hook-shim.mjs");
+  const { stdout } = await run(process.execPath, ["--input-type=module", "--eval",
+    `import { defaultRunner } from ${JSON.stringify(pathToFileURL(sdk).href)};
+     import { existsSync } from "node:fs";
+     const runner = defaultRunner();
+     console.log(JSON.stringify({ runner, exists: existsSync(runner) }));`],
+  { cwd: consumer });
+
+  const found = JSON.parse(stdout);
+  assert.equal(found.exists, true,
+    `the installed package looks for its hook runner at ${found.runner}`);
 });
 
 test("the manifest declares the binaries and the engine it was certified on", async t => {

--- a/tests/security/broken-client-config.test.mjs
+++ b/tests/security/broken-client-config.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, readdir, realpath, rm, writeFile }
+  from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import { ALL_ADAPTERS, clientContext } from "@agents-can-communicate/cli";
+import { describeOutcome, failureOf }
+  from "../../packages/cli/src/install-command.mjs";
+import { EXIT } from "@agents-can-communicate/protocol";
+
+const run = promisify(execFile);
+const repo = path.resolve(import.meta.dirname, "..", "..");
+const acc = path.join(repo, "bin", "acc.mjs");
+
+/**
+ * Installing over a config the client itself cannot read.
+ *
+ * Every adapter refused, which is right, and every one of them refused *after*
+ * laying its plugin tree down. So a malformed `~/.claude/settings.json` left
+ * nineteen files behind, no ownership recorded, and an uninstall that hit the
+ * same file and refused too - a directory the user had to find and delete by
+ * hand, whose name nothing had told them.
+ *
+ * And `acc install` said `installed 0 adapter(s); 1 failed` and exited 0. A
+ * script, a CI step, or an agent running the installer was told it had worked.
+ */
+const CONFIGS = Object.freeze({
+  claude_code: ".claude/settings.json",
+  gemini_cli: ".gemini/settings.json",
+  kimi: ".kimi-code/plugins/installed.json",
+  codex: ".agents/plugins/marketplace.json",
+});
+const BROKEN = '{ "enabledPlugins": ';
+
+async function home(t, { broken } = {}) {
+  const base = await realpath(await mkdtemp(path.join(tmpdir(), "acc-badcfg-")));
+  t.after(() => rm(base, { recursive: true, force: true }));
+  const env = { ...process.env, ACC_DATA_HOME: path.join(base, "data"),
+    GIT_DIR: "", GIT_WORK_TREE: "" };
+  const place = path.join(base, "home");
+  await mkdir(place, { recursive: true });
+  if (broken !== undefined) {
+    await mkdir(path.join(place, path.dirname(broken)), { recursive: true });
+    await writeFile(path.join(place, broken), BROKEN);
+  }
+  const cli = (...argv) => run(process.execPath, [acc, ...argv, "--home", place, "--yes"],
+    { env });
+  const ours = async () => (await readdir(place, { recursive: true }))
+    .filter(entry => entry.includes("agents-can-communicate"));
+  return { base, place, env, cli, ours };
+}
+
+for (const [adapterId, config] of Object.entries(CONFIGS)) {
+  test(`${adapterId}: a config it cannot read leaves nothing behind`, async t => {
+    const place = await home(t, { broken: config });
+    const adapter = ALL_ADAPTERS().find(item => item.id === adapterId);
+
+    // The adapter directly, not `acc install`: what is under test is what gets
+    // written, not which clients happen to be on the machine running this.
+    const failure = await adapter.install(clientContext(place.place))
+      .then(() => null, error => error);
+
+    assert.notEqual(failure, null, `${adapterId} installed over a config it cannot read`);
+    assert.match(failure.message, /is not valid JSON/);
+    assert.match(failure.message, new RegExp(path.basename(config)));
+    assert.deepEqual(await place.ours(), [],
+      `${adapterId} wrote its files and then refused`);
+    assert.equal(await readFile(path.join(place.place, config), "utf8"), BROKEN,
+      "the file the user has to fix was rewritten");
+  });
+}
+
+test("a failed adapter ends the command", async () => {
+  // Asserted here rather than by running `acc install`: that acts only on
+  // clients it can find on the machine, and a test that quietly does nothing
+  // wherever none are installed - every CI runner - proves nothing at all.
+  const failure = failureOf({ action: "install", acted: 1,
+    failed: [{ adapterId: "claude_code", error: "settings.json is not valid JSON" }] });
+
+  assert.notEqual(failure, null, "a script would be told the install had worked");
+  assert.equal(failure.code, EXIT.DATA);
+  assert.match(failure.message, /claude_code: settings\.json is not valid JSON/);
+});
+
+test("an outcome with nothing wrong is not an error", async () => {
+  assert.equal(failureOf({ action: "install", acted: 2, failed: [] }), null);
+});
+
+test("the report says why nothing happened", async () => {
+  // `installed 0 adapter(s)` was the whole answer whether four clients were
+  // absent, one refused, or nothing was asked for. Both reasons existed and
+  // only `--json` showed them.
+  const text = describeOutcome({ action: "install", acted: 0,
+    skipped: [{ adapterId: "kimi", reason: "Kimi Code is not installed on this machine" }],
+    failed: [{ adapterId: "codex", error: "marketplace.json is not valid JSON" }] });
+
+  assert.match(text, /skip kimi: Kimi Code is not installed/);
+  assert.match(text, /codex: marketplace\.json is not valid JSON/);
+});


### PR DESCRIPTION
Two defects, the second found by the first within a minute of fixing it.

## 1. A failed install reported success

Installing over a config the client itself cannot read: every adapter refused — right — and every one refused **after** laying its plugin tree down. A malformed `~/.claude/settings.json` left **19 files behind**, no ownership recorded, and an uninstall that hit the same file and refused too. A directory the user had to find and delete by hand, whose name nothing had told them.

And the command said:

```
installed 0 adapter(s); 1 failed
exit 0
```

A script, a CI step, or an agent running the installer was told it had worked.

Now: every adapter reads each foreign config **before** it writes anything; the command exits 4; and the message names the adapter and the file. `installed 0 adapter(s)` was also the whole report whether four clients were absent, one refused, or nothing was asked for — both reasons existed and only `--json` showed them.

## 2. The published package could not install anything

The moment `acc install` started failing loudly, the release check failed:

```
installed 0 adapter(s); 3 failed
  claude_code: refusing to install: the hook runner does not exist
  codex:       refusing to install: the hook runner does not exist
  kimi:        refusing to install: the hook runner does not exist
```

Every adapter writes a shim that runs `bin/acc-hook.mjs`, and the path to it was **counted out in `../`** from the SDK's own directory:

| layout | `../../../bin/acc-hook.mjs` resolves to |
|---|---|
| development checkout | `<repo>/bin/acc-hook.mjs` ✓ |
| published, workspaces bundled | `node_modules/bin/acc-hook.mjs` ✗ |

So from a clean `npm install` of the package, `acc install` refused for every client on the machine — the product's main command, unable to do the one thing it is for.

**Nothing caught it.** The command counted its failures in a line beginning with a success and exited 0, and `scripts/verify-package.mjs` discarded the output of the install it ran. The release gate printed `PASS` on that package.

The runner is found by walking up for it now, which holds in both layouts and in whatever the next one is.

## Pinned where it can be checked anywhere

The four end-to-end install tests only exercise clients that exist on the machine, and a CI runner has none of the four — the first version of these tests passed alone, failed under the full suite, and would have proved nothing on CI. So:

- the tarball is installed and the **installed SDK is asked where it would look**, needing no client at all;
- the reporting is asserted through `describeOutcome`/`failureOf` directly;
- the four adapter-level tests drive `adapter.install()` and check nothing is written.

The release script no longer throws away the output of a command it is checking.

## Verification

- 747 tests passing, 0 failing · `syntax ok in 161 file(s)`
- Both defects reproduce on `main`
- `PASS … sha256 d020b9bb…48a8cd built from e81aae2`
