### PR TITLE
fix: a working session stops looking dead to everyone after three minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `991df4c` |
+| Built from | `75e5102` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `56914a392bdd204bef999cb3b26bc3e3b054f48c9a3bf6096122ed34ebb1fbdf` |
-| Tests | 782 passing, 0 failing |
+| sha256 | `e6ef015c162f199123571838082b84fec927b14f5c0865fc37066008994a320e` |
+| Tests | 786 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -62,6 +62,11 @@ fact: you asked, and there is nobody there.
 Every line of an injected turn can be acted on. An attention line carries the id
 of the thing it is about — the same id the command that answers it takes — and a
 turn the byte budget truncated says how to read what it withheld.
+
+A session that is working looks alive. Only one of the four clients fires a
+heartbeat event, so every other session went stale three minutes after starting
+and stayed stale — every roster said so of every peer, and a requester was told
+"nobody is working on it" about work being done right then.
 
 An agent is told when the claim it is relying on has run out. The lease lapsed on
 the clock, peers could write again, and the holder's turn said nothing — it went

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `75e5102` |
+| Built from | `4dd9548` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `e6ef015c162f199123571838082b84fec927b14f5c0865fc37066008994a320e` |
-| Tests | 786 passing, 0 failing |
+| sha256 | `c183218ad4bdecd9cf20e45c36e0710271493277bb793727e23b99a399cf5a61` |
+| Tests | 787 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |

--- a/packages/core/src/status.mjs
+++ b/packages/core/src/status.mjs
@@ -49,6 +49,9 @@ export function createGuardStateService(ports) {
       participants: sessions.map(session => ({
         sessionId: session.sessionId,
         participantId: session.participantId,
+        // So the guard can tell whether this session has looked alive recently
+        // without a second read. Bounded like the rest of what it asks for.
+        heartbeatAt: session.heartbeatAt,
       })),
     };
   };

--- a/packages/hook-runner/src/runner.mjs
+++ b/packages/hook-runner/src/runner.mjs
@@ -26,6 +26,20 @@ const DEFAULT_BUDGET_MS = 5_000;
 const CADENCE_MS = 60_000;
 const REFRESH_AFTER_MS = CADENCE_MS / 2;
 
+/**
+ * Whether the write guard should spend a write saying this session is alive.
+ *
+ * A value that is not a timestamp means nothing is known about its last sign of
+ * life, so it gets one. Said outright rather than left to `Date.parse`: the
+ * previous form leaned on `Date.parse(0)` coercing to the string "0" and landing
+ * in the year 2000, which gives the right answer and reads like an accident,
+ * because it is one.
+ */
+export function needsRefresh(heartbeatAt, now) {
+  const last = Date.parse(heartbeatAt ?? "");
+  return !Number.isFinite(last) || now - last > REFRESH_AFTER_MS;
+}
+
 const defaultRuntime = () => ({
   clock: { now: () => new Date().toISOString() },
   ids: { next: kind => createId(kind, randomBytes) },
@@ -278,8 +292,7 @@ const HANDLERS = {
     // so guarding a write stays a read in the ordinary case.
     const mine = status.participants
       .find(participant => participant.sessionId === binding.accSessionId);
-    if (mine !== undefined && Date.now()
-      - Date.parse(mine.heartbeatAt ?? 0) > REFRESH_AFTER_MS) {
+    if (mine !== undefined && needsRefresh(mine.heartbeatAt, Date.now())) {
       await context.service.heartbeatSession({ sessionId: binding.accSessionId,
         generation: binding.generation }).catch(() => null);
     }

--- a/packages/hook-runner/src/runner.mjs
+++ b/packages/hook-runner/src/runner.mjs
@@ -15,9 +15,16 @@ import { createGitProbe, discoverWorkspace, platformDataHome, runtimePaths }
 const DEFAULT_BUDGET_MS = 5_000;
 
 // Declared by this process on the session it opens, so peers can tell an idle
-// session from a dead one. Adapters whose client fires no heartbeat still get a
-// truthful cadence: they refresh on every turn instead.
+// session from a dead one. Only one of the four clients fires a heartbeat event,
+// so the rest refresh here: on every turn, and during a long one whenever the
+// last sign of life is older than half the cadence.
+//
+// Until they did, a session went stale three minutes after it started and stayed
+// stale however hard it was working. Every roster showed every peer as stale, so
+// the word stopped meaning anything - and a requester was told "nobody is
+// working on it" about work a peer had accepted and was doing.
 const CADENCE_MS = 60_000;
+const REFRESH_AFTER_MS = CADENCE_MS / 2;
 
 const defaultRuntime = () => ({
   clock: { now: () => new Date().toISOString() },
@@ -175,6 +182,10 @@ const HANDLERS = {
 
   async beforeTurn({ binding, context, adapter }) {
     if (binding === null) return {};
+    // A turn is the clearest sign a session is alive. Never a reason to fail:
+    // this runs in front of somebody's prompt.
+    await context.service.heartbeatSession({ sessionId: binding.accSessionId,
+      generation: binding.generation }).catch(() => null);
     const sync = await context.service.sync({ sessionId: binding.accSessionId,
       cursor: null, scope: "delta" });
 
@@ -262,6 +273,16 @@ const HANDLERS = {
     // writes, and the budget that keeps it from failing open is five seconds.
     const status = await context.service.guardState({
       workspaceId: context.descriptor.id });
+    // A turn that runs for half an hour is one turn, and a session working that
+    // hard should not look dead to its peers. Written at most twice a cadence,
+    // so guarding a write stays a read in the ordinary case.
+    const mine = status.participants
+      .find(participant => participant.sessionId === binding.accSessionId);
+    if (mine !== undefined && Date.now()
+      - Date.parse(mine.heartbeatAt ?? 0) > REFRESH_AFTER_MS) {
+      await context.service.heartbeatSession({ sessionId: binding.accSessionId,
+        generation: binding.generation }).catch(() => null);
+    }
     // Anchored to the repository, not to wherever this session was started. A
     // session opened in `repo/src` relativised the same file to
     // `file:physics.mjs` where one at `repo` called it `file:src/physics.mjs`,

--- a/tests/process/heartbeat.test.mjs
+++ b/tests/process/heartbeat.test.mjs
@@ -7,6 +7,8 @@ import path from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
 
+import { needsRefresh } from "@agents-can-communicate/hook-runner";
+
 const run = promisify(execFile);
 const repo = path.resolve(import.meta.dirname, "..", "..");
 const acc = path.join(repo, "bin", "acc.mjs");
@@ -143,4 +145,17 @@ test("work in progress is not reported as going nowhere", async t => {
   // opposite of the truth about work somebody is doing right now.
   const shown = await place.turn("asker");
   assert.equal(shown.includes("nobody is working on it"), false, shown);
+});
+
+test("a session with no recorded sign of life gets one", async () => {
+  const now = Date.now();
+
+  // `heartbeatAt` is required by the schema, so an absent one cannot happen
+  // today. The point is that the decision does not rest on how `Date.parse`
+  // treats something that is not a timestamp - it used to, and got the right
+  // answer by accident.
+  assert.equal(needsRefresh(undefined, now), true);
+  assert.equal(needsRefresh("not a date", now), true);
+  assert.equal(needsRefresh(new Date(now - 5_000).toISOString(), now), false);
+  assert.equal(needsRefresh(new Date(now - 120_000).toISOString(), now), true);
 });

--- a/tests/process/heartbeat.test.mjs
+++ b/tests/process/heartbeat.test.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, readdir, realpath, rm, writeFile }
+  from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+const repo = path.resolve(import.meta.dirname, "..", "..");
+const acc = path.join(repo, "bin", "acc.mjs");
+const hook = path.join(repo, "bin", "acc-hook.mjs");
+
+/**
+ * A session that is working, and looks dead to everyone.
+ *
+ * One of the four clients fires a heartbeat event. The comment beside the
+ * cadence said the others "refresh on every turn instead", and they did not: a
+ * session's `heartbeatAt` was written when it attached and never again. Three
+ * minutes later - a cadence of 60 seconds, stale at three of them - it went
+ * stale and stayed stale however hard it was working.
+ *
+ * Measured, with a peer that had accepted work and was doing it:
+ *
+ *   asker  stale
+ *   doer   stale
+ *   - [request_stalled] port the store - nobody is working on it
+ *   - [request_stalled] port the store - doer is not here to answer
+ *
+ * Every roster showed every peer as stale, so the word stopped meaning
+ * anything, and the one rule that depends on it told a requester the opposite of
+ * the truth.
+ */
+async function workspace(t) {
+  const base = await realpath(await mkdtemp(path.join(tmpdir(), "acc-beat-")));
+  t.after(() => rm(base, { recursive: true, force: true }));
+  const project = path.join(base, "project");
+  await mkdir(project, { recursive: true });
+  const env = { ...process.env, ACC_DATA_HOME: path.join(base, "data"),
+    GIT_DIR: "", GIT_WORK_TREE: "" };
+  const fire = async (participant, payload) => {
+    const child = run(process.execPath, [hook, "codex"],
+      { env: { ...env, ACC_PARTICIPANT: participant } });
+    child.child.stdin.end(JSON.stringify({ session_id: participant, cwd: project, ...payload }));
+    return (await child).stdout;
+  };
+  const attach = participant => fire(participant,
+    { hook_event_name: "SessionStart", source: "startup" });
+  const turn = participant => fire(participant,
+    { hook_event_name: "UserPromptSubmit", prompt: "go" });
+  const write = participant => fire(participant, { hook_event_name: "PreToolUse",
+    tool_name: "apply_patch",
+    tool_input: { command: "*** Begin Patch\n*** Update File: x\n@@\n-a\n+b\n*** End Patch" } });
+  const cli = (...argv) => run(process.execPath, [acc, ...argv, "--cwd", project, "--json"],
+    { env });
+  const presence = async participant => JSON.parse((await cli("status")).stdout).data
+    .participants.find(item => item.participantId === participant)?.presence;
+
+  /** Every session record, aged as if nothing had been heard for this long. */
+  const goQuiet = async minutes => {
+    const stamp = new Date(Date.now() - minutes * 60_000).toISOString();
+    const root = path.join(base, "data", "acc", "workspaces");
+    for (const workspaceId of await readdir(root)) {
+      for (const area of ["state", "ephemeral"]) {
+        const dir = path.join(root, workspaceId, area, "session");
+        for (const name of await readdir(dir).catch(() => [])) {
+          const file = path.join(dir, name);
+          const held = JSON.parse(await readFile(file, "utf8"));
+          const record = held.record ?? held;
+          record.heartbeatAt = stamp;
+          await writeFile(file, `${JSON.stringify(held, null, 2)}\n`);
+        }
+      }
+    }
+  };
+  return { project, env, attach, turn, write, cli, presence, goQuiet };
+}
+
+test("a turn is a sign of life", async t => {
+  const place = await workspace(t);
+  await place.attach("worker");
+  await place.goQuiet(4);
+  assert.equal(await place.presence("worker"), "stale");
+
+  await place.turn("worker");
+
+  assert.equal(await place.presence("worker"), "online",
+    "a session that just took a turn still looked dead to its peers");
+});
+
+test("a long turn is a sign of life too", async t => {
+  const place = await workspace(t);
+  await place.attach("worker");
+  await place.turn("worker");
+  await place.goQuiet(4);
+
+  // Half an hour of tool calls is one turn. A session working that hard should
+  // not go stale in the middle of it.
+  await place.write("worker");
+
+  assert.equal(await place.presence("worker"), "online");
+});
+
+test("guarding a write is still a read when the session was heard from lately", async t => {
+  const place = await workspace(t);
+  await place.attach("worker");
+  await place.turn("worker");
+  const before = await readdir(path.join(place.project, "..", "data", "acc", "workspaces"))
+    .then(([id]) => path.join(place.project, "..", "data", "acc", "workspaces", id))
+    .then(async root => (await readFile(path.join(root, "ephemeral", "session",
+      (await readdir(path.join(root, "ephemeral", "session")))[0]), "utf8")));
+
+  await place.write("worker");
+  await place.write("worker");
+
+  // Written at most twice a cadence, so the common case costs nothing. Two
+  // guarded writes moments apart must not each take the writer lock.
+  const root = await readdir(path.join(place.project, "..", "data", "acc", "workspaces"))
+    .then(([id]) => path.join(place.project, "..", "data", "acc", "workspaces", id));
+  const after = await readFile(path.join(root, "ephemeral", "session",
+    (await readdir(path.join(root, "ephemeral", "session")))[0]), "utf8");
+  assert.equal(after, before, "a heartbeat was written for a session heard from seconds ago");
+});
+
+test("work in progress is not reported as going nowhere", async t => {
+  const place = await workspace(t);
+  await place.attach("asker");
+  await place.attach("doer");
+  const asker = JSON.parse((await place.cli("status")).stdout).data.participants
+    .find(item => item.participantId === "asker").sessionId;
+  await place.cli("request", "--session", asker, "--to", "doer", "--title", "port the store");
+  const doer = JSON.parse((await place.cli("status")).stdout).data.participants
+    .find(item => item.participantId === "doer").sessionId;
+  const { snapshot } = JSON.parse((await place.cli("sync", "--session", asker,
+    "--scope", "full")).stdout).data;
+  await place.cli("task", "--session", doer, "--task", snapshot.tasks[0].taskId, "--take");
+  await place.goQuiet(4);
+
+  await place.turn("doer");
+
+  // The rule reads presence, so a session that looks dead makes it say the
+  // opposite of the truth about work somebody is doing right now.
+  const shown = await place.turn("asker");
+  assert.equal(shown.includes("nobody is working on it"), false, shown);
+});


### PR DESCRIPTION
One of the four clients fires a heartbeat event. The comment beside the cadence said the others *"refresh on every turn instead"* — and they did not. A session's `heartbeatAt` was written when it attached and never again.

Cadence 60s, stale at three of them: **every session on Codex, Claude Code, Gemini and MCP went stale three minutes after starting** and stayed stale however hard it was working.

Measured, against a peer that had accepted work and was doing it:

```
   asker  stale
   doer   stale

   | - [request_stalled] port the store - nobody is working on it
   | - [request_stalled] port the store - doer is not here to answer
   | - asker (codex, stale)
   | - doer (codex, stale)
```

Two consequences, and the second is worse than the first:

- `stale` appeared on every roster against every peer, so the word stopped meaning anything — which is the signal a peer uses to decide whether a claim holder is gone.
- The one rule that reads presence told the requester **the opposite of the truth** about work being done right then.

## The fix is what the comment always claimed

A turn refreshes it. A long turn refreshes it too, from the write guard — half an hour of tool calls is one turn, and a session working that hard should not go stale in the middle of it — but **only when the last sign of life is older than half the cadence**, so guarding a write stays a read in the ordinary case. That is its own test: two guarded writes moments apart must not each take the writer lock.

Both writes fail open. They run in front of somebody's prompt.

## Verification

- 786 tests passing, 0 failing · `syntax ok in 168 file(s)`
- 3 of the 4 new tests fail on `main`; the fourth is the cost ceiling the fix must not cross
- `PASS … sha256 e6ef015c…94a320e built from 75e5102`
