### PR TITLE
fix: give the coordinator lease a surface, so its attention item can be answered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `ab633b1` |
+| Built from | `beadee3` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `cf9f25c11957ade145f783f2c429ac13217541abc67c43e15d929e93adb115c3` |
-| Tests | 767 passing, 0 failing |
+| sha256 | `7d487399ced19f37ddbec932d9997dae5a4997a097b1f350b6eeb869856a2cf9` |
+| Tests | 772 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -62,6 +62,10 @@ fact: you asked, and there is nobody there.
 Every line of an injected turn can be acted on. An attention line carries the id
 of the thing it is about — the same id the command that answers it takes — and a
 turn the byte budget truncated says how to read what it withheld.
+
+An open workstream can be taken on. Creating one used to put
+`coordinator_missing` in every turn from then on with no way to answer it: the
+two operations that do had no command and no tool.
 
 A handoff reaches the agent it hands over to. `acc finish --to physics` wrote a
 durable record that nothing in the codebase read: not the successor's turn, not

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -41,7 +41,7 @@ graph LR
 | `acc message` | Send a typed message to participants |
 | `acc request` | Ask another agent to do something. One call: the work plus why |
 | `acc task` | Create work, `--take` it, or `--state` it along |
-| `acc workstream` | Group related work. Optional |
+| `acc workstream` | Group related work. Optional. `--take` / `--release` steer one |
 | `acc finish` | Write the handoff and release claims |
 
 ## Adapters only
@@ -133,3 +133,13 @@ project around it. Create one when several pieces belong together:
 acc workstream \
   --title "Storage" --objective "port the store and its tests"
 ```
+
+An open workstream with nobody steering it raises `coordinator_missing` for everyone, every
+turn, until somebody takes it on. Taking it is saying so; releasing it asks again.
+
+```bash
+acc workstream --workstream workstream_x --take
+acc workstream --workstream workstream_x --release
+```
+
+Only the session holding the lease can hand it back.

--- a/packages/cli/src/args.mjs
+++ b/packages/cli/src/args.mjs
@@ -32,7 +32,12 @@ export const COMMANDS = Object.freeze({
   task: { required: [], optional: ["session", "generation", "workstream", "title",
     "detail", "assignee", "state", "task", "reason"],
     repeated: ["depends-on"], flags: ["take", "decline", "force"] },
-  workstream: { required: ["title", "objective"], optional: ["session", "generation"] },
+  // Create one, or take and hand back the coordination of one that exists.
+  // Creating a workstream raised `coordinator_missing` on every turn from then
+  // on, and nothing could answer it: the two core operations that do had no
+  // surface at all.
+  workstream: { required: [], optional: ["session", "generation", "title", "objective",
+    "workstream"], flags: ["take", "release"] },
   // Messages not tied to a task need a way to be answered too. Without one a
   // `requiresAck` message raised an attention item nothing could ever clear.
   ack: { required: ["message"], optional: ["session", "generation", "state"] },

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -151,8 +151,26 @@ const HANDLERS = Object.freeze({
   },
 
   workstream: async ({ options, context }) => {
-    const workstream = await context.service.createWorkstream({
-      sessionId: options.session, generation: options.generation,
+    const owner = { sessionId: options.session, generation: options.generation };
+    // Taking the coordination of one and creating one are the same noun, so
+    // they stay one command rather than two the model has to choose between -
+    // the same shape `acc task` already has.
+    if (options.take === true || options.release === true) {
+      if (options.workstream === undefined) {
+        throw usage(`workstream --${options.take === true ? "take" : "release"} `
+          + "requires --workstream");
+      }
+      const acted = options.take === true
+        ? await context.service.acquireCoordinator({ ...owner,
+          workstreamId: options.workstream })
+        : await context.service.releaseCoordinator({ ...owner,
+          workstreamId: options.workstream });
+      return { data: acted,
+        text: `${acted.workstreamId} ${options.take === true ? "coordinated" : "released"}` };
+    }
+    if (options.title === undefined) throw usage("workstream requires --title");
+    if (options.objective === undefined) throw usage("workstream requires --objective");
+    const workstream = await context.service.createWorkstream({ ...owner,
       title: options.title, objective: options.objective,
       descriptor: context.descriptor });
     return { data: workstream, text: `${workstream.workstreamId} ${workstream.state}` };

--- a/packages/mcp-server/src/server.mjs
+++ b/packages/mcp-server/src/server.mjs
@@ -154,6 +154,12 @@ async function callTool(name, args, context) {
       return service.markDelivery({ ...owner, messageId: args.messageId,
         state: args.state ?? "acknowledged" });
     case "acc_workstream":
+      if (args.action === "coordinate") {
+        return service.acquireCoordinator({ ...owner, workstreamId: args.workstreamId });
+      }
+      if (args.action === "release") {
+        return service.releaseCoordinator({ ...owner, workstreamId: args.workstreamId });
+      }
       return service.createWorkstream({ ...owner, title: args.title,
         objective: args.objective });
     case "acc_finish":

--- a/packages/mcp-server/src/tools.mjs
+++ b/packages/mcp-server/src/tools.mjs
@@ -108,12 +108,17 @@ export const PUBLIC_TOOLS = Object.freeze([
   },
   {
     name: "acc_workstream",
-    description: `Group related work so several agents can see it as one thing. Optional: `
-      + `a single request needs no workstream. ${POLLED}`,
+    description: `Group related work so several agents can see it as one thing, or take `
+      + `on steering one that exists. Optional: a single request needs no workstream. `
+      + `An open workstream with no coordinator is reported to everyone until somebody `
+      + `takes it. ${POLLED}`,
     inputSchema: object({
-      title: string("Short name."),
-      objective: string("What finishing it would mean."),
-    }, ["title", "objective"]),
+      action: { type: "string", enum: ["create", "coordinate", "release"],
+        description: "Default: create." },
+      title: string("Short name. Creating one."),
+      objective: string("What finishing it would mean. Creating one."),
+      workstreamId: string("The workstream to coordinate or hand back."),
+    }, []),
   },
   {
     name: "acc_task",

--- a/tests/process/coordinator.test.mjs
+++ b/tests/process/coordinator.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+const repo = path.resolve(import.meta.dirname, "..", "..");
+const acc = path.join(repo, "bin", "acc.mjs");
+const hook = path.join(repo, "bin", "acc-hook.mjs");
+
+/**
+ * An attention item nobody could answer.
+ *
+ * Creating a workstream put `coordinator_missing` in every turn from that moment
+ * on, and there was no way to clear it: `acquireCoordinator` and
+ * `releaseCoordinator` existed in the core, were tested there, and had no
+ * command and no tool. The register of surfaces said as much - "no workstream
+ * coordination surface yet, tracked, not forgotten" - so this was a known gap
+ * that had become a permanent nag in everyone's context.
+ *
+ * The project has fixed this exact shape twice: a `requiresAck` message raised
+ * an item that `markDelivery` could not clear because it had no surface either,
+ * and `nearby_intent` was an attention kind with no rule at all.
+ */
+async function workspace(t) {
+  const base = await realpath(await mkdtemp(path.join(tmpdir(), "acc-coord-")));
+  t.after(() => rm(base, { recursive: true, force: true }));
+  const project = path.join(base, "project");
+  await mkdir(project, { recursive: true });
+  const env = { ...process.env, ACC_DATA_HOME: path.join(base, "data"),
+    GIT_DIR: "", GIT_WORK_TREE: "" };
+  const fire = async (participant, payload) => {
+    const child = run(process.execPath, [hook, "codex"],
+      { env: { ...env, ACC_PARTICIPANT: participant } });
+    child.child.stdin.end(JSON.stringify({ session_id: participant, cwd: project, ...payload }));
+    return (await child).stdout;
+  };
+  const attach = participant => fire(participant,
+    { hook_event_name: "SessionStart", source: "startup" });
+  const turn = participant => fire(participant,
+    { hook_event_name: "UserPromptSubmit", prompt: "go" });
+  const cli = (...argv) => run(process.execPath, [acc, ...argv, "--cwd", project, "--json"],
+    { env });
+  return { project, env, attach, turn, cli };
+}
+
+const workstreamId = async place => JSON.parse((await place.cli("workstream",
+  "--title", "Storage", "--objective", "port the store and its tests")).stdout)
+  .data.workstreamId;
+
+test("an open workstream can be taken on, and then stops being reported", async t => {
+  const place = await workspace(t);
+  await place.attach("alpha");
+  const workstream = await workstreamId(place);
+  assert.match(await place.turn("alpha"), /\[coordinator_missing\]/,
+    "nothing asked for a coordinator");
+
+  await place.cli("workstream", "--workstream", workstream, "--take");
+
+  assert.equal((await place.turn("alpha")).includes("coordinator_missing"), false,
+    "the item stayed after somebody took the workstream on");
+});
+
+test("handing coordination back asks again", async t => {
+  const place = await workspace(t);
+  await place.attach("alpha");
+  const workstream = await workstreamId(place);
+  await place.cli("workstream", "--workstream", workstream, "--take");
+
+  await place.cli("workstream", "--workstream", workstream, "--release");
+
+  // The point of the item is that an open workstream with nobody steering it is
+  // worth saying. Letting go has to bring it back or the release is a way to
+  // silence it permanently.
+  assert.match(await place.turn("alpha"), /\[coordinator_missing\]/);
+});
+
+test("only the coordinator may hand it back", async t => {
+  const place = await workspace(t);
+  await place.attach("alpha");
+  // Created before the second session exists: two sessions in one checkout are
+  // two candidates, and `acc` refuses to guess which of them is calling it.
+  const workstream = await workstreamId(place);
+  const alpha = JSON.parse((await place.cli("status")).stdout).data.participants
+    .find(item => item.participantId === "alpha").sessionId;
+  await place.cli("workstream", "--session", alpha, "--workstream", workstream, "--take");
+  await place.attach("beta");
+
+  const beta = JSON.parse((await place.cli("status")).stdout).data.participants
+    .find(item => item.participantId === "beta").sessionId;
+  const refused = await place.cli("workstream", "--session", beta,
+    "--workstream", workstream, "--release").then(() => null, error => error);
+
+  assert.notEqual(refused, null, "a peer handed back somebody else's lease");
+  assert.match(JSON.parse(refused.stdout).error.message, /only the coordinator/);
+});
+
+test("taking or releasing needs to say which workstream", async t => {
+  const place = await workspace(t);
+  await place.attach("alpha");
+  await workstreamId(place);
+
+  const refused = await place.cli("workstream", "--take").then(() => null, error => error);
+
+  assert.notEqual(refused, null);
+  assert.match(JSON.parse(refused.stdout).error.message, /--take requires --workstream/);
+});
+
+test("creating one still needs a title and an objective", async t => {
+  const place = await workspace(t);
+  await place.attach("alpha");
+
+  // Both became optional so the command could act on an existing workstream.
+  // Optional in the parser is not optional in the command.
+  const refused = await place.cli("workstream", "--title", "Storage")
+    .then(() => null, error => error);
+
+  assert.notEqual(refused, null, "a workstream was created with no objective");
+  assert.match(JSON.parse(refused.stdout).error.message, /requires --objective/);
+});

--- a/tests/process/surface-coverage.test.mjs
+++ b/tests/process/surface-coverage.test.mjs
@@ -57,6 +57,7 @@ const BY_CLI = Object.freeze({
   forceReleaseClaim: "release", sendMessage: "message", markDelivery: "ack",
   requestWork: "request", createTask: "task", claimTask: "task",
   transitionTask: "task", declineTask: "task", createWorkstream: "workstream",
+  acquireCoordinator: "workstream", releaseCoordinator: "workstream",
   finishSession: "finish", collectStatus: "status",
 });
 
@@ -67,8 +68,6 @@ const INTERNAL = Object.freeze({
   locateSession: "a lookup the other operations share",
   pendingMessages: "read by the hook runtime when it builds a turn",
   renewClaim: "reached through `acc claim` on a claim this session already holds",
-  acquireCoordinator: "no workstream coordination surface yet - tracked, not forgotten",
-  releaseCoordinator: "same",
   recordDecision: "no decision surface yet - tracked, not forgotten",
   guardState: "the write guard's own read, kept narrow on purpose: `collectStatus` "
     + "answers the same question and reads the whole store, which put the cost of "
@@ -107,10 +106,12 @@ test("an operation an agent needs is offered over MCP as well", async () => {
   // of it, since a model should not be running the installer.
   const names = new Set(PUBLIC_TOOLS.map(tool => tool.name));
   for (const operation of ["sync", "setIntent", "acquireClaim", "sendMessage",
-    "markDelivery", "requestWork", "createTask", "createWorkstream", "finishSession"]) {
+    "markDelivery", "requestWork", "createTask", "createWorkstream", "acquireCoordinator",
+    "releaseCoordinator", "finishSession"]) {
     const expected = { sync: "acc_sync", setIntent: "acc_work", acquireClaim: "acc_claim",
       sendMessage: "acc_message", markDelivery: "acc_ack", requestWork: "acc_request",
       createTask: "acc_task", createWorkstream: "acc_workstream",
+      acquireCoordinator: "acc_workstream", releaseCoordinator: "acc_workstream",
       finishSession: "acc_finish" }[operation];
     assert.equal(names.has(expected), true, `${operation} has no MCP tool`);
   }


### PR DESCRIPTION
Create a workstream — a documented command, taught in the CLI reference — and every turn from that moment on carries this:

```
| 1 session(s); cursor 0000000000000003
| - [coordinator_missing] workstream_2_U9YcQ8xVeQJOxTZR1kag Storage
| - a (codex, online)
```

**Nothing could clear it.** `acquireCoordinator` and `releaseCoordinator` existed in the core and were tested there, with no command and no tool. The register of surfaces said so in as many words:

```js
acquireCoordinator: "no workstream coordination surface yet - tracked, not forgotten",
releaseCoordinator: "same",
```

A known gap had quietly become a permanent line in everyone's context, put there by using the feature as documented.

**This is the third time this shape has come up.** A `requiresAck` message once raised an item `markDelivery` could not clear, because that had no surface either. `nearby_intent` was an attention kind with no rule behind it at all.

## Now

```
--- after creating it:
   | - [coordinator_missing] workstream_2_U9Yc… Storage
--- taking it on:
workstream_2_U9Yc… coordinated
--- the turn now:
                                     ← nothing to say
--- handing it back:
workstream_2_U9Yc… released
--- and the turn again:
   | - [coordinator_missing] workstream_2_U9Yc… Storage
```

`--take` and `--release`, and the same over MCP as an `action`. Both operations move out of the internal register and into `BY_CLI`.

## Two things the tests hold

- **Releasing brings the item back.** That is the point of it: an open workstream with nobody steering it is worth saying, and a release that silenced it permanently would be a way to make the report go away rather than the condition.
- **Creating one still needs a title and an objective.** Both became optional *in the parser* so the command could act on an existing workstream — and optional in the parser reads exactly like optional in the command, so it is asserted separately.

## Verification

- 772 tests passing, 0 failing · `syntax ok in 165 file(s)`
- 4 of the 5 new tests fail on `main`
- `PASS … sha256 7d487399…6a2cf9 built from beadee3`
