### PR TITLE
docs: correct three README claims and say where state actually lives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ release.
 
 | | |
 |---|---|
-| Built from | `b5750dc` |
+| Built from | `2359027` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `8cf52b89586a403374a8ff14d675a7ffebaede4d0687bfc2118ee9ba3ccd717a` |
+| sha256 | `626ff0b987d70afc374bd16dd632c9371a46a9d7a5e59dd3000feab2df941d5b` |
 | Tests | 800 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |

--- a/README.md
+++ b/README.md
@@ -121,7 +121,12 @@ Every operation is in the [CLI reference](docs/CLI.md) if you want to drive it y
 - `protection guarded` applies while every session present is one ACC can stop. One that
   cannot changes it to `advisory`.
 - Codex requires you to trust the plugin before its hooks run. `acc doctor` reports this.
-- Windows fails 86 of 587 tests. macOS and Linux are supported.
+- Nothing is pruned yet. A workspace that has carried thousands of messages makes each turn
+  slower to build; a project's worth of coordination is fine, an archive is not.
+- Windows does not work: the store fsyncs a directory after a rename, which Windows
+  refuses, and `O_NOFOLLOW` does not hold there. Last measured at 86 failures out of 587
+  tests; the suite has grown a good deal since and nobody has run it there again. macOS and
+  Linux are supported and both run in CI.
 
 ## How it works
 
@@ -134,11 +139,21 @@ graph LR
   H --> C
 ```
 
-Clients call out at three moments: a session starts, a tool is about to run, a turn begins.
-ACC answers at those and is idle otherwise. A hook that does not answer within five seconds
-lets the tool run.
+Clients call out when a session starts and ends, when a turn begins, and before a tool
+runs — plus a heartbeat, on the one client that sends them. ACC answers at those and is
+idle otherwise. A hook that does not answer within five seconds lets the tool run, so ACC
+can be slow or broken without stopping anyone's work.
 
-State lives beside your other tool settings, never inside the repository.
+State lives beside your other tool settings, never inside the repository:
+
+```text
+~/Library/Application Support/acc     macOS
+~/.local/share/acc                    Linux
+```
+
+Inside it, one directory per workspace — keyed by the repository rather than the folder, so
+every worktree of it is one workspace and two unrelated projects share nothing. Deleting a
+workspace directory loses that project's coordination history and nothing else.
 
 ## Documentation
 

--- a/tests/acceptance/recorded-candidate.test.mjs
+++ b/tests/acceptance/recorded-candidate.test.mjs
@@ -50,8 +50,15 @@ test("the changelog's digest describes the code that is here now", async () => {
     return;
   }
 
-  const changed = (await git("diff", "--name-only", `${recorded}..HEAD`, "--", ...PACKED))
-    .split("\n").filter(Boolean);
+  // Commits, and the working tree beside them. Comparing only commits meant
+  // `npm test` passed on an edited README and the pre-push hook caught it a
+  // moment later - the right answer at the wrong time, when the fix is a
+  // re-record and the commit is already made.
+  const changed = [...new Set([
+    ...(await git("diff", "--name-only", `${recorded}..HEAD`, "--", ...PACKED)).split("\n"),
+    ...(await git("status", "--porcelain", "--", ...PACKED))
+      .split("\n").map(line => line.slice(3)),
+  ])].filter(Boolean).sort();
 
   assert.deepEqual(changed, [],
     `shipped code changed since ${recorded}, so the recorded digest describes nothing `


### PR DESCRIPTION
Read as a newcomer would, and checked each claim by running it.

| claim | was | now |
|---|---|---|
| how often it runs | *"Clients call out at three moments"* | there are five, and one of the two it omitted is **a session ending** — which somebody deciding whether to let this near their clients wants to know about |
| Windows | *"fails 86 of 587 tests"* | reads as a current measurement; the suite is 800 now and nobody has run it there since. Says why it does not work, and that the count is old |
| what state is | *"beside your other tool settings"* | says **where**, with both paths and the layout |

Added one limit a user meets by using the thing rather than by doing something wrong: nothing is pruned, so a workspace that has carried thousands of messages makes each turn slower to build.

Verified rather than assumed — the README's own example still reproduces exactly:

```
   2 live; 1 claim(s); protection guarded
```

## The gate caught this, one moment late

The pre-push hook refused the push, correctly: `README.md` is packed, so editing it invalidates the recorded digest. But `npm test` had passed on the same tree — the check compared **commits**, and the edit was not committed yet. So it spoke after the commit was made, when the remedy is a re-record.

It reads `git status` for the packed paths too now, and says so before the commit rather than after.

## Not changed here

The install section still says the package is not published, because it is not. That line changes with the release, not before it.

## Verification

- 800 tests passing, 0 failing · `syntax ok in 169 file(s)`
- `PASS … sha256 626ff0b9…941d5b built from 2359027`
