### PR TITLE
fix: tell an agent when the claim it is relying on has run out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `d0b1afc` |
+| Built from | `991df4c` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `4746b75ae70c63f35f74e2926e7faedaec4a47404573346f5539c02273a6632d` |
-| Tests | 778 passing, 0 failing |
+| sha256 | `56914a392bdd204bef999cb3b26bc3e3b054f48c9a3bf6096122ed34ebb1fbdf` |
+| Tests | 782 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -62,6 +62,10 @@ fact: you asked, and there is nobody there.
 Every line of an injected turn can be acted on. An attention line carries the id
 of the thing it is about — the same id the command that answers it takes — and a
 turn the byte budget truncated says how to read what it withheld.
+
+An agent is told when the claim it is relying on has run out. The lease lapsed on
+the clock, peers could write again, and the holder's turn said nothing — it went
+on working on a file it believed it had reserved.
 
 A decision can be recorded. The protocol has described the object from the start
 and nothing could make one; the rule that an agent cannot record a human decision

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -94,6 +94,7 @@ Computed from explicit rules, never from a hidden classifier. Lower sorts first:
 | 3 | `task_unblocked` | Work addressed to your participant is `pending` — every dependency is `done` |
 | 4 | `coordinator_missing` | An open workstream has no coordinator |
 | 5 | `request_stalled` | You asked for something and nobody is on it: work you requested is held by a session that has gone quiet or addressed to a participant that is not here, or a question of yours needing an answer is addressed to a participant that is not here |
+| 6 | `claim_expired` | A claim you took has run out. Peers can write to it again, and until now nothing said so |
 
 A task with unmet dependencies is `blocked`, and finishing the last one flips its dependents
 to `pending`. So `pending` already means ready, and nothing has to re-evaluate the graph.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -205,9 +205,9 @@ A handoff contains:
 
 ## Sync and attention
 
-Adapters request deltas since a cursor. Core computes attention items from five explicit
+Adapters request deltas since a cursor. Core computes attention items from six explicit
 rules — `direct_request`, `claim_conflict`, `task_unblocked`, `coordinator_missing`,
-`request_stalled` — listed with their exact trigger in
+`request_stalled`, `claim_expired` — listed with their exact trigger in
 [ARCHITECTURE.md](ARCHITECTURE.md).
 
 Semantic relevance may be assessed by the receiving model, but correctness cannot depend on a hidden central LLM classifier.

--- a/packages/core/src/claims.mjs
+++ b/packages/core/src/claims.mjs
@@ -84,8 +84,13 @@ export function createClaimService(ports, sessions) {
     let record = null;
     await store.transaction(async tx => {
       const live = tx.list("claim", claim => isLive(claim, now));
-      const mine = live.find(claim => claim.ownerSessionId === session.sessionId
-        && claim.resource === resource);
+      // This session's own claim on this resource, live or lapsed. Looking only
+      // among the live ones left the expired record behind and made a fresh one
+      // beside it, so taking a resource back after a lease ran out reported
+      // success while the workspace still held a dead claim saying otherwise -
+      // and the owner went on being told its claim had run out.
+      const mine = tx.list("claim", claim => claim.ownerSessionId === session.sessionId
+        && claim.resource === resource).at(0);
       const blocking = live.find(claim => overlaps(claim.resource, resource)
         && claim.ownerSessionId !== session.sessionId
         && (claim.mode === "exclusive" || input.mode === "exclusive"));
@@ -101,7 +106,9 @@ export function createClaimService(ports, sessions) {
         mode: input.mode ?? "exclusive",
         enforcement: input.enforcement ?? "advisory",
         reason: input.reason,
-        acquiredAt: mine?.acquiredAt ?? now,
+        // A lapsed claim taken again is a new period of holding it, not a
+        // continuation of one that ended.
+        acquiredAt: mine !== undefined && isLive(mine, now) ? mine.acquiredAt : now,
         expiresAt,
         generation: ids.next("generation"),
       });

--- a/packages/core/src/sync.mjs
+++ b/packages/core/src/sync.mjs
@@ -15,6 +15,7 @@ export const ATTENTION_PRIORITY = Object.freeze({
   task_unblocked: 3,
   coordinator_missing: 4,
   request_stalled: 5,
+  claim_expired: 6,
 });
 
 function directRequests(snapshot, participantId) {
@@ -28,6 +29,29 @@ function directRequests(snapshot, participantId) {
       sourceId: message.messageId, summary: message.subject });
   }
   return items;
+}
+
+/**
+ * A claim of yours that has run out.
+ *
+ * A lease lapses on the clock, and nothing said so. Measured: while it held, a
+ * peer's write into the file was refused; three seconds later the same write
+ * went through, and the holder's turn was identical before and after. It went on
+ * working on a file it believed it had reserved, and everyone else was free to
+ * change it.
+ *
+ * Only for the session that took it, and only while that session is the one
+ * asking: a lapsed claim is news to its owner and nobody else's business.
+ * Re-claiming refreshes the lease and clears this; releasing it clears it too.
+ */
+function expiredClaims(snapshot, session, now) {
+  if (session == null) return [];
+  return (snapshot.claims ?? [])
+    .filter(claim => claim.ownerSessionId === session.sessionId
+      && Date.parse(claim.expiresAt) <= Date.parse(now))
+    .map(claim => ({ kind: "claim_expired", priority: ATTENTION_PRIORITY.claim_expired,
+      sourceId: claim.claimId,
+      summary: `${claim.resource} - your claim has run out, and peers can write to it` }));
 }
 
 function claimConflicts(snapshot, session, now) {
@@ -142,6 +166,7 @@ export function computeAttention(snapshot, { session, participantId, now }) {
   return [
     ...directRequests(snapshot, participantId),
     ...claimConflicts(snapshot, session, now),
+    ...expiredClaims(snapshot, session, now),
     ...unblockedTasks(snapshot, session, participantId),
     ...coordinatorGaps(snapshot),
     ...stalledRequests(snapshot, participantId, now),

--- a/packages/core/test/sync.test.mjs
+++ b/packages/core/test/sync.test.mjs
@@ -139,16 +139,21 @@ test("every attention kind in the priority table is one a rule can produce", () 
   // it. `nearby_intent` sat in this table with no rule, so it read as a shipped
   // feature in review, was documented as one, and produced nothing at runtime.
   //
-  // The snapshot below is built to trigger all four rules at once. Adding a
-  // fifth entry to the table without a rule fails this test; adding one with a
-  // rule fails it until the snapshot exercises it, which is the point.
+  // The snapshot below is built to trigger every rule at once. An entry added to
+  // the table without a rule fails this test; one added with a rule fails it
+  // until the snapshot exercises it, which is the point.
   const snapshot = {
     messages: [{ messageId: "message_a", subject: "Need slots", requiresAck: true }],
     receipts: [{ messageId: "message_a", recipientParticipantId: "participant_a",
       state: "injected" }],
     intents: [{ sessionId: "session_a", resourceHints: ["file:src/**"] }],
-    claims: [{ claimId: "claim_a", ownerSessionId: "session_b", resource: "file:src/main.mjs",
-      expiresAt: "2026-08-16T02:00:00.000Z" }],
+    claims: [
+      { claimId: "claim_a", ownerSessionId: "session_b", resource: "file:src/main.mjs",
+        expiresAt: "2026-08-16T02:00:00.000Z" },
+      // This session's own, and its lease has run out.
+      { claimId: "claim_b", ownerSessionId: "session_a", resource: "file:src/lapsed.mjs",
+        expiresAt: "2026-08-16T00:30:00.000Z" },
+    ],
     tasks: [
       { taskId: "task_a", state: "pending", assigneeSessionId: "session_a",
         title: "port the store" },

--- a/tests/process/lapsed-claim.test.mjs
+++ b/tests/process/lapsed-claim.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+const repo = path.resolve(import.meta.dirname, "..", "..");
+const acc = path.join(repo, "bin", "acc.mjs");
+const hook = path.join(repo, "bin", "acc-hook.mjs");
+
+/**
+ * A claim that ran out while its owner was still working.
+ *
+ * A lease lapses on the clock and nothing said so. Measured: while it held, a
+ * peer's write into the file was refused; three seconds later the same write
+ * went through, and the holder's turn was identical before and after. It went on
+ * working on a file it believed it had reserved, while everyone else was free to
+ * change it - the guard doing exactly what it was told, and the one agent who
+ * needed to know being the only one not told.
+ */
+async function workspace(t) {
+  const base = await realpath(await mkdtemp(path.join(tmpdir(), "acc-lapsed-")));
+  t.after(() => rm(base, { recursive: true, force: true }));
+  const project = path.join(base, "project");
+  await mkdir(project, { recursive: true });
+  const env = { ...process.env, ACC_DATA_HOME: path.join(base, "data"),
+    GIT_DIR: "", GIT_WORK_TREE: "" };
+  const fire = async (participant, payload) => {
+    const child = run(process.execPath, [hook, "codex"],
+      { env: { ...env, ACC_PARTICIPANT: participant } });
+    child.child.stdin.end(JSON.stringify({ session_id: participant, cwd: project, ...payload }));
+    return (await child).stdout;
+  };
+  const attach = participant => fire(participant,
+    { hook_event_name: "SessionStart", source: "startup" });
+  const turn = participant => fire(participant,
+    { hook_event_name: "UserPromptSubmit", prompt: "go" });
+  const cli = (...argv) => run(process.execPath, [acc, ...argv, "--cwd", project, "--json"],
+    { env });
+  const sessionOf = async participant => JSON.parse((await cli("status")).stdout).data
+    .participants.find(item => item.participantId === participant).sessionId;
+  const lapse = () => new Promise(resolve => { setTimeout(resolve, 2100); });
+  return { project, env, attach, turn, cli, sessionOf, lapse };
+}
+
+test("the owner is told when its claim runs out", async t => {
+  const place = await workspace(t);
+  await place.attach("holder");
+  await place.cli("claim", "--resource", "file:src/x.mjs", "--reason", "editing",
+    "--lease", "2");
+  assert.equal((await place.turn("holder")).includes("claim_expired"), false,
+    "reported before the lease had run out");
+
+  await place.lapse();
+
+  assert.match(await place.turn("holder"),
+    /\[claim_expired\] claim_\S+ file:src\/x\.mjs - your claim has run out/);
+});
+
+test("taking it again clears the report and leaves one claim", async t => {
+  const place = await workspace(t);
+  await place.attach("holder");
+  await place.cli("claim", "--resource", "file:src/x.mjs", "--reason", "editing",
+    "--lease", "2");
+  await place.lapse();
+
+  await place.cli("claim", "--resource", "file:src/x.mjs", "--reason", "editing");
+
+  // An item nobody can answer is the defect this project keeps finding, so the
+  // way out has to work. Looking for the session's own claim only among the live
+  // ones left the lapsed record beside the new one, and the report stood.
+  const shown = await place.turn("holder");
+  assert.equal(shown.includes("claim_expired"), false, shown);
+  const session = await place.sessionOf("holder");
+  const { snapshot } = JSON.parse((await place.cli("sync", "--session", session,
+    "--scope", "full")).stdout).data;
+  assert.equal(snapshot.claims.length, 1);
+});
+
+test("releasing it clears the report too", async t => {
+  const place = await workspace(t);
+  await place.attach("holder");
+  const { stdout } = await place.cli("claim", "--resource", "file:src/x.mjs",
+    "--reason", "editing", "--lease", "2");
+  const { claimId } = JSON.parse(stdout).data;
+  await place.lapse();
+
+  await place.cli("release", "--claim", claimId);
+
+  // Two ways out, because an owner who no longer wants the file should not have
+  // to take it back to stop being told about it.
+  assert.equal((await place.turn("holder")).includes("claim_expired"), false);
+});
+
+test("a peer is not told about somebody else's lapsed claim", async t => {
+  const place = await workspace(t);
+  await place.attach("holder");
+  const holder = await place.sessionOf("holder");
+  await place.cli("claim", "--session", holder, "--resource", "file:src/x.mjs",
+    "--reason", "editing", "--lease", "2");
+  await place.attach("peer");
+  await place.lapse();
+
+  // It is news to its owner and nobody else's business: for a peer the file is
+  // simply free again, which the roster and the guard already say.
+  assert.equal((await place.turn("peer")).includes("claim_expired"), false);
+});


### PR DESCRIPTION
A lease lapses on the clock, and nothing said so.

```
--- while the lease holds:
   peer write: exit 2                 ← refused
--- the holder's turn:
   | 2 session(s); cursor 0000000000000004
   | - writer (codex, online)
   | - holder (codex, online)

--- three seconds later, the lease has lapsed:
   peer write: exit 0                 ← allowed
--- and the holder's turn now:
   | 2 session(s); cursor 0000000000000004
   | - writer (codex, online)
   | - holder (codex, online)         ← identical
```

The holder goes on working on a file it believes it has reserved, while everyone else is free to change it. The guard is doing exactly what it was told; the one agent who needed to know is the only one not told.

`claim_expired` reports it — to the session that took the claim and to nobody else. For a peer the file is simply free again, which the roster and the guard already say.

## Why it could not be added on its own

`acquireClaim` looked for the session's own claim on a resource **only among the live ones**. So taking a resource back after a lease ran out made a *second* record beside the dead one, and the report stood after the very action that answers it:

```
--- the holder takes it again:
claimed file:src/x.mjs
--- and its turn now:
   | - [claim_expired] claim_94kAWv… file:src/x.mjs - your claim has run out
```

That is the "attention item nobody can clear" defect this project has now found four times — `nearby_intent`, `markDelivery`, `coordinator_missing`, and very nearly this one, introduced by the fix for it. The record is reused either way now, and a lapsed claim taken again gets a fresh `acquiredAt`: that is a new period of holding it, not a continuation of one that ended.

## Two ways out, both tested

Take it again, or let it go. An owner who no longer wants the file should not have to take it back to stop being told about it.

## Verification

- 782 tests passing, 0 failing · `syntax ok in 167 file(s)`
- 2 of the 4 new tests fail on `main`; the other two are the edges the fix must not cross
- `PASS … sha256 56914a39…b1fbdf built from 991df4c`
