### PR TITLE
fix: a home that had nothing is left with nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `e81aae2` |
+| Built from | `9e10333` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `d020b9bb50e055a7b848cd26478d2391af1b6e0c4ee93ab7ea1fe97f1448a8cd` |
-| Tests | 747 passing, 0 failing |
+| sha256 | `e0ab2514697f1f11d277ad00720315e2d6142369dfd228a3f5f9aec61d06d63e` |
+| Tests | 749 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -89,7 +89,8 @@ left every running session heartbeating the old one, invisible to everyone and
 not recovering until its client restarted.
 
 Installing edits configuration for four other tools, and every one of their homes
-comes back as it was found — byte for byte, with nothing left behind and nothing
+comes back as it was found — including a home that had none of those files, which
+is left with none of them — byte for byte, with nothing left behind and nothing
 reformatted. Uninstall removes the entries ACC recorded writing and nothing else. A settings key ACC had to create
 goes only when it is empty: plugins the user enabled afterwards live in that same
 key, and taking it outright took them too.

--- a/packages/adapter-claude-code/src/install.mjs
+++ b/packages/adapter-claude-code/src/install.mjs
@@ -4,7 +4,9 @@ import path from "node:path";
 import { AccError, EXIT } from "@agents-can-communicate/protocol";
 import { fileURLToPath } from "node:url";
 
-import { bakeSkillCommand, mergeOwnedEntries, ownedEntries, removeInstalledTree,
+import { acccreatedFile, bakeSkillCommand, blankJson, mergeOwnedEntries, ownedEntries,
+  removeIfEmpty,
+  removeInstalledTree,
   removeOwnedEntries, writeForeignJson, writeHookShim }
   from "@agents-can-communicate/adapter-sdk";
 
@@ -154,7 +156,7 @@ export async function installClaudePlugin({ configDir, runner, node, now = new D
   // behind, no ownership recorded, and an uninstall that hit the same file and
   // refused. What the user had to do about it was delete a directory by hand
   // that nothing had told them the name of.
-  const settings = await readJson(settingsPath(configDir), {});
+  const settings = await readJson(settingsPath(configDir), null);
   const known = await readJson(knownMarketplacesPath(configDir), {});
   const installed = await readJson(installedPluginsPath(configDir),
     { version: 2, plugins: {} });
@@ -197,15 +199,16 @@ export async function installClaudePlugin({ configDir, runner, node, now = new D
 
   const file = settingsPath(configDir);
   const existing = settings;
+  const createdFile = settings === null;
   // Entry-level ownership: `enabledPlugins` holds every plugin the user has, so
   // taking the whole key would destroy them and handing it back on uninstall
   // would destroy them again.
-  await writeSettings(file, mergeOwnedEntries(existing, {
+  await writeSettings(file, mergeOwnedEntries(existing ?? {}, {
     extraKnownMarketplaces: {
       [MARKETPLACE]: { source: { source: "directory", path: marketplaceDir(configDir) } },
     },
     enabledPlugins: { [QUALIFIED]: true },
-  }));
+  }, { createdFile }));
 
   return { ok: true,
     changes: [source, cached, marketplaceFile(configDir),
@@ -236,6 +239,11 @@ export async function uninstallClaudePlugin({ configDir, keep = [] }) {
       Object.keys(rest).length);
     changes.push(QUALIFIED);
   }
+
+  // Only if ACC made it. A settings file holding `{}` looks the same whether
+  // ACC created it or the user did, which is why the install recorded it.
+  await removeIfEmpty(settingsPath(configDir),
+    { readFile, rm, isEmpty: blankJson(), created: acccreatedFile(settings) });
 
   await removeInstalledTree(cacheRoot(configDir), keep);
   await removeInstalledTree(sourceDir(configDir), keep);

--- a/packages/adapter-codex/src/install.mjs
+++ b/packages/adapter-codex/src/install.mjs
@@ -2,7 +2,8 @@ import { cp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { bakeSkillCommand, removeInstalledTree, removeTomlBlock, stripBlock, tomlString,
+import { bakeSkillCommand, blankJson, blankText, removeIfEmpty, removeInstalledTree,
+  removeTomlBlock, stripBlock, tomlString,
   writeForeignJson, writeHookShim, writeTomlBlock }
   from "@agents-can-communicate/adapter-sdk";
 import { AccError, EXIT } from "@agents-can-communicate/protocol";
@@ -175,6 +176,20 @@ export async function uninstallCodexPlugin({ home, agentsHome = home,
   if (await removeTomlBlock(configPath(codexHome))) changes.push(configPath(codexHome));
   // The marketplace directory is ACC's too, so it goes rather than being left
   // behind empty.
+  // A blank TOML config and an absent one are the same to this client, and a
+  // file with nothing in it holds nothing to lose - so no record of who created
+  // it is needed here, unlike the JSON settings where `{}` can be a container
+  // the user made.
+  await removeIfEmpty(configPath(codexHome), { readFile, rm, isEmpty: blankText });
+  // The manifest goes only when what is left is ACC's own marketplace with no
+  // plugins in it. A manifest naming someone else's marketplace is theirs, empty
+  // or not.
+  await removeIfEmpty(marketplacePath(agentsHome), { readFile, rm,
+    isEmpty: text => {
+      const value = JSON.parse(text);
+      return value?.name === MARKETPLACE && (value.plugins ?? []).length === 0;
+    } });
+
   await removeInstalledTree(cacheRoot(codexHome), keep);
   await removeInstalledTree(pluginPath(agentsHome), keep);
   return { ok: true, changes, diagnostics: [] };

--- a/packages/adapter-gemini-cli/src/install.mjs
+++ b/packages/adapter-gemini-cli/src/install.mjs
@@ -4,7 +4,9 @@ import path from "node:path";
 import { AccError, EXIT } from "@agents-can-communicate/protocol";
 import { fileURLToPath } from "node:url";
 
-import { bakeSkillCommand, removeInstalledTree, writeForeignJson, writeHookShim }
+import { acccreatedFile, bakeSkillCommand, blankJson, removeIfEmpty,
+  removeInstalledTree,
+  writeForeignJson, writeHookShim }
   from "@agents-can-communicate/adapter-sdk";
 
 const bundle = fileURLToPath(new URL("../extension", import.meta.url));
@@ -63,7 +65,8 @@ const withShim = (wiring, shim) => ({ hooks: Object.fromEntries(
 export async function installGeminiExtension({ home, runner, node }) {
   // Read before writing: a settings file that will not parse must not be found
   // out after the extension tree is already on disk.
-  const existing = await readJson(settingsPath(home), {});
+  const found = await readJson(settingsPath(home), null);
+  const existing = found ?? {};
 
   const target = extensionPath(home);
   await rm(target, { recursive: true, force: true });
@@ -87,6 +90,9 @@ export async function installGeminiExtension({ home, runner, node }) {
     { hooks: {} }), shim);
   const file = settingsPath(home);
   const merged = { ...existing, hooks: { ...(existing.hooks ?? {}) } };
+  // Recorded now: afterwards a settings file holding `{}` looks the same
+  // whether ACC created it or the user did.
+  if (found === null) merged["acc:createdFile"] = true;
   for (const [event, entries] of Object.entries(ours.hooks)) {
     const foreign = (merged.hooks[event] ?? [])
       .map(entry => ({ ...entry, hooks: (entry.hooks ?? []).filter(hook => !isOurs(hook)) }))
@@ -113,8 +119,12 @@ export async function uninstallGeminiExtension({ home, keep = [] }) {
     const next = { ...existing };
     if (Object.keys(hooks).length > 0) next.hooks = hooks;
     else delete next.hooks;
+    delete next["acc:createdFile"];
     await writeJson(file, next);
   }
+  await removeIfEmpty(settingsPath(home),
+    { readFile, rm, isEmpty: blankJson(), created: acccreatedFile(existing) });
+
   await removeInstalledTree(extensionPath(home), keep);
   return { ok: true, changes, diagnostics: [] };
 }

--- a/packages/adapter-kimi/src/install.mjs
+++ b/packages/adapter-kimi/src/install.mjs
@@ -4,8 +4,8 @@ import path from "node:path";
 import { AccError, EXIT } from "@agents-can-communicate/protocol";
 import { fileURLToPath } from "node:url";
 
-import { assertRunner, bakeSkillCommand, defaultRunner, removeInstalledTree,
-  runnerExists, writeForeignJson }
+import { assertRunner, bakeSkillCommand, blankText, defaultRunner, removeIfEmpty,
+  removeInstalledTree, runnerExists, writeForeignJson }
   from "@agents-can-communicate/adapter-sdk";
 
 const bundle = fileURLToPath(new URL("../plugin", import.meta.url));
@@ -179,6 +179,11 @@ export async function uninstallKimiPlugin({ home, keep = [] }) {
       await rm(registry, { force: true });
     }
   }
+
+  // Blank and absent are the same to this client, so there is nothing to lose
+  // by removing a config that holds nothing - and no record of who created it is
+  // needed, unlike a JSON settings file where `{}` can be the user's own.
+  await removeIfEmpty(configPath(home), { readFile, rm, isEmpty: blankText });
 
   await removeInstalledTree(pluginPath(home), keep);
   return { ok: true, changes, diagnostics: [] };

--- a/packages/adapter-sdk/src/config-merge.mjs
+++ b/packages/adapter-sdk/src/config-merge.mjs
@@ -10,6 +10,11 @@ const ENTRY_MARKER = "acc:ownedEntries";
 // creating one is permission to remove it when it ends up empty, not permission
 // to take whatever the user has put in it since.
 const CREATED_MARKER = "acc:createdContainers";
+// The file itself, as opposed to a container inside it. Recorded at install
+// because uninstall cannot tell afterwards: a settings file holding `{}` looks
+// the same whether ACC made it or the user did, and deleting the user's would
+// be the same overreach as taking a container they had put entries in.
+const CREATED_FILE = "acc:createdFile";
 
 /**
  * Merge ACC entries into a user's config and record ownership, so uninstall can
@@ -54,8 +59,9 @@ export function ownedKeys(existing, { owner = MARKER } = {}) {
  * one the user has since put their own entries into is theirs.
  */
 export function mergeOwnedEntries(existing, additions,
-  { entryOwner = ENTRY_MARKER, createdOwner = CREATED_MARKER } = {}) {
+  { entryOwner = ENTRY_MARKER, createdOwner = CREATED_MARKER, createdFile } = {}) {
   const merged = { ...existing };
+  if (createdFile === true) merged[CREATED_FILE] = true;
   const entries = new Map((existing?.[entryOwner] ?? [])
     .map(pair => [`${pair[0]}\u0000${pair[1]}`, pair]));
   const created = new Set(existing?.[createdOwner] ?? []);
@@ -96,6 +102,7 @@ export function removeOwnedEntries(existing,
   }
   delete result[entryOwner];
   delete result[createdOwner];
+  delete result[CREATED_FILE];
   return removeOwnedConfig(result, { owner });
 }
 
@@ -160,3 +167,49 @@ export function formatJsonAs(value, style) {
   const text = JSON.stringify(value, null, indent);
   return style?.trailingNewline === false ? text : `${text}\n`;
 }
+
+/**
+ * Remove a file ACC wrote once nothing is left in it.
+ *
+ * The same rule as a container ACC created: what is empty was ACC's alone, and
+ * leaving it is litter in a home that did not have it. Measured after an install
+ * and uninstall in a home that started with nothing - four files left behind,
+ * two of them empty, one a marketplace manifest naming ACC's own marketplace.
+ *
+ * It was already fixed for two registries. The fixture that proved it seeded
+ * every config first, so the branch where ACC creates the file was never taken:
+ * the instance was fixed and the shape was not.
+ */
+export function acccreatedFile(value) {
+  return value?.[CREATED_FILE] === true;
+}
+
+export async function removeIfEmpty(file, { readFile, rm, isEmpty, created = true }) {
+  if (created !== true) return false;
+  const current = await readFile(file, "utf8").catch(() => null);
+  if (current === null) return false;
+  let empty;
+  try {
+    empty = isEmpty(current);
+  } catch {
+    // Unparseable is not empty. A file nobody can read is the user's to fix,
+    // and deleting it would take whatever it was meant to hold.
+    return false;
+  }
+  if (!empty) return false;
+  await rm(file, { force: true });
+  return true;
+}
+
+/** Nothing but whitespace, for the clients whose config is TOML. */
+export const blankText = text => text.trim() === "";
+
+/** An object with no keys, or only the ones named as ACC's own. */
+export const blankJson = (ours = []) => text => {
+  const value = JSON.parse(text);
+  if (value === null || typeof value !== "object") return false;
+  return Object.entries(value)
+    .every(([key, held]) => ours.includes(key)
+      || (Array.isArray(held) ? held.length === 0
+        : held !== null && typeof held === "object" && Object.keys(held).length === 0));
+};

--- a/packages/adapter-sdk/src/index.mjs
+++ b/packages/adapter-sdk/src/index.mjs
@@ -9,7 +9,8 @@ export { BEGIN, END, removeTomlBlock, renderBlock, stripBlock, tomlString, write
   from "./toml-block.mjs";
 export { projectContext } from "./context-projector.mjs";
 export { formatJsonAs, jsonStyleOf, mergeOwnedConfig, mergeOwnedEntries, ownedEntries, ownedKeys,
-  removeOwnedConfig, removeOwnedEntries, writeForeignJson } from "./config-merge.mjs";
+  acccreatedFile, removeIfEmpty, removeOwnedConfig, removeOwnedEntries, writeForeignJson,
+  blankJson, blankText } from "./config-merge.mjs";
 export { clearSessionBinding, listSessionBindings, loadSessionBinding,
   storeSessionBinding }
   from "./session-binding.mjs";

--- a/tests/security/installer.test.mjs
+++ b/tests/security/installer.test.mjs
@@ -162,16 +162,18 @@ test("uninstall keeps plugins the user enabled after the install", async t => {
   assert.equal(Object.hasOwn(after, "acc:createdContainers"), false);
 });
 
-test("uninstall leaves no empty container behind either", async t => {
-  const { adapter, context, read } = await claudeHome(t);
+test("uninstall leaves no empty container behind, nor the file that held it", async t => {
+  const { adapter, context, settings } = await claudeHome(t);
   await adapter.install(context);
   await adapter.uninstall(context);
 
-  // Nothing else ever wanted the key, so keeping it would be litter in a file
-  // ACC only borrowed - the same standard as restoring a config byte for byte.
-  const after = await read();
-  assert.equal(Object.hasOwn(after, "enabledPlugins"), false);
-  assert.equal(Object.hasOwn(after, "extraKnownMarketplaces"), false);
+  // Nothing else ever wanted the key, and this home had no settings file before
+  // the install, so the file goes with it. Keeping either would be litter in a
+  // place ACC only borrowed - the same standard as restoring a config byte for
+  // byte. Which of the two happens depends on whether ACC created the file, and
+  // the install records that because afterwards `{}` looks identical either way.
+  assert.equal(await readFile(settings, "utf8").then(() => true, () => false), false,
+    "a settings file ACC created and then emptied was left behind");
 });
 
 test("a container the user already had survives uninstall", async t => {

--- a/tests/security/restore-every-client.test.mjs
+++ b/tests/security/restore-every-client.test.mjs
@@ -113,6 +113,45 @@ for (const adapterId of ["codex", "claude_code", "gemini_cli", "kimi"]) {
 }
 
 /**
+ * A home that had none of these files to begin with.
+ *
+ * The fixture above seeds every config, so the branch where ACC *creates* one
+ * was never taken. In a home that starts empty, install and uninstall left four
+ * files behind - two of them empty, one a marketplace manifest naming ACC's own
+ * marketplace. Two registries had already been fixed for exactly this; the
+ * instance was fixed and the shape was not, so this checks both fixtures.
+ */
+test("a home that had nothing is left with nothing", async t => {
+  const home = await realpath(await mkdtemp(path.join(tmpdir(), "acc-empty-")));
+  t.after(() => rm(home, { recursive: true, force: true }));
+
+  for (const adapter of ALL_ADAPTERS()) {
+    await adapter.install(clientContext(home));
+    await adapter.uninstall(clientContext(home));
+  }
+
+  const left = [...(await fingerprint(home)).keys()].sort();
+  assert.deepEqual(left, [],
+    `an install and its removal left files in a home that had none: ${left.join(", ")}`);
+});
+
+test("a file with anything of the user's in it is not removed as empty", async t => {
+  const { blankJson, blankText } = await import("@agents-can-communicate/adapter-sdk");
+
+  // The rule is "nothing left", not "nothing ACC recognises". A key the user
+  // added, a value in a container, a line of TOML - any of them means the file
+  // is theirs and stays.
+  assert.equal(blankText("   \n "), true);
+  assert.equal(blankText('model = "o3"\n'), false);
+  assert.equal(blankJson()("{}"), true);
+  assert.equal(blankJson()('{ "enabledPlugins": {} }'), true);
+  assert.equal(blankJson()('{ "enabledPlugins": { "theirs": true } }'), false);
+  assert.equal(blankJson()('{ "theme": "Dracula" }'), false);
+  assert.equal(blankJson(["name"])('{ "name": "acc-local", "plugins": [] }'), true);
+  assert.equal(blankJson(["name"])('{ "name": "acc-local", "plugins": [{ "x": 1 }] }'), false);
+});
+
+/**
  * The style is read from the file, so every style a file can be in has to
  * survive being read and written back. Counting the indent characters instead
  * of keeping them turned one tab into one space and reformatted every line of a


### PR DESCRIPTION
Found while running the whole negotiated loop through a package installed from the tarball — the path that #39 had just made usable. Install and uninstall in a home that started **empty** left four files:

```
~/.kimi-code/config.toml            (blank)
~/.claude/settings.json             {}
~/.codex/config.toml                (blank)
~/.agents/plugins/marketplace.json  { "name": "acc-local", … "plugins": [] }
```

This had already been fixed for two of Claude Code's registries. **The fixture that proved it seeded every config first**, so the branch where ACC *creates* the file was never taken — the instance was fixed and the shape was not. Both fixtures are checked now.

## What can be lost decides how much is recorded

| file | rule | why |
|---|---|---|
| JSON settings | removed only if the install recorded `acc:createdFile` | `{}` looks identical whether ACC made it or the user did, and deleting theirs is the same overreach as taking a container they had put entries in |
| TOML config | removed when blank | absent and empty read alike to both clients, so there is nothing to lose and nothing to record |
| marketplace manifest | removed only when what remains is **ACC's own** marketplace with no plugins | one naming someone else's marketplace is theirs, empty or not |

Verified in both directions:

```
empty home                                    -> 0 files left
a settings file the user made, holding {}     -> byte-for-byte unchanged
```

## One older test got stricter

It asserted that no empty container was left in the settings file. In a home that starts empty the answer is now that the file goes too, which is more than it was asking for — so it asserts that instead.

## Verification

- 749 tests passing, 0 failing · `syntax ok in 161 file(s)`
- `a home that had nothing is left with nothing` fails on `main`
- `PASS … sha256 e0ab2514…6d63e built from 9e10333`
