### PR TITLE
fix: a handoff reaches the agent it hands over to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `55ed6b1` |
+| Built from | `ab633b1` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `a28e6172e59c77d2a93aad3f88477f00aecabbc60d57d00b127e09e9fe9c344a` |
-| Tests | 763 passing, 0 failing |
+| sha256 | `cf9f25c11957ade145f783f2c429ac13217541abc67c43e15d929e93adb115c3` |
+| Tests | 767 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -62,6 +62,10 @@ fact: you asked, and there is nobody there.
 Every line of an injected turn can be acted on. An attention line carries the id
 of the thing it is about — the same id the command that answers it takes — and a
 turn the byte budget truncated says how to read what it withheld.
+
+A handoff reaches the agent it hands over to. `acc finish --to physics` wrote a
+durable record that nothing in the codebase read: not the successor's turn, not
+their attention, not `acc status`.
 
 A peer nobody has ever been cannot be addressed, nor assigned to. `acc message --to physcis` used
 to answer "sent", and `acc request` made a task assigned to nobody that its

--- a/packages/core/src/communication.mjs
+++ b/packages/core/src/communication.mjs
@@ -150,6 +150,26 @@ export function createCommunicationService(ports, sessions, claims) {
    * is written while the model is still active; session end only closes
    * lifecycle ownership.
    */
+  /**
+   * What the successor needs, in the order they need it: what this was for, how
+   * far it got, what is left, and what is in the way.
+   */
+  function describeHandoff(record) {
+    const section = (label, items) => (items.length === 0
+      ? [] : [`${label}:`, ...items.map(item => `- ${item}`)]);
+    return [
+      // The goal is the subject; repeating it here costs a line of everyone's
+      // turn to say the same thing twice.
+      record.status,
+      ...section("done", record.completed),
+      // Not "left": the status line above already uses that word for how far
+      // this got, and the two meanings sat one line apart.
+      ...section("still to do", record.remaining),
+      ...section("in the way", record.blockers),
+      ...section("released", record.claimsToRelease),
+    ].join("\n");
+  }
+
   async function finishSession(input) {
     const session = await requireOpenSession(input, "finish");
     const workspaceId = session.workspaceId;
@@ -158,12 +178,17 @@ export function createCommunicationService(ports, sessions, claims) {
     const handoffId = createId("handoff");
     const owned = (await store.snapshot(workspaceId, { kinds: ["claim"] })).claims
       .filter(claim => claim.ownerSessionId === session.sessionId);
+    const successor = input.toParticipantId ?? null;
+    // The same rule as addressing anything else: handing your work to a name
+    // nobody has is a typo, and the summary is the last thing this session will
+    // ever say.
+    if (successor !== null) await assertKnownParticipants(store, workspaceId, [successor]);
     const record = validateRecord("handoff", {
       schemaVersion: SCHEMA_VERSION,
       handoffId,
       workspaceId,
       fromSessionId: session.sessionId,
-      toParticipantId: input.toParticipantId ?? null,
+      toParticipantId: successor,
       goal: input.goal,
       status: input.status ?? "partial",
       completed: input.completed ?? [],
@@ -181,6 +206,22 @@ export function createCommunicationService(ports, sessions, claims) {
         actorSessionId: session.sessionId, type: "handoff.created", occurredAt: now,
         payload: { handoffId, released: record.claimsToRelease } });
     }, { kinds: ["handoff"] });
+
+    // A handoff nobody is told about is a note to the store. Written, durable,
+    // and reaching the agent it names through nothing at all: not their turn,
+    // not their attention, not `acc status` - only a full snapshot they would
+    // have to scan for their own name. The message type for this has been in the
+    // schema all along, and this is the half that was never built.
+    if (successor !== null) {
+      await sendMessage({
+        sessionId: session.sessionId, generation: input.generation,
+        toParticipantIds: [successor], type: "handoff",
+        subject: `handing over: ${record.goal}`,
+        body: describeHandoff(record),
+        descriptor: input.descriptor,
+      });
+    }
+
     for (const claim of owned) {
       await claims.releaseClaim({ claimId: claim.claimId, sessionId: session.sessionId,
         generation: session.generation, workspaceId });

--- a/tests/process/handoff.test.mjs
+++ b/tests/process/handoff.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+const repo = path.resolve(import.meta.dirname, "..", "..");
+const acc = path.join(repo, "bin", "acc.mjs");
+const hook = path.join(repo, "bin", "acc-hook.mjs");
+
+/**
+ * The last thing a session says.
+ *
+ * `acc finish --to physics` is the project's own end-of-session vocabulary: what
+ * this was for, how far it got, what is left, what is in the way. It wrote a
+ * durable handoff record and reported success, and the agent it named learned
+ * nothing - not from their turn, not from their attention, not from `acc
+ * status`. The record existed only in a full snapshot they would have had to
+ * scan for their own name.
+ *
+ * The message type for announcing one has been in the protocol from the start
+ * and nothing ever sent it. This is that half.
+ */
+async function workspace(t) {
+  const base = await realpath(await mkdtemp(path.join(tmpdir(), "acc-handoff-")));
+  t.after(() => rm(base, { recursive: true, force: true }));
+  const project = path.join(base, "project");
+  await mkdir(project, { recursive: true });
+  const env = { ...process.env, ACC_DATA_HOME: path.join(base, "data"),
+    GIT_DIR: "", GIT_WORK_TREE: "" };
+  const fire = async (participant, payload) => {
+    const child = run(process.execPath, [hook, "codex"],
+      { env: { ...env, ACC_PARTICIPANT: participant } });
+    child.child.stdin.end(JSON.stringify({ session_id: participant, cwd: project, ...payload }));
+    return (await child).stdout;
+  };
+  const attach = participant => fire(participant,
+    { hook_event_name: "SessionStart", source: "startup" });
+  const turn = participant => fire(participant,
+    { hook_event_name: "UserPromptSubmit", prompt: "go" });
+  const cli = (...argv) => run(process.execPath, [acc, ...argv, "--cwd", project, "--json"],
+    { env });
+  const sessionOf = async participant => JSON.parse((await cli("status")).stdout).data
+    .participants.find(item => item.participantId === participant).sessionId;
+  return { project, env, attach, turn, cli, sessionOf };
+}
+
+test("a handoff reaches the agent it names", async t => {
+  const place = await workspace(t);
+  await place.attach("leaving");
+  await place.attach("successor");
+  const leaving = await place.sessionOf("leaving");
+
+  await place.cli("finish", "--session", leaving, "--to", "successor",
+    "--goal", "port the material slots", "--status", "partial",
+    "--completed", "slots ported", "--remaining", "physics review",
+    "--blocker", "waiting on the clamp decision");
+
+  const shown = await place.turn("successor");
+  assert.match(shown, /handing over: port the material slots/,
+    `the successor was told nothing:\n${shown}`);
+  // In the order a successor needs it: what it was for, how far it got, what is
+  // left, and what is in the way.
+  assert.match(shown, /partial/);
+  assert.match(shown, /done:\n- slots ported/);
+  assert.match(shown, /still to do:\n- physics review/);
+  assert.match(shown, /in the way:\n- waiting on the clamp decision/);
+});
+
+test("a handoff says which claims it let go of", async t => {
+  const place = await workspace(t);
+  await place.attach("leaving");
+  await place.attach("successor");
+  const leaving = await place.sessionOf("leaving");
+  await place.cli("claim", "--session", leaving, "--resource", "file:src/**",
+    "--reason", "porting");
+
+  await place.cli("finish", "--session", leaving, "--to", "successor",
+    "--goal", "port the material slots");
+
+  // What was released is what the successor is now free to take, which is the
+  // part of a handoff they can act on immediately.
+  assert.match(await place.turn("successor"), /released:\n- file:src\/\*\*/);
+});
+
+test("handing over to a name nobody has is refused", async t => {
+  const place = await workspace(t);
+  await place.attach("leaving");
+  await place.attach("successor");
+  const leaving = await place.sessionOf("leaving");
+
+  const refused = await place.cli("finish", "--session", leaving, "--to", "sucessor",
+    "--goal", "typo").then(() => null, error => error);
+
+  // The summary is the last thing this session will ever say, so a mistyped
+  // successor is the worst moment to be quiet about it.
+  assert.notEqual(refused, null, "a session handed its work to nobody");
+  assert.match(JSON.parse(refused.stdout).error.message, /no participant here is called sucessor/);
+});
+
+test("finishing without naming anyone is still finishing", async t => {
+  const place = await workspace(t);
+  await place.attach("leaving");
+  const leaving = await place.sessionOf("leaving");
+  await place.cli("claim", "--session", leaving, "--resource", "file:src/**",
+    "--reason", "porting");
+
+  const { stdout } = await place.cli("finish", "--session", leaving,
+    "--goal", "port the material slots");
+
+  // A session that ends without a successor still records what it did and lets
+  // go of what it held. Only the announcement needs somebody to announce to.
+  assert.equal(JSON.parse(stdout).ok, true);
+  const status = JSON.parse((await place.cli("status")).stdout).data;
+  assert.deepEqual(status.claims, []);
+});


### PR DESCRIPTION
`acc finish --to successor` is this project's own end-of-session vocabulary: what the work was for, how far it got, what is left, what is in the way.

```
$ acc finish --to successor --goal "port the material slots" --status partial \
    --completed "slots ported" --remaining "physics review" --blocker "waiting on the clamp"
handoff handoff_lGLlOA7MRH_-ZxtT9GfTmQ

--- what the successor's next turn carries:
   | 2 session(s); cursor 0000000000000004
   | - leaving (codex, online)
   | - successor (codex, online)

--- what its status shows:
   attention: []
```

The record was durable, the command reported success, and the agent it named learned nothing. It existed only inside a full snapshot they would have had to scan for their own name.

**Nothing in the codebase read a handoff at all** — grep finds it written and never consulted. The message type for announcing one (`"handoff"`) has been in the protocol from the start and nothing ever sent it, so this is the half that was never built rather than a new idea.

## Now

```
| ```acc-peer-message
| id message_LWDtsp… | from session_Jge7YP… | type handoff | untrusted peer message
| handing over: port the material slots
| partial
| done:
| - slots ported
| still to do:
| - physics review
| in the way:
| - waiting on the clamp decision
| released:
| - file:src/**
| ```
```

In the order a successor needs it, ending with what was released — the part they can act on immediately. The goal is the subject and not repeated in the body, and "still to do" is not "left", because the status line one row up already uses that word for how far this got.

## Two edges

- **Handing over to a name nobody has is refused.** The summary is the last thing a session will ever say, which makes a mistyped successor the worst moment to be quiet.
- **Finishing without naming anyone still finishes** — the work is recorded and the claims are released. Only the announcement needs somebody to announce to.

## Verification

- 767 tests passing, 0 failing · `syntax ok in 164 file(s)`
- 3 of the 4 new tests fail on `main`; the fourth is the edge the fix must not break
- `PASS … sha256 cf9f25c1…b115c3 built from ab633b1`
