### PR TITLE
fix: an unknown sync scope is refused rather than turned into a delta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ release.
 
 | | |
 |---|---|
-| Built from | `229bbe8` |
+| Built from | `b5750dc` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `ecfbcf9dd1491a934c03a64f9d825a860600e261a160130e35906b6447b0af98` |
-| Tests | 795 passing, 0 failing |
+| sha256 | `8cf52b89586a403374a8ff14d675a7ffebaede4d0687bfc2118ee9ba3ccd717a` |
+| Tests | 800 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |
@@ -62,6 +62,10 @@ fact: you asked, and there is nobody there.
 Every line of an injected turn can be acted on. An attention line carries the id
 of the thing it is about — the same id the command that answers it takes — and a
 turn the byte budget truncated says how to read what it withheld.
+
+A cursor that is not a cursor is refused, and so is a scope that is not a scope —
+`--scope ful` used to answer the one question the full scope exists for with a
+delta carrying no snapshot.
 
 A cursor that is not a cursor is refused. It used to answer "nothing new" every
 time, for as long as it was held, so a corrupt one looked exactly like a quiet

--- a/packages/core/src/sync.mjs
+++ b/packages/core/src/sync.mjs
@@ -10,6 +10,19 @@ const DEFAULT_LIMIT = 100;
 // has.
 const CURSOR = /^[0-9]{16}$/;
 
+// The two a caller may ask for. An unknown one used to become `delta`, so
+// `--scope ful` answered the one question the full scope exists for - "show me
+// everything, I cannot see the rest of the system" - with a delta carrying no
+// snapshot at all, and the agent concluded there was nothing to see.
+const SCOPES = Object.freeze(["delta", "full"]);
+
+function assertScope(scope) {
+  if (scope != null && !SCOPES.includes(scope)) {
+    throw new AccError(EXIT.USAGE,
+      `scope is one of ${SCOPES.join(", ")}; leave it out for ${SCOPES[0]}`, { scope });
+  }
+}
+
 function assertCursor(cursor) {
   if (typeof cursor !== "string" || !CURSOR.test(cursor)) {
     throw new AccError(EXIT.USAGE,
@@ -206,6 +219,7 @@ export function createSyncService(ports, sessions) {
     // workspace rather than a mistake. `"0000000000000001; DROP"` was quietly
     // taken as the sequence it starts with.
     if (input.cursor != null) assertCursor(input.cursor);
+    assertScope(input.scope);
     const workspaceId = input.workspaceId ?? store.workspaceId;
     const now = clock.now();
     const located = input.sessionId === undefined

--- a/tests/process/cursor.test.mjs
+++ b/tests/process/cursor.test.mjs
@@ -44,7 +44,9 @@ async function workspace(t) {
   const session = JSON.parse((await cli("status")).stdout).data.participants[0].sessionId;
   const syncFrom = cursor => cli("sync", "--session", session,
     ...(cursor === undefined ? [] : ["--cursor", cursor]));
-  return { project, env, cli, session, syncFrom };
+  const syncScope = scope => cli("sync", "--session", session,
+    ...(scope === undefined ? [] : ["--scope", scope]));
+  return { project, env, cli, session, syncFrom, syncScope };
 }
 
 for (const cursor of ["not-a-cursor", "-1", "0000000000000001; DROP", "1", "00000000000000001"]) {
@@ -87,4 +89,36 @@ test("a turn still works, because that is where cursors actually come from", asy
     session_id: "worker", cwd: place.project, prompt: "go" }));
 
   await child;
+});
+
+/**
+ * The scope that answers "show me everything".
+ *
+ * An unknown one became `delta`. So `--scope ful` answered the one question the
+ * full scope exists for - a session that cannot see the rest of the system - with
+ * a delta carrying no snapshot at all, and the agent had no way to tell that from
+ * a workspace with nothing in it.
+ */
+for (const scope of ["ful", "FULL", "nonsense", ""]) {
+  test(`a scope of ${JSON.stringify(scope)} is refused, not turned into a delta`, async t => {
+    const place = await workspace(t);
+
+    const refused = await place.syncScope(scope).then(() => null, error => error);
+
+    assert.notEqual(refused, null, `${scope} was quietly answered with a delta`);
+    assert.match(JSON.parse(refused.stdout ?? "{}").error?.message ?? refused.stderr,
+      /scope is one of|requires a value/);
+  });
+}
+
+test("the two scopes that exist still work, and one is the default", async t => {
+  const place = await workspace(t);
+
+  const full = JSON.parse((await place.syncScope("full")).stdout).data;
+  const delta = JSON.parse((await place.syncScope("delta")).stdout).data;
+  const plain = JSON.parse((await place.syncScope()).stdout).data;
+
+  assert.equal("snapshot" in full, true, "the full scope carried no snapshot");
+  assert.equal("snapshot" in delta, false);
+  assert.equal(plain.scope, "delta");
 });


### PR DESCRIPTION
```js
scope: input.scope === "full" ? "full" : "delta"
```

Anything that is not exactly `"full"` became a delta:

```
--scope full      -> scope=full   snapshot=yes
--scope delta     -> scope=delta  snapshot=NO
--scope ful       -> scope=delta  snapshot=NO
--scope FULL      -> scope=delta  snapshot=NO
--scope nonsense  -> scope=delta  snapshot=NO
```

So `--scope ful` answered the one question the full scope exists for — the protocol calls it *"the full scope exists so no session ever has to say it cannot see the rest of the system"* — with a delta carrying no snapshot at all. Nothing in that answer distinguishes it from a workspace with nothing in it.

The MCP tool declares the two as an enum, so its clients were already protected. The CLI was not, and the check belongs in the core where both arrive.

Leaving it out still means a delta: that is the ambient default the protocol describes, and it is a different thing from asking for something that does not exist.

## Verification

- 800 tests passing, 0 failing · `syntax ok in 169 file(s)`
- 3 of the new tests fail on `main`; the fourth (`--scope ""`) was already refused by the parser, and the fifth pins that both real scopes still work and which one is the default
- `PASS … sha256 8cf52b89…cd717a built from b5750dc`
