### PR TITLE
fix: hand an MCP client its mail, and let agents start at the same time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `9e10333` |
+| Built from | `b6d2cb1` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `e0ab2514697f1f11d277ad00720315e2d6142369dfd228a3f5f9aec61d06d63e` |
-| Tests | 749 passing, 0 failing |
+| sha256 | `8e079d309cf33eda4947ef09cbfe3a216c6a3581d1ca57f5c267af7743c9d5b6` |
+| Tests | 756 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -62,6 +62,15 @@ fact: you asked, and there is nobody there.
 Every line of an injected turn can be acted on. An attention line carries the id
 of the thing it is about — the same id the command that answers it takes — and a
 turn the byte budget truncated says how to read what it withheld.
+
+Agents that start at the same time in a workspace none of them has opened all get
+in. Three of four used to fail: the identity document each writes first carries
+the moment it was written, and materialisation asked whether it was needed before
+taking the lock that would have answered.
+
+An MCP client is handed its messages by `acc_sync`, body and all, and its receipts
+move — it had only ever seen a subject line, and the sender was told its message
+was undelivered by an agent that had answered it.
 
 A peer's message reaches the recipient's turn as a fenced, attributed, escaped
 block, and its receipt advances to `injected` only for what the turn actually

--- a/packages/core/src/materialisation.mjs
+++ b/packages/core/src/materialisation.mjs
@@ -31,19 +31,32 @@ export async function materialise({ store, clock, ids }, { workspaceId, descript
     ?? "session_bootstrap";
 
   await store.transaction(async tx => {
-    tx.put("workspace", workspaceId, {
-      schemaVersion: SCHEMA_VERSION,
-      workspaceId,
-      displayName: descriptor?.displayName ?? workspaceId,
-      source: descriptor?.source ?? "directory",
-      roots: descriptor?.roots ?? [],
-      createdAt: now,
-    });
-    tx.append({ schemaVersion: SCHEMA_VERSION, eventId: ids.next("event"), workspaceId,
-      actorSessionId, type: "workspace.materialised", occurredAt: now, payload: { reason } });
+    // Asked again inside the lock. `ensureMaterialised` asks before taking it,
+    // which is a check-then-act across processes: agents starting together in a
+    // workspace neither had opened - the ordinary way two agents start - all saw
+    // "not materialised", and every one but the first was refused with
+    // `workspace ... changed under this transaction` and could not attach.
+    const already = tx.get("workspace", workspaceId) !== null;
+    if (!already) {
+      tx.put("workspace", workspaceId, {
+        schemaVersion: SCHEMA_VERSION,
+        workspaceId,
+        displayName: descriptor?.displayName ?? workspaceId,
+        source: descriptor?.source ?? "directory",
+        roots: descriptor?.roots ?? [],
+        createdAt: now,
+      });
+      tx.append({ schemaVersion: SCHEMA_VERSION, eventId: ids.next("event"), workspaceId,
+        actorSessionId, type: "workspace.materialised", occurredAt: now,
+        payload: { reason } });
+    }
 
     for (const entry of staged) {
       for (const record of entry.records) {
+        // Whoever got here first may have promoted this record already, and
+        // promoting is a copy: the ephemeral and durable shapes are the same,
+        // so the one already there is the one this would write.
+        if (tx.get(entry.kind, record[entry.key]) !== null) continue;
         tx.put(entry.kind, record[entry.key], record);
         if (entry.event === null) continue;
         tx.append({ schemaVersion: SCHEMA_VERSION, eventId: ids.next("event"), workspaceId,

--- a/packages/mcp-server/src/server.mjs
+++ b/packages/mcp-server/src/server.mjs
@@ -71,6 +71,43 @@ async function resolveSession(context) {
   return session;
 }
 
+/**
+ * A poll is this client's turn.
+ *
+ * The hook runtime hands a session its pending messages when it builds a turn,
+ * and marks them delivered. An MCP client has no turn and no hook, and no tool
+ * ever handed it anything: it saw a `direct_request` line carrying a subject and
+ * an id, and to read what a peer had actually said it had to ask for the whole
+ * snapshot and search every message in the workspace for its own name.
+ *
+ * The receipt never moved either. It stayed `queued` for as long as the client
+ * ran, so the sender was told its message had not been delivered by an agent
+ * that had answered it.
+ *
+ * Returning them here is delivery, in the same sense and with the same honesty
+ * as the turn: what is handed over is marked `injected`, and nothing else is.
+ * Acknowledgement stays a separate act, because being shown something is not
+ * agreeing to it.
+ */
+async function syncWithMail(service, owner, context, args) {
+  const sync = await service.sync({ ...owner, cursor: args.cursor ?? null,
+    scope: args.scope, limit: args.limit });
+  const messages = await service.pendingMessages({
+    workspaceId: context.workspaceId,
+    participantId: context.participantId,
+    exceptSessionId: owner.sessionId });
+  if (messages.length === 0) return sync;
+
+  for (const message of messages) {
+    // One failure must not swallow the rest: the client is holding the message
+    // either way, and a receipt that cannot be written is not a reason to hide
+    // what a peer said.
+    await service.markDelivery({ ...owner, messageId: message.messageId,
+      state: "injected" }).catch(() => null);
+  }
+  return { ...sync, messages };
+}
+
 async function callTool(name, args, context) {
   const session = await resolveSession(context);
   const owner = { sessionId: session.sessionId, generation: session.generation,
@@ -79,8 +116,7 @@ async function callTool(name, args, context) {
 
   switch (name) {
     case "acc_sync":
-      return service.sync({ ...owner, cursor: args.cursor ?? null, scope: args.scope,
-        limit: args.limit });
+      return syncWithMail(service, owner, context, args);
     case "acc_work":
       if (args.clear === true) return service.clearIntent({ ...owner });
       return service.setIntent({ ...owner, summary: args.summary, mode: args.mode,

--- a/packages/storage-filesystem/src/identity.mjs
+++ b/packages/storage-filesystem/src/identity.mjs
@@ -38,7 +38,20 @@ export async function requireStoreIdentity(paths, { workspaceId, clock, create =
     throw new AccError(EXIT.DATA, "store is not initialised", { filePath });
   }
   const record = { storeVersion: STORE_VERSION, workspaceId, initialisedAt: clock.now() };
-  await publishAtomic(filePath, encode(record), { root: paths.root, tmpDir: paths.tmp });
+  try {
+    await publishAtomic(filePath, encode(record), { root: paths.root, tmpDir: paths.tmp });
+  } catch (error) {
+    // Losing this race is not a failure. Two agents starting together in a
+    // workspace neither has opened before is the ordinary case, and the two
+    // identity documents they write differ in one field - the moment each was
+    // written - so the second was refused for "different bytes" and that agent
+    // could not attach at all.
+    //
+    // What the store has to refuse is a directory belonging to a *different*
+    // workspace, and that is decided below by reading what is actually there
+    // rather than by whose bytes arrived first.
+    if (error.code !== EXIT.CONFLICT) throw error;
+  }
   const published = await readJsonIfPresent(filePath, paths.root);
   return assertIdentity(published.value, workspaceId, filePath);
 }

--- a/tests/acceptance/mcp-only.test.mjs
+++ b/tests/acceptance/mcp-only.test.mjs
@@ -123,3 +123,104 @@ test("the MCP client sees the peer's claim, so it can choose to respect it", asy
   assert.equal(text.includes("file:src/**"), true,
     "the claim was not visible to the MCP client");
 });
+
+/**
+ * A poll is this client's turn.
+ *
+ * The hook runtime hands a session its pending messages when it builds a turn.
+ * An MCP client has no turn and no hook, and no tool handed it anything: it saw
+ * a `direct_request` line carrying a subject and an id, and to read what a peer
+ * had actually said it had to ask for the whole snapshot and search every
+ * message in the workspace for its own name. The receipt stayed `queued` for as
+ * long as the client ran, so the sender was told its message had not been
+ * delivered by an agent that had answered it.
+ */
+async function mailed(t, { requiresAck = true } = {}) {
+  const place = await workspace(t);
+  const client = connectMcp({ ...place, participant: "mcp_reader" });
+  t.after(() => client.close());
+  const call = async (name, args = {}) => {
+    const out = await client.request("tools/call", { name, arguments: args, _meta: meta });
+    assert.equal(out.error, undefined, JSON.stringify(out.error));
+    return JSON.parse(out.result.content[0].text);
+  };
+  await call("acc_work", { summary: "reading", mode: "explore" });
+
+  const sender = await cli(place, ["attach", "--participant", "sender", "--harness", "cli"]);
+  await cli(place, ["message", "--session", sender.sessionId,
+    "--generation", sender.generation, "--to", "mcp_reader",
+    "--subject", "which way should the hull clamp?", "--body", "Blocking me.",
+    ...(requiresAck ? ["--requires-ack"] : [])]);
+  const receipts = async () => (await cli(place, ["sync", "--session", sender.sessionId,
+    "--scope", "full"])).snapshot.receipts.map(receipt => receipt.state);
+  return { place, call, sender, receipts };
+}
+
+test("a message addressed to an MCP client reaches it, body and all", async t => {
+  const { call } = await mailed(t);
+
+  const synced = await call("acc_sync");
+
+  const [message] = synced.messages ?? [];
+  assert.notEqual(message, undefined,
+    `nothing was handed over: ${JSON.stringify(Object.keys(synced))}`);
+  assert.equal(message.subject, "which way should the hull clamp?");
+  assert.equal(message.body, "Blocking me.");
+});
+
+test("what has been handed over is not handed over again", async t => {
+  const { call } = await mailed(t);
+  await call("acc_sync");
+
+  const second = await call("acc_sync");
+
+  // A client that polls every few seconds would otherwise be told the same
+  // thing until it acknowledged it, and most messages ask for no answer.
+  assert.deepEqual(second.messages ?? [], []);
+});
+
+test("the sender stops being told its message is undelivered", async t => {
+  const { call, receipts } = await mailed(t);
+  assert.deepEqual(await receipts(), ["queued"]);
+
+  await call("acc_sync");
+
+  assert.deepEqual(await receipts(), ["injected"]);
+});
+
+test("being shown something is still not agreeing to it", async t => {
+  const { call, receipts } = await mailed(t);
+  const synced = await call("acc_sync");
+  const [message] = synced.messages;
+
+  await call("acc_ack", { messageId: message.messageId });
+
+  // Delivery and acknowledgement are different facts, and the sender asked for
+  // the second one.
+  assert.deepEqual(await receipts(), ["acknowledged"]);
+});
+
+test("an MCP client can ask a hooked peer for work and be told it is done", async t => {
+  const place = await workspace(t);
+  const client = connectMcp({ ...place, participant: "graphics" });
+  t.after(() => client.close());
+  const call = async (name, args = {}) => {
+    const out = await client.request("tools/call", { name, arguments: args, _meta: meta });
+    assert.equal(out.error, undefined, JSON.stringify(out.error));
+    return JSON.parse(out.result.content[0].text);
+  };
+  const peer = await cli(place, ["attach", "--participant", "physics", "--harness", "cli"]);
+
+  const asked = await call("acc_request", { toParticipantId: "physics",
+    title: "Tank sinks through mud", detail: "Not mine to fix. Can you take it?" });
+  await cli(place, ["task", "--session", peer.sessionId, "--generation", peer.generation,
+    "--task", asked.task.taskId, "--take"]);
+  await cli(place, ["task", "--session", peer.sessionId, "--generation", peer.generation,
+    "--task", asked.task.taskId, "--state", "done"]);
+
+  // The whole loop, from the tier with no hooks at all: asked, taken, finished,
+  // and the answer arrives where this client can see it.
+  const synced = await call("acc_sync");
+  const answers = (synced.messages ?? []).map(message => message.subject);
+  assert.deepEqual(answers, ["accepted: Tank sinks through mud", "done: Tank sinks through mud"]);
+});

--- a/tests/process/store-concurrency.test.mjs
+++ b/tests/process/store-concurrency.test.mjs
@@ -132,3 +132,53 @@ test("the event log has no gaps and no duplicate sequences after contention", as
     ["workspace.materialised", "session.opened"]);
   await access(path.join(root, "protocol.json"));
 });
+
+/** A workspace nobody has opened, and the CLI, for the first-run race. */
+async function freshWorkspace(t) {
+  const cwd = await realpath(await mkdtemp(path.join(tmpdir(), "acc-fresh-")));
+  const dataHome = await realpath(await mkdtemp(path.join(tmpdir(), "acc-fresh-data-")));
+  t.after(() => Promise.all([rm(cwd, { recursive: true, force: true }),
+    rm(dataHome, { recursive: true, force: true })]));
+  const env = { ...process.env, ACC_DATA_HOME: dataHome, GIT_DIR: "", GIT_WORK_TREE: "" };
+  const attach = participant => execFileAsync(process.execPath,
+    [path.join(repoRoot, "bin", "acc.mjs"), "attach", "--participant", participant,
+      "--harness", "cli", "--cwd", cwd, "--json"], { env });
+  return { cwd, dataHome, env, attach };
+}
+
+test("agents starting together in a fresh workspace all get in", async t => {
+  const place = await freshWorkspace(t);
+
+  // The first thing every process does is establish the store's identity, and
+  // that document carries the moment it was written. Two of them racing wrote
+  // records differing in exactly that field, so the loser was refused for
+  // "record already published with different bytes" and could not attach at all
+  // - in a workspace neither had opened before, which is the ordinary way two
+  // agents start.
+  const outcomes = await Promise.all(["alpha", "beta", "gamma", "delta"]
+    .map(participant => place.attach(participant)
+      .then(({ stdout }) => JSON.parse(stdout).ok, error => error.stdout ?? error.message)));
+
+  assert.deepEqual(outcomes, [true, true, true, true],
+    `an agent could not open a workspace because another was opening it: ${
+      JSON.stringify(outcomes.filter(outcome => outcome !== true))}`);
+});
+
+test("a directory belonging to another workspace is still refused", async t => {
+  const place = await freshWorkspace(t);
+  await place.attach("alpha");
+
+  // Tolerating the race must not tolerate adopting someone else's store. What
+  // decides it is the identity on disk, not whose bytes arrived first.
+  const workspaces = path.join(place.dataHome, "acc", "workspaces");
+  const [existing] = await readdir(workspaces);
+  const file = path.join(workspaces, existing, "protocol.json");
+  const record = JSON.parse(await readFile(file, "utf8"));
+  await writeFile(file,
+    `${JSON.stringify({ ...record, workspaceId: "workspace_someone_else" })}\n`);
+
+  const refused = await place.attach("beta").then(() => null, error => error);
+
+  assert.notEqual(refused, null, "a store belonging to another workspace was adopted");
+  assert.match(refused.stdout, /different workspace/);
+});


### PR DESCRIPTION
Driving the negotiated loop over MCP — the one client path nothing had exercised — turned up three things, each found by the one before it.

## 1. No tool ever handed an MCP client a message

The hook runtime gives a session its pending messages when it builds a turn. A client with no hook has no turn, and nothing replaced it:

```
attention: [{"kind":"direct_request","sourceId":"message_34L1…","summary":"which way should the hull clamp?"}]
```

A subject and an id. To read what the peer had actually **said**, the client had to ask for the whole snapshot and search every message in the workspace for its own name.

The receipt never moved either — `queued` for as long as the client ran, so the sender was told its message had not been delivered *by an agent that had answered it*.

`acc_sync` returns them now and marks delivered exactly what it handed over, which is the same honesty the turn keeps. Acknowledgement stays a separate act: being shown something is not agreeing to it.

## 2. Then the test for it failed under the full suite and not alone

Which was not flakiness. **Two agents opening a workspace neither has opened before — the ordinary way two agents start — could not both get in.**

```
code 5: record already published with different bytes
  destination: …/protocol.json
```

The identity document each process writes first carries `initialisedAt`, so two of them racing differ in exactly that field and the loser was refused. Losing that race is not a failure: what the store must refuse is a directory belonging to a **different** workspace, and that is decided by reading what is on disk rather than by whose bytes arrived first.

## 3. Under that, a second race

```
code 5: workspace workspace_f086… changed under this transaction
```

`ensureMaterialised` checks before taking the writer lock — check-then-act across processes. All four agents saw "not materialised"; **three of four were refused and could not attach.**

The question is asked again inside the lock now, and promoting an ephemeral record that is already there is skipped rather than attempted: promotion is a copy, so the record already present is the one this would have written.

## Pinned

Four processes attaching at once, plus a companion holding the line that a store belonging to another workspace is **still** refused — tolerating the race must not tolerate adopting someone else's store.

Five of the new tests fail on `main`. The full suite ran clean three times in a row, since the whole reason this was found is that one run in isolation proved nothing.

## Verification

- 756 tests passing, 0 failing · `syntax ok in 161 file(s)`
- `PASS … sha256 8e079d30…c9d5b6 built from b6d2cb1`
