### PR TITLE
fix: work cannot be assigned to a name nobody has

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `b9bc09f` |
+| Built from | `0ebaf00` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `550019651a24c6f9086828fc119321da90198c675bc22c85f96063e21f7287af` |
-| Tests | 761 passing, 0 failing |
+| sha256 | `e243080d21cab9b1cc444255f73526e69ccde87bacd583ee31ec052c1edfe011` |
+| Tests | 763 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -63,7 +63,7 @@ Every line of an injected turn can be acted on. An attention line carries the id
 of the thing it is about — the same id the command that answers it takes — and a
 turn the byte budget truncated says how to read what it withheld.
 
-A peer nobody has ever been cannot be addressed. `acc message --to physcis` used
+A peer nobody has ever been cannot be addressed, nor assigned to. `acc message --to physcis` used
 to answer "sent", and `acc request` made a task assigned to nobody that its
 requester then waited on. The refusal names who is here, and it bounds the
 recipient list by construction — one message naming three thousand participants

--- a/packages/core/src/communication.mjs
+++ b/packages/core/src/communication.mjs
@@ -2,58 +2,13 @@ import { AccError, EXIT, SCHEMA_VERSION, advanceDelivery, createId, validateReco
   from "@agents-can-communicate/protocol";
 
 import { ensureMaterialised } from "./materialisation.mjs";
+import { assertKnownParticipants } from "./participants.mjs";
 import { writeTask } from "./tasks.mjs";
 
 const receiptId = (messageId, recipient) => `${messageId}--${recipient}`;
 
 // Peer content is data, never authority. Messages carry attribution and a
 // typed intent; nothing in a body can change policy or promote a proposal.
-/**
- * Everyone this workspace has ever seen.
- *
- * Participants are created when a session attaches and are never removed, so
- * "has been here" is the right test and "is here now" is not: work is addressed
- * to a participant precisely so it survives their session ending.
- *
- * Before anything durable is written the participants live in the ephemeral
- * area, which is where a workspace with one session keeps everything.
- */
-async function knownParticipants(store, workspaceId) {
-  const snapshot = await store.snapshot(workspaceId,
-    { kinds: ["workspace", "participant"] });
-  const durable = snapshot.workspace !== null
-    ? snapshot.participants
-    : await store.ephemeral.list("participant");
-  return new Set(durable.map(participant => participant.participantId));
-}
-
-/**
- * A recipient nobody has ever been is a typo, and saying "sent" to one is the
- * worst answer available: `acc message --to physcis` reported success, the
- * message went nowhere, and the agent that meant `physics` had no way to find
- * out. `acc request` was worse - it made a task addressed to nobody, and the
- * requester waited for an agent that does not exist.
- *
- * It also bounds the recipient list by construction. Nothing did: one message
- * naming three thousand participants took 24.8 seconds, wrote three thousand
- * receipts, and left every session in that workspace paying 5.1 seconds to
- * attach and take one turn - past the point where a hook gives up and allows
- * whatever it was guarding.
- */
-async function assertKnownRecipients(store, workspaceId, recipients) {
-  const known = await knownParticipants(store, workspaceId);
-  const strangers = [...new Set(recipients)].filter(name => !known.has(name));
-  if (strangers.length === 0) return;
-  // Not a usage error: the command is well formed and the workspace disagrees
-  // with it. Which matters beyond tidiness - the gate that runs every documented
-  // command holds them to being *accepted*, and every example names a peer that
-  // a fresh sandbox has never seen.
-  throw new AccError(EXIT.DATA,
-    `no participant here is called ${strangers.join(", ")}. `
-    + `This workspace has: ${[...known].sort().join(", ") || "nobody else yet"}`,
-    { strangers, known: [...known].sort() });
-}
-
 export function createCommunicationService(ports, sessions, claims) {
   const { store, clock, ids } = ports;
 
@@ -98,7 +53,7 @@ export function createCommunicationService(ports, sessions, claims) {
     });
     // After the record is validated, so a body carrying control characters is
     // refused for what it is rather than for who it was addressed to.
-    await assertKnownRecipients(store, workspaceId, recipients);
+    await assertKnownParticipants(store, workspaceId, recipients);
 
     await store.transaction(async tx => {
       tx.put("message", messageId, record);
@@ -286,7 +241,7 @@ export function createCommunicationService(ports, sessions, claims) {
     }
     await ensureMaterialised(ports, { workspaceId, descriptor: input.descriptor,
       reason: "durable_object" });
-    await assertKnownRecipients(store, workspaceId, [recipient]);
+    await assertKnownParticipants(store, workspaceId, [recipient]);
     const now = clock.now();
     const messageId = createId("message");
     let task = null;

--- a/packages/core/src/participants.mjs
+++ b/packages/core/src/participants.mjs
@@ -1,0 +1,48 @@
+import { AccError, EXIT } from "@agents-can-communicate/protocol";
+
+/**
+ * Everyone this workspace has ever seen.
+ *
+ * Participants are created when a session attaches and are never removed, so
+ * "has been here" is the right test and "is here now" is not: work is addressed
+ * to a participant precisely so it survives their session ending.
+ *
+ * Before anything durable is written the participants live in the ephemeral
+ * area, which is where a workspace with one session keeps everything.
+ */
+export async function knownParticipants(store, workspaceId) {
+  const snapshot = await store.snapshot(workspaceId,
+    { kinds: ["workspace", "participant"] });
+  const durable = snapshot.workspace !== null
+    ? snapshot.participants
+    : await store.ephemeral.list("participant");
+  return new Set(durable.map(participant => participant.participantId));
+}
+
+/**
+ * A recipient nobody has ever been is a typo, and saying "sent" to one is the
+ * worst answer available: `acc message --to physcis` reported success, the
+ * message went nowhere, and the agent that meant `physics` had no way to find
+ * out. `acc request` was worse - it made a task addressed to nobody, and the
+ * requester waited for an agent that does not exist.
+ *
+ * It also bounds the recipient list by construction. Nothing did: one message
+ * naming three thousand participants took 24.8 seconds, wrote three thousand
+ * receipts, and left every session in that workspace paying 5.1 seconds to
+ * attach and take one turn - past the point where a hook gives up and allows
+ * whatever it was guarding.
+ */
+export async function assertKnownParticipants(store, workspaceId, recipients) {
+  const known = await knownParticipants(store, workspaceId);
+  const strangers = [...new Set(recipients)].filter(name => !known.has(name));
+  if (strangers.length === 0) return;
+  // Not a usage error: the command is well formed and the workspace disagrees
+  // with it. Which matters beyond tidiness - the gate that runs every documented
+  // command holds them to being *accepted*, and every example names a peer that
+  // a fresh sandbox has never seen.
+  throw new AccError(EXIT.DATA,
+    `no participant here is called ${strangers.join(", ")}. `
+    + `This workspace has: ${[...known].sort().join(", ") || "nobody else yet"}`,
+    { strangers, known: [...known].sort() });
+}
+

--- a/packages/core/src/tasks.mjs
+++ b/packages/core/src/tasks.mjs
@@ -2,6 +2,7 @@ import { AccError, EXIT, SCHEMA_VERSION, createId, transitionTask as stepTask, v
   from "@agents-can-communicate/protocol";
 
 import { ensureMaterialised } from "./materialisation.mjs";
+import { assertKnownParticipants } from "./participants.mjs";
 import { classifySessionPresence } from "./sessions.mjs";
 import { closeRequestReceipt, writeWorkResponse } from "./notify.mjs";
 
@@ -90,6 +91,13 @@ export function createTaskService(ports, workstreams) {
     const workspaceId = session.workspaceId;
     await ensureMaterialised(ports, { workspaceId, descriptor: input.descriptor,
       reason: "durable_object" });
+    // The same rule as addressing a message. `acc task --assignee physcis` was
+    // accepted and left work `pending` for a participant nobody has ever been:
+    // invisible to every roster, raising `task_unblocked` for nobody, and not
+    // even stalled, since nothing was waiting on it that could be told.
+    if (input.assigneeParticipantId != null) {
+      await assertKnownParticipants(store, workspaceId, [input.assigneeParticipantId]);
+    }
     const now = clock.now();
     let record = null;
     await store.transaction(async tx => {

--- a/tests/process/unknown-recipient.test.mjs
+++ b/tests/process/unknown-recipient.test.mjs
@@ -124,3 +124,37 @@ test("a body that cannot be stored is refused for that, not for its recipient", 
   assert.notEqual(refused, null);
   assert.match(JSON.parse(refused.stdout).error.message, /control characters/i);
 });
+
+test("work cannot be assigned to a name nobody has", async t => {
+  const place = await workspace(t);
+  const sender = await place.attach("graphics");
+  await place.attach("physics");
+
+  const refused = await failed(place.cli("task", "--session", sender.sessionId,
+    "--generation", sender.generation, "--title", "fix the tank",
+    "--assignee", "physcis"));
+
+  // `acc task --assignee` is how work is handed over without a message, and it
+  // was the one path this rule had not reached. A task left `pending` for a
+  // participant nobody has ever been is invisible to every roster, raises
+  // `task_unblocked` for nobody, and is not even stalled - nothing was waiting
+  // on it that could be told.
+  assert.notEqual(refused, null, "work was assigned to nobody");
+  assert.match(JSON.parse(refused.stdout).error.message, /no participant here is called physcis/);
+  const { snapshot } = JSON.parse((await place.cli("sync", "--session", sender.sessionId,
+    "--scope", "full")).stdout).data;
+  assert.deepEqual(snapshot.tasks, []);
+});
+
+test("work with no assignee at all is still allowed", async t => {
+  const place = await workspace(t);
+  const sender = await place.attach("graphics");
+
+  // Unassigned work is ordinary: a task noted now and picked up by whoever
+  // takes it. The rule is about naming somebody who is not there, not about
+  // naming nobody.
+  const { stdout } = await place.cli("task", "--session", sender.sessionId,
+    "--generation", sender.generation, "--title", "something to do");
+
+  assert.equal(JSON.parse(stdout).ok, true);
+});


### PR DESCRIPTION
```
$ acc task --title "fix the tank" --assignee physcis
task_TdCZQG4wv4OcgJxLoKnFeA pending
```

The task sits `pending` for a participant nobody has ever been: invisible to every roster, raising `task_unblocked` for nobody, and **not even stalled** — nothing was waiting on it that could be told.

`acc task --assignee` is how work is handed over without a message, and it was the one path the rule added in #42 had not reached. Probing the neighbours showed the shape clearly:

| field | before |
|---|---|
| `--depends-on task_does_not_exist` | `a dependency does not exist` ✓ |
| `--workstream workstream_nope` | `the workstream does not exist` ✓ |
| `--assignee physcis` | `task_TdCZ… pending` ✗ |

The field between two that were checked was not.

## One small move

The check now lives in `participants.mjs`. Tasks and communication both need it, and reaching into the communication service for it would be the wrong direction. Nothing outside the core imported it and the behaviour for messages and requests is unchanged.

## The limit it must not cross

Unassigned work stays ordinary — a task noted now and picked up by whoever takes it. The rule is about naming somebody who is not there, not about naming nobody. Pinned as its own test.

## Verification

- 763 tests passing, 0 failing · `syntax ok in 163 file(s)`
- `PASS … sha256 e243080d…dfe011 built from 0ebaf00`
