### PR TITLE
fix: make a decision recordable, and stop the identity gate rotting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `beadee3` |
+| Built from | `d0b1afc` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `7d487399ced19f37ddbec932d9997dae5a4997a097b1f350b6eeb869856a2cf9` |
-| Tests | 772 passing, 0 failing |
+| sha256 | `4746b75ae70c63f35f74e2926e7faedaec4a47404573346f5539c02273a6632d` |
+| Tests | 778 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -62,6 +62,11 @@ fact: you asked, and there is nobody there.
 Every line of an injected turn can be acted on. An attention line carries the id
 of the thing it is about — the same id the command that answers it takes — and a
 turn the byte budget truncated says how to read what it withheld.
+
+A decision can be recorded. The protocol has described the object from the start
+and nothing could make one; the rule that an agent cannot record a human decision
+by itself is now reachable rather than only implemented. Every core operation has
+a surface — the register of "tracked, not forgotten" is empty.
 
 An open workstream can be taken on. Creating one used to put
 `coordinator_missing` in every turn from then on with no way to answer it: the

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -42,6 +42,7 @@ graph LR
 | `acc request` | Ask another agent to do something. One call: the work plus why |
 | `acc task` | Create work, `--take` it, or `--state` it along |
 | `acc workstream` | Group related work. Optional. `--take` / `--release` steer one |
+| `acc decide` | Record what was settled, so the next session does not reopen it |
 | `acc finish` | Write the handoff and release claims |
 
 ## Adapters only
@@ -92,6 +93,24 @@ acc status --all
 
 That is how a cleanup asks: each entry carries `checkoutRoot`, `branch` and `presence`, so
 a worktree with no live session behind it can be told apart from someone's desk.
+
+## Recording what was settled
+
+A decision outlives the conversation that produced it, which is why it is a durable object
+rather than another message in the log.
+
+```bash
+acc decide --title "hull clamps at half height" \
+  --outcome "settle() clamps to GROUND_Y + height/2; renderer draws what physics returns"
+```
+
+`--authority` is who settled it: `workstream` (the default) for an agreement between
+agents, `policy` for a rule that already existed, and `human` only when a person actually
+said so — which needs `--human` as well. A peer proposal cannot become a human-authority
+decision on its own; that is the one way this record could launder an agent's opinion into
+a ruling.
+
+`--supersedes` points at the decision this replaces, and the one it names has to exist.
 
 ## Asking another agent
 

--- a/packages/cli/src/args.mjs
+++ b/packages/cli/src/args.mjs
@@ -41,6 +41,12 @@ export const COMMANDS = Object.freeze({
   // Messages not tied to a task need a way to be answered too. Without one a
   // `requiresAck` message raised an attention item nothing could ever clear.
   ack: { required: ["message"], optional: ["session", "generation", "state"] },
+  // Recording what was settled, so the next session does not reopen it. The
+  // protocol has described this object from the start and nothing could make
+  // one: no command, no tool.
+  decide: { required: ["title", "outcome"],
+    optional: ["session", "generation", "authority", "workstream", "supersedes"],
+    repeated: ["decided-by"], flags: ["human"] },
   finish: { required: ["goal"], optional: ["session", "generation", "status", "to"],
     repeated: ["completed", "remaining", "blocker"] },
   status: { required: [], optional: ["participant"], flags: ["all"] },

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -150,6 +150,28 @@ const HANDLERS = Object.freeze({
     return { data: receipt, text: `${receipt.messageId} ${receipt.state}` };
   },
 
+  /**
+   * What was settled, and on whose authority.
+   *
+   * `--human` is the caller stating that a person actually decided this. The
+   * core refuses `--authority human` without it, because a peer proposal
+   * becoming a human decision on its own is the one way this record could
+   * launder an agent's opinion into a ruling.
+   */
+  decide: async ({ options, context }) => {
+    const decision = await context.service.recordDecision({
+      sessionId: options.session, generation: options.generation,
+      title: options.title, outcome: options.outcome,
+      authority: options.authority ?? "workstream",
+      workstreamId: options.workstream ?? null,
+      decidedBy: options.decidedBy,
+      supersedes: options.supersedes ?? null,
+      humanConfirmed: options.human === true,
+      descriptor: context.descriptor });
+    return { data: decision,
+      text: `${decision.decisionId} ${decision.authority}: ${decision.title}` };
+  },
+
   workstream: async ({ options, context }) => {
     const owner = { sessionId: options.session, generation: options.generation };
     // Taking the coordination of one and creating one are the same noun, so

--- a/packages/cli/src/session-owner.mjs
+++ b/packages/cli/src/session-owner.mjs
@@ -20,7 +20,7 @@ import { AccError, EXIT } from "@agents-can-communicate/protocol";
  * answers that from something the caller demonstrably has.
  */
 const NEEDS_OWNER = Object.freeze(new Set(["work", "claim", "release", "message",
-  "request", "ack", "workstream", "task", "finish"]));
+  "request", "ack", "workstream", "task", "finish", "decide"]));
 
 /**
  * Reads that are answers about *you*.

--- a/packages/mcp-server/src/server.mjs
+++ b/packages/mcp-server/src/server.mjs
@@ -153,6 +153,11 @@ async function callTool(name, args, context) {
     case "acc_ack":
       return service.markDelivery({ ...owner, messageId: args.messageId,
         state: args.state ?? "acknowledged" });
+    case "acc_decide":
+      return service.recordDecision({ ...owner, title: args.title, outcome: args.outcome,
+        authority: args.authority ?? "workstream", workstreamId: args.workstreamId ?? null,
+        decidedBy: args.decidedBy, supersedes: args.supersedes ?? null,
+        humanConfirmed: args.humanConfirmed === true });
     case "acc_workstream":
       if (args.action === "coordinate") {
         return service.acquireCoordinator({ ...owner, workstreamId: args.workstreamId });

--- a/packages/mcp-server/src/tools.mjs
+++ b/packages/mcp-server/src/tools.mjs
@@ -107,6 +107,25 @@ export const PUBLIC_TOOLS = Object.freeze([
     }, ["messageId"]),
   },
   {
+    name: "acc_decide",
+    description: `Record what was settled, so the next session does not reopen it. `
+      + `Separate from a message because a decision outlives the conversation that `
+      + `produced it. \`authority\` is who settled it: \`workstream\` for an agreement `
+      + `between agents, \`policy\` for a rule that already existed, \`human\` only when a `
+      + `person actually said so - which needs \`humanConfirmed\`. ${POLLED}`,
+    inputSchema: object({
+      title: string("What was decided, in one line."),
+      outcome: string("What was settled, and enough of why to act on it."),
+      authority: { type: "string", enum: ["workstream", "policy", "human"],
+        description: "Default: workstream." },
+      humanConfirmed: { type: "boolean",
+        description: "A person said so. Required for human authority." },
+      workstreamId: string("Optional workstream context."),
+      supersedes: string("A decision this replaces."),
+      decidedBy: stringList("Participants who settled it. Defaults to you."),
+    }, ["title", "outcome"]),
+  },
+  {
     name: "acc_workstream",
     description: `Group related work so several agents can see it as one thing, or take `
       + `on steering one that exists. Optional: a single request needs no workstream. `

--- a/packages/mcp-server/test/tools.test.mjs
+++ b/packages/mcp-server/test/tools.test.mjs
@@ -10,8 +10,8 @@ test("the model-facing surface is exactly this list", () => {
   // reachable by adapters and stay out of here. Named rather than counted, so
   // a tool swapped for another still trips this.
   assert.deepEqual(names.sort(),
-    ["acc_ack", "acc_claim", "acc_finish", "acc_message", "acc_request", "acc_sync",
-      "acc_task", "acc_work", "acc_workstream"]);
+    ["acc_ack", "acc_claim", "acc_decide", "acc_finish", "acc_message", "acc_request",
+      "acc_sync", "acc_task", "acc_work", "acc_workstream"]);
 });
 
 test("every tool declares a strict 2020-12 input schema", () => {

--- a/tests/docs/skills.test.mjs
+++ b/tests/docs/skills.test.mjs
@@ -25,9 +25,10 @@ const TAUGHT = Object.freeze(["sync", "work", "claim", "request", "task", "messa
   "finish", "status", "ack"]);
 
 // Reachable by an agent but not worth a section: `release` is covered by
-// `finish`, `workstream` only matters once work
-// is large enough that the model will have read the CLI reference anyway.
-const OPTIONAL = Object.freeze(["release", "workstream"]);
+// `finish`, and `workstream` and `decide` only matter once work is large enough,
+// or a disagreement real enough, that the model will have read the CLI reference
+// anyway. Four sections in every skill is four sections read on every turn.
+const OPTIONAL = Object.freeze(["release", "workstream", "decide"]);
 
 /** Every SKILL.md an adapter ships. */
 async function skills() {

--- a/tests/process/decide.test.mjs
+++ b/tests/process/decide.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+const repo = path.resolve(import.meta.dirname, "..", "..");
+const acc = path.join(repo, "bin", "acc.mjs");
+const hook = path.join(repo, "bin", "acc-hook.mjs");
+
+/**
+ * What was settled, so the next session does not reopen it.
+ *
+ * `Decision` has been a first-class object in the protocol reference from the
+ * start, with an interface, a supersedes chain, and a rule about authority.
+ * `recordDecision` implemented all of it and had no command and no tool, so
+ * nothing could make one - the register of surfaces called it "no decision
+ * surface yet, tracked, not forgotten", and it was the last entry left with that
+ * wording.
+ *
+ * Reading them already worked: they are in a full snapshot. Only writing was
+ * missing.
+ */
+async function workspace(t) {
+  const base = await realpath(await mkdtemp(path.join(tmpdir(), "acc-decide-")));
+  t.after(() => rm(base, { recursive: true, force: true }));
+  const project = path.join(base, "project");
+  await mkdir(project, { recursive: true });
+  const env = { ...process.env, ACC_DATA_HOME: path.join(base, "data"),
+    GIT_DIR: "", GIT_WORK_TREE: "" };
+  const child = run(process.execPath, [hook, "codex"],
+    { env: { ...env, ACC_PARTICIPANT: "graphics" } });
+  child.child.stdin.end(JSON.stringify({ hook_event_name: "SessionStart",
+    session_id: "graphics", cwd: project, source: "startup" }));
+  await child;
+  const cli = (...argv) => run(process.execPath, [acc, ...argv, "--cwd", project, "--json"],
+    { env });
+  const decisions = async () => {
+    const session = JSON.parse((await cli("status")).stdout).data.participants[0].sessionId;
+    return JSON.parse((await cli("sync", "--session", session, "--scope", "full")).stdout)
+      .data.snapshot.decisions;
+  };
+  return { project, env, cli, decisions };
+}
+
+const failed = promise => promise.then(() => null, error => error);
+
+test("an agreement between agents can be written down", async t => {
+  const place = await workspace(t);
+
+  const { stdout } = await place.cli("decide", "--title", "hull clamps at half height",
+    "--outcome", "settle() clamps to GROUND_Y + height/2");
+
+  assert.equal(JSON.parse(stdout).data.authority, "workstream");
+  const [decision] = await place.decisions();
+  assert.equal(decision.title, "hull clamps at half height");
+  // Written down is only useful if a later session can read it back.
+  assert.equal(decision.outcome, "settle() clamps to GROUND_Y + height/2");
+});
+
+test("an agent cannot record that a person decided something", async t => {
+  const place = await workspace(t);
+
+  const refused = await failed(place.cli("decide", "--title", "ship it",
+    "--outcome", "release on friday", "--authority", "human"));
+
+  // The one way this record could do harm: laundering an agent's opinion into a
+  // ruling nobody made. Saying `--human` is the caller stating a person did.
+  assert.notEqual(refused, null, "an agent recorded a human decision by itself");
+  assert.match(JSON.parse(refused.stdout).error.message, /requires an explicit human/);
+  assert.deepEqual(await place.decisions(), []);
+});
+
+test("with the confirmation, human authority is recorded as such", async t => {
+  const place = await workspace(t);
+
+  await place.cli("decide", "--title", "ship it", "--outcome", "release on friday",
+    "--authority", "human", "--human");
+
+  const [decision] = await place.decisions();
+  assert.equal(decision.authority, "human");
+});
+
+test("superseding a decision that does not exist is refused", async t => {
+  const place = await workspace(t);
+
+  const refused = await failed(place.cli("decide", "--title", "revised",
+    "--outcome", "the other way", "--supersedes", "decision_nope"));
+
+  // A supersedes chain that points at nothing is worse than no chain: it reads
+  // as history that was checked.
+  assert.notEqual(refused, null);
+  assert.match(JSON.parse(refused.stdout).error.message, /superseded decision does not exist/);
+});
+
+test("a decision replaces the one it names", async t => {
+  const place = await workspace(t);
+  const first = JSON.parse((await place.cli("decide", "--title", "clamp at full height",
+    "--outcome", "no clamping")).stdout).data.decisionId;
+
+  await place.cli("decide", "--title", "hull clamps at half height",
+    "--outcome", "settle() clamps to GROUND_Y + height/2", "--supersedes", first);
+
+  const superseded = (await place.decisions()).find(item => item.supersedes !== null);
+  assert.equal(superseded.supersedes, first);
+});

--- a/tests/process/session-resolution.test.mjs
+++ b/tests/process/session-resolution.test.mjs
@@ -6,6 +6,8 @@ import path from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
 
+import { COMMANDS } from "@agents-can-communicate/cli";
+
 const run = promisify(execFile);
 const repo = path.resolve(import.meta.dirname, "..", "..");
 const acc = path.join(repo, "bin", "acc.mjs");
@@ -142,6 +144,8 @@ test("a session that has closed is not mistaken for the caller", async t => {
  * no command. This runs each agent-facing command the way the skill tells an
  * agent to, and fails if any of them refuses for want of identity.
  */
+// Arguments for the ones that need them; every other command in the CLI is
+// covered by the derivation below rather than by being remembered here.
 const AGENT_FACING = Object.freeze([
   ["sync", []],
   ["status", []],
@@ -153,7 +157,26 @@ const AGENT_FACING = Object.freeze([
   ["workstream", ["--title", "a stream", "--objective", "an objective"]],
   ["ack", ["--message", "message_absent"]],
   ["finish", ["--goal", "what this session was for"]],
+  ["decide", ["--title", "settled", "--outcome", "what was settled"]],
+  ["release", ["--claim", "claim_absent"]],
 ]);
+
+// Setup and lifecycle: a model should not be running the installer, and these
+// three are the adapter's own calls, which pass their identity explicitly.
+const NOT_AGENT_FACING = Object.freeze(["install", "uninstall", "doctor", "config",
+  "attach", "heartbeat", "detach"]);
+
+test("the list above is every command an agent can run", async () => {
+  // Remembered lists rot. `acc decide` was added, needed an identity like the
+  // rest, and was not in this list - so the gate for exactly that defect passed
+  // while the command refused every agent that tried it.
+  const covered = new Set([...AGENT_FACING.map(([command]) => command),
+    ...NOT_AGENT_FACING]);
+  const forgotten = Object.keys(COMMANDS).filter(command => !covered.has(command));
+
+  assert.deepEqual(forgotten, [],
+    "a command exists that this gate does not exercise");
+});
 
 test("no agent-facing command refuses for want of an identity", async t => {
   const { cli } = await stage(t,

--- a/tests/process/surface-coverage.test.mjs
+++ b/tests/process/surface-coverage.test.mjs
@@ -58,7 +58,7 @@ const BY_CLI = Object.freeze({
   requestWork: "request", createTask: "task", claimTask: "task",
   transitionTask: "task", declineTask: "task", createWorkstream: "workstream",
   acquireCoordinator: "workstream", releaseCoordinator: "workstream",
-  finishSession: "finish", collectStatus: "status",
+  finishSession: "finish", collectStatus: "status", recordDecision: "decide",
 });
 
 // Deliberately internal, each for a stated reason rather than by omission.
@@ -68,7 +68,6 @@ const INTERNAL = Object.freeze({
   locateSession: "a lookup the other operations share",
   pendingMessages: "read by the hook runtime when it builds a turn",
   renewClaim: "reached through `acc claim` on a claim this session already holds",
-  recordDecision: "no decision surface yet - tracked, not forgotten",
   guardState: "the write guard's own read, kept narrow on purpose: `collectStatus` "
     + "answers the same question and reads the whole store, which put the cost of "
     + "guarding one write in proportion to every message the workspace had carried",


### PR DESCRIPTION
`Decision` has been a first-class object in `docs/PROTOCOL.md` from the start — an interface, a supersedes chain, and a rule that *"peer proposals never become human-authority decisions without an explicit human or policy transition."*

`recordDecision` implemented all of it. **Nothing could call it** — no command, no tool. Reading them already worked, since they sit in a full snapshot; only writing one was missing.

That was the last entry in the register of surfaces still reading `"tracked, not forgotten"`. Every core operation now has one.

```
$ acc decide --title "hull clamps at half height" --outcome "settle() clamps to GROUND_Y + height/2"
decision_ERKTqTI63b-lOSxjSiVjxA workstream: hull clamps at half height

$ acc decide --title "ship it" --outcome "friday" --authority human
human authority requires an explicit human confirmation

$ acc decide --title "ship it" --outcome "friday" --authority human --human
decision_x3JsmYOe_QUZaoF1XQKHPg human: ship it
```

The authority rule is the one way this record could do harm — laundering an agent's opinion into a ruling nobody made — and it is now reachable rather than only implemented.

## Adding it found a hole in a gate I wrote for exactly this

The gate that checks *no agent-facing command refuses for want of an identity* enumerated its commands **by hand**. So `decide` was not in the list, needed an identity like every other mutating command, and refused every agent that tried it — while the gate stayed green:

```
$ acc decide --title "…" --outcome "…"
cannot record a decision from this session generation
```

The list is now derived from the CLI's own command table: anything neither exercised nor named as setup fails the test. That immediately turned up `release`, which had never been exercised either.

## One classification made on purpose

`decide` joins `workstream` and `release` in the skills' `OPTIONAL` set rather than `TAUGHT`. It matters once a disagreement is real enough that the model will have read the CLI reference anyway, and four more sections in every skill is four more sections read on every turn.

## Verification

- 778 tests passing, 0 failing · `syntax ok in 166 file(s)`
- All 5 new behaviour tests fail on `main`
- `PASS … sha256 4746b75a…a6632d built from d0b1afc`
