### PR TITLE
docs: catch the documentation up with what the code now does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ release.
 
 | | |
 |---|---|
-| Built from | `0ebaf00` |
+| Built from | `55ed6b1` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `e243080d21cab9b1cc444255f73526e69ccde87bacd583ee31ec052c1edfe011` |
+| sha256 | `a28e6172e59c77d2a93aad3f88477f00aecabbc60d57d00b127e09e9fe9c344a` |
 | Tests | 763 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -95,6 +95,12 @@ a worktree with no live session behind it can be told apart from someone's desk.
 
 ## Asking another agent
 
+`--to` and `--assignee` name a participant from the roster. One nobody here has is refused
+rather than accepted: a message to a name that does not exist used to report `sent` and go
+nowhere, and a request made a task assigned to nobody that its author then waited on. A
+participant who has closed their terminal is still a participant — that is the whole reason
+work is addressed to one.
+
 ```bash
 acc request --to claude_code --title "finish the store tests" \
   --detail "I ported src/store but ran out of time on the concurrency cases."

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -63,6 +63,9 @@ Exit code `5` means conflict.
 
 ## 5. Say something
 
+`--to` takes a name from the roster — `acc status` above is where you get it. Using one
+nobody here has is refused, and the refusal lists the names there are.
+
 ```bash
 acc message --to models --subject "Slots" --body "Which names are stable?" --type question
 ```

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -149,11 +149,15 @@ recorded -> queued -> injected -> seen -> acknowledged
 
 States are monotonic. One recipient's receipt cannot alter another recipient's state. `seen` means exposed to the receiving session or explicitly marked, not that the model obeyed it.
 
-`sendMessage` leaves a receipt at `queued`. It advances to `injected` when a recipient's
-turn context actually carried the message — and only then. A message the context budget
-could not fit stays `queued` and goes out on a later turn, because a receipt claiming
-delivery for text nobody was shown tells the sender something untrue. Whatever the budget
-left out is stated in the projection rather than dropped in silence.
+`sendMessage` leaves a receipt at `queued`. It advances to `injected` when the message was
+actually handed to the recipient — and only then. For a hooked session that means the turn
+context carried it: one the budget could not fit stays `queued` and goes out on a later
+turn, because a receipt claiming delivery for text nobody was shown tells the sender
+something untrue, and whatever the budget left out is stated in the projection rather than
+dropped in silence. For a client with no hooks it means `acc_sync` returned it, which is
+that client's turn — until it did, such a receipt stayed `queued` for the life of the
+client and the sender was told its message had not arrived by an agent that had answered
+it.
 
 ## Decisions
 

--- a/packages/adapter-claude-code/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-claude-code/plugin/skills/acc/SKILL.md
@@ -49,6 +49,10 @@ One call records the work and tells them why. `--to` is a participant from the r
 `acc status --json` lists who is here. They are told at their next turn and may take it,
 leave it, or reply. It is a request, not an order.
 
+A name nobody here has is refused, and the refusal lists the names there are — so a
+mistyped peer costs one command rather than a request that goes nowhere. The same is true
+of `--assignee` on a task.
+
 ## Reading your turn
 
 Every attention line carries the id of the thing it is about, and that id is the argument

--- a/packages/adapter-codex/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-codex/plugin/skills/acc/SKILL.md
@@ -49,6 +49,10 @@ One call records the work and tells them why. `--to` is a participant from the r
 `acc status --json` lists who is here. They are told at their next turn and may take it,
 leave it, or reply. It is a request, not an order.
 
+A name nobody here has is refused, and the refusal lists the names there are — so a
+mistyped peer costs one command rather than a request that goes nowhere. The same is true
+of `--assignee` on a task.
+
 ## Reading your turn
 
 Every attention line carries the id of the thing it is about, and that id is the argument

--- a/packages/adapter-gemini-cli/extension/skills/acc/SKILL.md
+++ b/packages/adapter-gemini-cli/extension/skills/acc/SKILL.md
@@ -49,6 +49,10 @@ One call records the work and tells them why. `--to` is a participant from the r
 `acc status --json` lists who is here. They are told at their next turn and may take it,
 leave it, or reply. It is a request, not an order.
 
+A name nobody here has is refused, and the refusal lists the names there are — so a
+mistyped peer costs one command rather than a request that goes nowhere. The same is true
+of `--assignee` on a task.
+
 ## Reading your turn
 
 Every attention line carries the id of the thing it is about, and that id is the argument

--- a/packages/adapter-kimi/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-kimi/plugin/skills/acc/SKILL.md
@@ -49,6 +49,10 @@ One call records the work and tells them why. `--to` is a participant from the r
 `acc status --json` lists who is here. They are told at their next turn and may take it,
 leave it, or reply. It is a request, not an order.
 
+A name nobody here has is refused, and the refusal lists the names there are — so a
+mistyped peer costs one command rather than a request that goes nowhere. The same is true
+of `--assignee` on a task.
+
 ## Reading your turn
 
 Every attention line carries the id of the thing it is about, and that id is the argument


### PR DESCRIPTION
Three prose claims went stale under changes made this week, and **no gate caught any of them**: they check that every documented command runs and that every attention kind has a row, not that the sentences beside them are still true.

| where | was | now |
|---|---|---|
| the four skills | `--to` is a name from the roster, and nothing about a wrong one | a name nobody has is refused and the refusal lists the names there are — said for `--assignee` too |
| `docs/PROTOCOL.md` | `injected` means "the recipient's turn context carried it" | true of a hooked session; a client with no hooks advances it when `acc_sync` hands the message over, which is that client's turn |
| `docs/GETTING_STARTED.md` | the first `--to` example names a peer the reader does not have | points at the roster it just printed |

The protocol one matters most: until #41, that receipt stayed `queued` for the life of an MCP client — so the document was describing the only path there was, and stopped being complete the moment there were two.

## Verified alongside, by measurement

The README leads with *"one session behaves exactly as it did before you installed anything."* Checked rather than reread:

```
attach output: 0 bytes
turn output:   0 bytes
guard output:  0 bytes (exit 0)
durable state written: 0 records
anything in the project: 0 entries
```

## Verification

- 763 tests passing, 0 failing · `syntax ok in 163 file(s)`
- `PASS … sha256 a28e6172…9c344a built from 55ed6b1`
