### PR TITLE
fix: a cursor that is not a cursor is refused, not answered with silence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `4dd9548` |
+| Built from | `229bbe8` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `c183218ad4bdecd9cf20e45c36e0710271493277bb793727e23b99a399cf5a61` |
-| Tests | 787 passing, 0 failing |
+| sha256 | `ecfbcf9dd1491a934c03a64f9d825a860600e261a160130e35906b6447b0af98` |
+| Tests | 795 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -62,6 +62,10 @@ fact: you asked, and there is nobody there.
 Every line of an injected turn can be acted on. An attention line carries the id
 of the thing it is about — the same id the command that answers it takes — and a
 turn the byte budget truncated says how to read what it withheld.
+
+A cursor that is not a cursor is refused. It used to answer "nothing new" every
+time, for as long as it was held, so a corrupt one looked exactly like a quiet
+workspace.
 
 A session that is working looks alive. Only one of the four clients fires a
 heartbeat event, so every other session went stale three minutes after starting

--- a/packages/core/src/sync.mjs
+++ b/packages/core/src/sync.mjs
@@ -1,7 +1,23 @@
+import { AccError, EXIT } from "@agents-can-communicate/protocol";
+
 import { classifySessionPresence } from "./sessions.mjs";
 import { overlaps } from "./claims.mjs";
 
 const DEFAULT_LIMIT = 100;
+
+// The shape every event carries, and the only thing a caller may ask to resume
+// from. `null` means the beginning, which is what a session with no cursor yet
+// has.
+const CURSOR = /^[0-9]{16}$/;
+
+function assertCursor(cursor) {
+  if (typeof cursor !== "string" || !CURSOR.test(cursor)) {
+    throw new AccError(EXIT.USAGE,
+      "a cursor is the 16-digit sequence a previous sync returned; "
+      + "leave it out to start from the beginning",
+      { cursor });
+  }
+}
 
 // Attention is computed from explicit rules, never from a hidden classifier.
 // Lower priority sorts first.
@@ -183,6 +199,13 @@ export function createSyncService(ports, sessions) {
    * view because of its role. The bounded delta is only the ambient default.
    */
   async function sync(input = {}) {
+    // A cursor that is not a cursor answered "nothing new", every time, for as
+    // long as it was held. `eventsSince` compares sequences as strings, so
+    // `not-a-cursor` sorts after every event there has ever been - and an
+    // adapter holding a corrupt one, or an agent that invented one, saw a quiet
+    // workspace rather than a mistake. `"0000000000000001; DROP"` was quietly
+    // taken as the sequence it starts with.
+    if (input.cursor != null) assertCursor(input.cursor);
     const workspaceId = input.workspaceId ?? store.workspaceId;
     const now = clock.now();
     const located = input.sessionId === undefined

--- a/tests/process/cursor.test.mjs
+++ b/tests/process/cursor.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import { EXIT } from "@agents-can-communicate/protocol";
+
+const run = promisify(execFile);
+const repo = path.resolve(import.meta.dirname, "..", "..");
+const acc = path.join(repo, "bin", "acc.mjs");
+const hook = path.join(repo, "bin", "acc-hook.mjs");
+
+/**
+ * A cursor that is not a cursor.
+ *
+ * `eventsSince` compares sequences as strings, so anything sorting after
+ * `9999999999999999` means "nothing has happened since". `not-a-cursor` does,
+ * and answered "nothing new" every time it was passed - for as long as it was
+ * held. An adapter with a corrupt stored cursor, or an agent that invented one,
+ * saw a quiet workspace rather than a mistake.
+ *
+ * `"0000000000000001; DROP"` was quietly taken as the sequence it starts with,
+ * which is the other half of the same silence: input nobody checked, answered
+ * with something plausible.
+ */
+async function workspace(t) {
+  const base = await realpath(await mkdtemp(path.join(tmpdir(), "acc-cursor-")));
+  t.after(() => rm(base, { recursive: true, force: true }));
+  const project = path.join(base, "project");
+  await mkdir(project, { recursive: true });
+  const env = { ...process.env, ACC_DATA_HOME: path.join(base, "data"),
+    GIT_DIR: "", GIT_WORK_TREE: "" };
+  const child = run(process.execPath, [hook, "codex"],
+    { env: { ...env, ACC_PARTICIPANT: "worker" } });
+  child.child.stdin.end(JSON.stringify({ hook_event_name: "SessionStart",
+    session_id: "worker", cwd: project, source: "startup" }));
+  await child;
+  const cli = (...argv) => run(process.execPath, [acc, ...argv, "--cwd", project, "--json"],
+    { env });
+  await cli("claim", "--resource", "file:x", "--reason", "editing");
+  const session = JSON.parse((await cli("status")).stdout).data.participants[0].sessionId;
+  const syncFrom = cursor => cli("sync", "--session", session,
+    ...(cursor === undefined ? [] : ["--cursor", cursor]));
+  return { project, env, cli, session, syncFrom };
+}
+
+for (const cursor of ["not-a-cursor", "-1", "0000000000000001; DROP", "1", "00000000000000001"]) {
+  test(`a cursor of ${JSON.stringify(cursor)} is refused, not answered with silence`, async t => {
+    const place = await workspace(t);
+
+    const refused = await place.syncFrom(cursor).then(() => null, error => error);
+
+    assert.notEqual(refused, null, `${cursor} was accepted and reported an empty workspace`);
+    assert.equal(refused.code, EXIT.USAGE);
+    assert.match(JSON.parse(refused.stdout).error.message, /16-digit sequence/);
+  });
+}
+
+test("the cursor a sync returns is one it will take back", async t => {
+  const place = await workspace(t);
+  const { cursor } = JSON.parse((await place.syncFrom()).stdout).data;
+
+  const { stdout } = await place.syncFrom(cursor);
+
+  // The round trip is the whole contract: whatever `sync` hands out has to be
+  // accepted, or the validation would break the callers it exists to protect.
+  assert.equal(JSON.parse(stdout).ok, true);
+  assert.deepEqual(JSON.parse(stdout).data.events, []);
+});
+
+test("no cursor means from the beginning", async t => {
+  const place = await workspace(t);
+
+  const { stdout } = await place.syncFrom();
+
+  assert.equal(JSON.parse(stdout).data.events.length > 0, true);
+});
+
+test("a turn still works, because that is where cursors actually come from", async t => {
+  const place = await workspace(t);
+  const child = run(process.execPath, [hook, "codex"],
+    { env: { ...place.env, ACC_PARTICIPANT: "worker" } });
+  child.child.stdin.end(JSON.stringify({ hook_event_name: "UserPromptSubmit",
+    session_id: "worker", cwd: place.project, prompt: "go" }));
+
+  await child;
+});


### PR DESCRIPTION
`eventsSince` compares sequences as strings, so anything sorting after `9999999999999999` means *"nothing has happened since"*. `not-a-cursor` does:

```
cursor '0000000000000001'       -> ok | events: 2
cursor '9999999999999999'       -> ok | events: 0
cursor 'not-a-cursor'           -> ok | events: 0     ← silence, forever
cursor '-1'                     -> ok | events: 3     ← read as before the beginning
cursor '0000000000000001; DROP' -> ok | events: 2     ← taken as the sequence it starts with
```

An adapter holding a corrupt stored cursor, or an agent that invented one, saw a **quiet workspace** rather than a mistake — and would go on seeing one for as long as it held that cursor.

## The shape was already defined

`sequence` in the protocol validates exactly this on every event record. The one place a cursor arrives from *outside* was the one place nothing checked it. Validated in `sync`, so every surface gets it at once; `null` still means from the beginning, which is what a session with no cursor yet has.

## The round trip is its own test

Whatever `sync` hands out has to be accepted again — otherwise this breaks the callers it exists to protect. So is a turn, since a stored cursor is where real cursors actually come from.

## Verification

- 795 tests passing, 0 failing · `syntax ok in 169 file(s)`
- 5 of the 8 new tests fail on `main`; the other three are the contract the fix must not break
- `PASS … sha256 ecfbcf9d…7b0af98 built from 229bbe8`
