### PR TITLE
release: 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 # Changelog
 
-## 0.0.0 — release candidate (unpublished)
+## 0.1.0 — first release
 
-Built and verified locally. **Not published**: no npm release, no tag, no GitHub
-release.
+Published to npm. `0.x` because the surfaces are young: several of them changed
+in the week before this, and a version that promised otherwise would be the first
+thing in here that was not measured.
 
 | | |
 |---|---|
 | Built from | `2359027` |
-| Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
+| Tarball | `agents-can-communicate-0.1.0.tgz`, 109 KB, 103 entries |
 | sha256 | `626ff0b987d70afc374bd16dd632c9371a46a9d7a5e59dd3000feab2df941d5b` |
 | Tests | 800 passing, 0 failing |
 | Node | 24 (current production LTS) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ release.
 
 | | |
 |---|---|
-| Built from | `b5750dc` |
+| Built from | `2359027` |
 | Tarball | `agents-can-communicate-0.0.0.tgz`, 109 KB, 103 entries |
-| sha256 | `8cf52b89586a403374a8ff14d675a7ffebaede4d0687bfc2118ee9ba3ccd717a` |
+| sha256 | `626ff0b987d70afc374bd16dd632c9371a46a9d7a5e59dd3000feab2df941d5b` |
 | Tests | 800 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ thing in here that was not measured.
 
 | | |
 |---|---|
-| Built from | `e861a20` |
-| Tarball | `agents-can-communicate-0.1.0.tgz`, 121 KB, 104 entries |
-| sha256 | `d43d2bf323f1efe110a9069101a228d729e4cd10e5c83a87a9be8389e9635e27` |
-| Tests | 800 passing, 0 failing |
+| Built from | `c318458` |
+| Tarball | `agents-can-communicate-0.1.0.tgz`, 123 KB, 105 entries |
+| sha256 | `e4ed773feb25dd40a0fb5d2bb010f66261613a3cac14882750b431f3ab2a3480` |
+| Tests | 808 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ thing in here that was not measured.
 
 | | |
 |---|---|
-| Built from | `2359027` |
-| Tarball | `agents-can-communicate-0.1.0.tgz`, 109 KB, 103 entries |
-| sha256 | `626ff0b987d70afc374bd16dd632c9371a46a9d7a5e59dd3000feab2df941d5b` |
+| Built from | `e861a20` |
+| Tarball | `agents-can-communicate-0.1.0.tgz`, 121 KB, 104 entries |
+| sha256 | `d43d2bf323f1efe110a9069101a228d729e4cd10e5c83a87a9be8389e9635e27` |
 | Tests | 800 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ What is left for a person is the install and looking in on it:
 
 | | |
 |---|---|
+| `acc help` | every command, one line each |
 | `acc status` | who is here, what is claimed, what is in flight |
 | `acc doctor` | what is installed, what is missing, what to do next |
 | `acc install` · `acc uninstall` | wire clients up, or take it back out |

--- a/README.md
+++ b/README.md
@@ -69,10 +69,8 @@ $ acc status
 
 ## Install
 
-Not published yet, so build it from a clone:
-
 ```bash
-npm ci && npm pack && npm install -g ./agents-can-communicate-*.tgz
+npm install -g agents-can-communicate
 ```
 
 Then wire up the clients you have:

--- a/README.md
+++ b/README.md
@@ -121,7 +121,12 @@ Every operation is in the [CLI reference](docs/CLI.md) if you want to drive it y
 - `protection guarded` applies while every session present is one ACC can stop. One that
   cannot changes it to `advisory`.
 - Codex requires you to trust the plugin before its hooks run. `acc doctor` reports this.
-- Windows fails 86 of 587 tests. macOS and Linux are supported.
+- Nothing is pruned yet. A workspace that has carried thousands of messages makes each turn
+  slower to build; a project's worth of coordination is fine, an archive is not.
+- Windows does not work: the store fsyncs a directory after a rename, which Windows
+  refuses, and `O_NOFOLLOW` does not hold there. Last measured at 86 failures out of 587
+  tests; the suite has grown a good deal since and nobody has run it there again. macOS and
+  Linux are supported and both run in CI.
 
 ## How it works
 
@@ -134,11 +139,21 @@ graph LR
   H --> C
 ```
 
-Clients call out at three moments: a session starts, a tool is about to run, a turn begins.
-ACC answers at those and is idle otherwise. A hook that does not answer within five seconds
-lets the tool run.
+Clients call out when a session starts and ends, when a turn begins, and before a tool
+runs — plus a heartbeat, on the one client that sends them. ACC answers at those and is
+idle otherwise. A hook that does not answer within five seconds lets the tool run, so ACC
+can be slow or broken without stopping anyone's work.
 
-State lives beside your other tool settings, never inside the repository.
+State lives beside your other tool settings, never inside the repository:
+
+```text
+~/Library/Application Support/acc     macOS
+~/.local/share/acc                    Linux
+```
+
+Inside it, one directory per workspace — keyed by the repository rather than the folder, so
+every worktree of it is one workspace and two unrelated projects share nothing. Deleting a
+workspace directory loses that project's coordination history and nothing else.
 
 ## Documentation
 

--- a/bin/acc.mjs
+++ b/bin/acc.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { randomBytes } from "node:crypto";
+import { readFile } from "node:fs/promises";
 
 import { createId } from "@agents-can-communicate/protocol";
 import { main } from "@agents-can-communicate/cli";
@@ -14,6 +15,10 @@ const runtime = {
   stderr: process.stderr,
   clock: { now: () => new Date().toISOString() },
   ids: { next: kind => createId(kind, randomBytes) },
+  // Asked for only by `acc version`, so a package missing its own manifest
+  // fails that one command rather than every command.
+  version: async () => JSON.parse(
+    await readFile(new URL("../package.json", import.meta.url), "utf8")).version,
 };
 
 process.exitCode = await main(process.argv.slice(2), runtime);

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -2,6 +2,15 @@
 
 Every command takes `--json` for machine output and `--cwd` to pick the workspace.
 
+`acc help` prints this list in short form, and `acc version` prints what is installed.
+Both work anywhere, including a directory that is no workspace at all.
+
+<!-- test:command -->
+```bash
+acc help
+acc version
+```
+
 ```mermaid
 graph LR
   subgraph You
@@ -48,6 +57,13 @@ graph LR
 ## Adapters only
 
 `acc attach`, `acc heartbeat`, `acc detach` — driven by hooks, not by people.
+
+## About acc
+
+| Command | Does |
+|---|---|
+| `acc help` | Every command with one line each. `--help` and `-h` mean the same |
+| `acc version` | The installed version, read from the package. `--version` and `-v` too |
 
 ## Exit codes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -102,51 +102,51 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.0.0"
+      "version": "0.1.0"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.0.0"
+      "version": "0.1.0"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.0.0"
+      "version": "0.1.0"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.0.0"
+      "version": "0.1.0"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.0.0"
+      "version": "0.1.0"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.0.0"
+      "version": "0.1.0"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.0.0"
+      "version": "0.1.0"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.0.0"
+      "version": "0.1.0"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.0.0"
+      "version": "0.1.0"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.0.0"
+      "version": "0.1.0"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.0.0"
+      "version": "0.1.0"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.0.0"
+      "version": "0.1.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "description": "Model- and harness-agnostic coordination for independent AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-claude-code/plugin/.claude-plugin/plugin.json
+++ b/packages/adapter-claude-code/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Coordinate this Claude Code session with other AI agent sessions working in the same workspace: shared presence, resource claims, typed messages, and handoffs."
 }

--- a/packages/adapter-claude-code/test/adapter.test.mjs
+++ b/packages/adapter-claude-code/test/adapter.test.mjs
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { CLAUDE_PLUGIN, pluginVersion } from "../../../tests/helpers/plugin-version.mjs";
+
 import { EXIT } from "@agents-can-communicate/protocol";
 
 import { createClaudeCodeAdapter } from "../src/adapter.mjs";
@@ -46,7 +48,7 @@ test("install registers the plugin and preserves the user's own hook", async t =
     "marketplaces", "acc-local", "agents-can-communicate")),
   [".claude-plugin", "hooks", "skills"].sort());
   assert.deepEqual(await readdir(path.join(context.configDir, "plugins", "cache",
-    "acc-local", "agents-can-communicate", "0.0.0")),
+    "acc-local", "agents-can-communicate", await pluginVersion(CLAUDE_PLUGIN))),
   [".claude-plugin", "hooks", "skills"].sort());
 
   // Registered the way the client registers plugins, measured from its own

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/plugin/.codex-plugin/plugin.json
+++ b/packages/adapter-codex/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Coordinate this Codex session with other AI agent sessions working in the same workspace.",
   "license": "UNLICENSED",
   "keywords": ["coordination", "multi-agent", "claims", "handoff"],

--- a/packages/adapter-codex/test/install.test.mjs
+++ b/packages/adapter-codex/test/install.test.mjs
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { CODEX_PLUGIN, pluginVersion } from "../../../tests/helpers/plugin-version.mjs";
+
 import { EXIT } from "@agents-can-communicate/protocol";
 
 import { createCodexAdapter } from "../src/adapter.mjs";
@@ -332,7 +334,7 @@ test("detect reports the plugin as installed once the client has cached it", asy
 
   // What `codex plugin add` leaves behind.
   await mkdir(path.join(context.codexHome, "plugins", "cache", "acc-local",
-    "agents-can-communicate", "0.0.0"), { recursive: true });
+    "agents-can-communicate", await pluginVersion(CODEX_PLUGIN)), { recursive: true });
 
   assert.match((await adapter.detect(context)).diagnostics.join(" "),
     /plugin installed in the client's cache/);
@@ -366,7 +368,7 @@ test("install finishes the job the client's own command would have done", async 
   // the command, and by running a real session against a cache ACC wrote:
   // all five hooks fired.
   const cached = path.join(context.codexHome, "plugins", "cache", "acc-local",
-    "agents-can-communicate", "0.0.0");
+    "agents-can-communicate", await pluginVersion(CODEX_PLUGIN));
   assert.deepEqual((await readdir(cached)).sort(),
     [".codex-plugin", "acc-hook.sh", "hooks.json", "skills"].sort());
 });
@@ -380,7 +382,8 @@ test("the cached copy carries the same absolute hook command", async t => {
   // to the bundle would not survive the copy; an absolute one does, which is
   // the whole reason the shim is written with absolute paths.
   const cached = JSON.parse(await readFile(path.join(context.codexHome, "plugins",
-    "cache", "acc-local", "agents-can-communicate", "0.0.0", "hooks.json"), "utf8"));
+    "cache", "acc-local", "agents-can-communicate", await pluginVersion(CODEX_PLUGIN),
+  "hooks.json"), "utf8"));
   const command = Object.values(cached.hooks)[0][0].hooks[0].command;
   const executable = command.match(/"([^"]+)"/)[1];
   assert.equal(path.isAbsolute(executable), true, `relative command: ${command}`);

--- a/packages/adapter-gemini-cli/extension/gemini-extension.json
+++ b/packages/adapter-gemini-cli/extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Coordinate this Gemini CLI session with other AI agent sessions working in the same workspace.",
   "contextFileName": "skills/acc/SKILL.md"
 }

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/plugin/.kimi-plugin/plugin.json
+++ b/packages/adapter-kimi/plugin/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Coordinate this Kimi Code session with other AI agent sessions working in the same workspace: shared presence, resource claims, typed messages, and handoffs.",
   "skills": "./skills/",
   "sessionStart": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/src/args.mjs
+++ b/packages/cli/src/args.mjs
@@ -58,7 +58,19 @@ export const COMMANDS = Object.freeze({
     subcommands: ["init", "validate"] },
   install: { required: [], optional: ["adapter", "home"], flags: ["dry-run", "yes"] },
   uninstall: { required: [], optional: ["adapter", "home"], flags: ["yes"] },
+  // The two things a person types first after installing from a registry. The
+  // CLI answered neither: `acc --version` and `acc --help` were both "unknown
+  // command", and `acc` on its own asked for a command without naming one.
+  help: { required: [], optional: [] },
+  version: { required: [], optional: [] },
 });
+
+// Spelled as the commands they mean, and only in first position. A message body
+// legitimately begins with "--" - exchanging diffs is the point of this tool -
+// so reading them anywhere in the argv would make `acc message --body "--help"`
+// print the help instead of sending it.
+const ALIASES = Object.freeze({ "--help": "help", "-h": "help",
+  "--version": "version", "-v": "version", "-V": "version" });
 
 const GLOBAL = Object.freeze(["json", "workspace", "cwd"]);
 
@@ -69,10 +81,15 @@ function usage(message, details = {}) {
 const camel = name => name.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
 
 export function parseArgs(argv) {
-  if (!Array.isArray(argv) || argv.length === 0) usage("a command is required");
-  const [command, ...rest] = argv;
+  if (!Array.isArray(argv) || argv.length === 0) {
+    usage("a command is required - `acc help` lists them");
+  }
+  const [first, ...rest] = argv;
+  const command = ALIASES[first] ?? first;
   const spec = COMMANDS[command];
-  if (spec === undefined) usage(`unknown command: ${command}`, { command });
+  if (spec === undefined) {
+    usage(`unknown command: ${command} - \`acc help\` lists them`, { command });
+  }
 
   let tokens = rest;
   let subcommand;

--- a/packages/cli/src/help.mjs
+++ b/packages/cli/src/help.mjs
@@ -1,0 +1,78 @@
+import { COMMANDS } from "./args.mjs";
+
+/**
+ * What `acc` says to a person who has just installed it.
+ *
+ * The list of commands is read from the command table, so a command that exists
+ * is always listed. Only the heading a command sits under and its one line are
+ * written here, and the tests prove both cover every command in the table.
+ *
+ * The required options are deliberately not repeated: the parser already
+ * answers `acc claim` with "claim requires --resource", which is the same
+ * answer at the moment it is actually needed.
+ */
+const GROUPS = Object.freeze([
+  ["Set up", ["install", "uninstall", "doctor", "config"]],
+  ["In a session", ["status", "sync", "work", "claim", "release", "ack", "message",
+    "request", "task", "workstream", "decide", "finish"]],
+  ["Driven by adapters, not by people", ["attach", "heartbeat", "detach"]],
+  ["About acc", ["help", "version"]],
+]);
+
+const SUMMARY = Object.freeze({
+  install: "install adapters for the clients on this machine",
+  uninstall: "remove what acc wrote, keep what you edited",
+  doctor: "clients, versions, install health, and what to run next",
+  config: "write or check acc.workspace.json (init | validate)",
+  status: "who else is here, what they hold, how protected this workspace is",
+  sync: "what has happened since a cursor; silent while you are alone",
+  work: "publish what this session is doing, or --clear when it has stopped",
+  claim: "reserve a resource; exit 5 when someone else already holds it",
+  release: "give a claim back",
+  ack: "answer a message that asked for one, so it stops asking",
+  message: "send a typed message to named participants",
+  request: "ask another agent to do something: the work and the why, in one call",
+  task: "create work, --take it, or move its --state along",
+  workstream: "group related work, and steer it with --take / --release",
+  decide: "record what was settled, so the next session does not reopen it",
+  finish: "write the handoff and release what this session held",
+  attach: "open a session; an adapter calls this, not a person",
+  heartbeat: "say the session is still alive",
+  detach: "close a session",
+  help: "this list",
+  version: "print the version that is installed",
+});
+
+/** The same list `acc help --json` returns, so a tool can read it too. */
+export function describeCommands() {
+  return GROUPS.map(([heading, names]) => ({
+    heading,
+    commands: names.map(name => ({
+      name,
+      summary: SUMMARY[name],
+      required: COMMANDS[name].required ?? [],
+      subcommands: COMMANDS[name].subcommands ?? [],
+    })),
+  }));
+}
+
+const DOCS = "https://github.com/automatis-tools/agents-can-communicate"
+  + "/blob/main/docs/CLI.md";
+
+export function helpText() {
+  const width = Math.max(...Object.keys(COMMANDS).map(name => name.length)) + 4;
+  const lines = ["acc - several agents in one workspace, none of them in charge", ""];
+  for (const { heading, commands } of describeCommands()) {
+    lines.push(heading);
+    for (const { name, summary } of commands) {
+      lines.push(`  ${`acc ${name}`.padEnd(width)}  ${summary}`);
+    }
+    lines.push("");
+  }
+  // A URL rather than a path: only `docs/CAPABILITIES.md` is packed, so a
+  // reference to `docs/CLI.md` would name a file the installed package does not
+  // have. The test alongside holds this to the repository the manifest names.
+  lines.push("Every command takes --json for machine output and --cwd to choose the workspace.",
+    `Full reference: ${DOCS}`);
+  return lines.join("\n");
+}

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -8,6 +8,7 @@ import { parseArgs, positiveNumber } from "./args.mjs";
 // A usage error names what is missing rather than failing deeper in a service
 // with the argument already half-applied.
 const usage = message => new AccError(EXIT.USAGE, message);
+import { describeCommands, helpText } from "./help.mjs";
 import { runConfigCommand } from "./config-command.mjs";
 import { runInstallCommand } from "./install-command.mjs";
 import { runDoctor } from "./doctor-command.mjs";
@@ -273,11 +274,28 @@ const HANDLERS = Object.freeze({
     runInstallCommand({ options, runtime, action: "uninstall" }),
 
   doctor: async ({ options, context, runtime }) => runDoctor({ options, context, runtime }),
+
+  help: async () => ({ data: { commands: describeCommands() }, text: helpText() }),
+
+  version: async ({ runtime }) => {
+    // Read by the composition root from the package manifest: `bin/` sits at
+    // the same depth in the published package as it does in this tree, which is
+    // not true of anything under `packages/`. A version typed into the source
+    // would be one more place the next bump has to reach, and the kind that
+    // goes stale without failing.
+    if (typeof runtime.version !== "function") {
+      throw new AccError(EXIT.DATA, "this build was assembled without a version to report");
+    }
+    const version = await runtime.version();
+    return { data: { version }, text: version };
+  },
 });
 
 /**
  * @returns {Promise<number>} the process exit code
  */
+const NO_WORKSPACE = Object.freeze(["config", "install", "uninstall", "help", "version"]);
+
 export async function main(argv, runtime) {
   const write = (stream, text) => new Promise((resolve, reject) =>
     stream.write(text, error => (error ? reject(error) : resolve())));
@@ -288,10 +306,11 @@ export async function main(argv, runtime) {
     // open. Discovery validates the config too, so a broken one would fail
     // there first and `acc config validate` - the command a user runs to find
     // out what is wrong - would never reach its own report.
-    // These three work on a machine, not a workspace. `config` must run even
-    // when discovery cannot open the workspace - that is what a user is trying
-    // to find out - and install touches client configuration, not ACC state.
-    const context = ["config", "install", "uninstall"].includes(parsed.command)
+    // These work on a machine, not a workspace. `config` must run even when
+    // discovery cannot open the workspace - that is what a user is trying to
+    // find out - install touches client configuration rather than ACC state,
+    // and `help` has to answer in a directory that is no workspace at all.
+    const context = NO_WORKSPACE.includes(parsed.command)
       ? null
       : await openContext(parsed.options, runtime);
     // Which session is calling is answered once, here, rather than by each

--- a/packages/cli/test/help.test.mjs
+++ b/packages/cli/test/help.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { EXIT } from "@agents-can-communicate/protocol";
+
+import { COMMANDS, parseArgs } from "../src/args.mjs";
+import { describeCommands, helpText } from "../src/help.mjs";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const binary = path.join(repoRoot, "bin", "acc.mjs");
+
+/**
+ * The first two things anyone types after `npm install -g`.
+ *
+ * Both were "unknown command" in the package that was about to be published,
+ * and no test noticed: every other test knew a command to run.
+ */
+test("the two first questions a person asks are commands", () => {
+  for (const spelling of ["--help", "-h", "help"]) {
+    assert.equal(parseArgs([spelling]).command, "help", spelling);
+  }
+  for (const spelling of ["--version", "-v", "-V", "version"]) {
+    assert.equal(parseArgs([spelling]).command, "version", spelling);
+  }
+});
+
+test("`acc` on its own says how to find the commands", () => {
+  assert.throws(() => parseArgs([]),
+    error => error.code === EXIT.USAGE && error.message.includes("acc help"));
+  assert.throws(() => parseArgs(["teleport"]),
+    error => error.code === EXIT.USAGE && error.message.includes("acc help"));
+});
+
+test("a message body may still be the word --help", () => {
+  // The reason the spellings are read in first position only. Agents exchange
+  // diffs and console output, and a body that begins with "--" is ordinary.
+  const parsed = parseArgs(["message", "--to", "peer", "--subject", "s",
+    "--body", "--help"]);
+
+  assert.equal(parsed.command, "message");
+  assert.equal(parsed.options.body, "--help");
+});
+
+test("the help lists every command the CLI accepts, and invents none", () => {
+  const listed = describeCommands().flatMap(group => group.commands.map(one => one.name));
+
+  assert.deepEqual([...listed].sort(), Object.keys(COMMANDS).sort(),
+    "a command exists that the help does not mention, or the other way round");
+  assert.equal(new Set(listed).size, listed.length, "a command appears under two headings");
+  for (const name of listed) {
+    assert.match(helpText(), new RegExp(`acc ${name}\\b`), `${name} is not in the text`);
+  }
+});
+
+test("every listed command says what it does", () => {
+  const missing = describeCommands().flatMap(group => group.commands)
+    .filter(one => typeof one.summary !== "string" || one.summary === "")
+    .map(one => one.name);
+
+  assert.deepEqual(missing, [], "a command is listed with nothing said about it");
+});
+
+test("help and version answer even when the store cannot be opened", async t => {
+  // They describe the program, not a workspace. Pointing the data home at a
+  // file makes every command that opens the store fail, which is what proves
+  // these two never reach it - rather than restating the routing table.
+  const home = await realpath(await mkdtemp(path.join(tmpdir(), "acc-help-")));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const blocked = path.join(home, "not-a-directory");
+  await writeFile(blocked, "");
+
+  const run = argv => execFileAsync(process.execPath, [binary, ...argv],
+    { cwd: home, env: { ...process.env, ACC_DATA_HOME: blocked, HOME: home } });
+
+  await assert.rejects(run(["status"]), "a workspace command still opened the store");
+
+  const help = await run(["help"]);
+  assert.match(help.stdout, /acc claim/);
+  const version = await run(["version"]);
+  const manifest = JSON.parse(await readFile(path.join(repoRoot, "package.json"), "utf8"));
+  assert.equal(version.stdout.trim(), manifest.version);
+});
+
+test("the reference the help points at is one the reader can actually reach", async () => {
+  // It named `docs/CLI.md` first, which is not packed: `files` ships `bin/`,
+  // `README.md`, `LICENSE` and `docs/CAPABILITIES.md`. Help that points into
+  // the installed package has to point at something that is in it.
+  const manifest = JSON.parse(await readFile(path.join(repoRoot, "package.json"), "utf8"));
+  const repository = manifest.repository.url.replace(/^git\+/, "").replace(/\.git$/, "");
+  const [reference] = helpText().match(/https:\/\/\S+/) ?? [];
+
+  assert.equal(typeof reference, "string", "the help offers nowhere to read more");
+  assert.equal(reference.startsWith(repository), true,
+    `the help points at ${reference}, which is not the repository the manifest names`);
+  for (const shipped of manifest.files) {
+    assert.equal(helpText().includes(` ${shipped}`), false,
+      "the help names a packed path where a URL belongs");
+  }
+  assert.equal(/\bdocs\/(?!CAPABILITIES)/.test(helpText().replace(reference, "")), false,
+    "the help names a document the installed package does not carry");
+});
+
+test("the version is the package's own, not one typed into the source", async () => {
+  // `bin/` sits at the same depth in the published package as it does here, so
+  // this relative read is the one thing that stays true in both layouts.
+  const manifest = JSON.parse(await readFile(path.join(repoRoot, "package.json"), "utf8"));
+  const source = await readFile(binary, "utf8");
+
+  assert.match(source, /\.\.\/package\.json/);
+  assert.equal(source.includes(manifest.version), false,
+    "the version is written into bin/acc.mjs, so the next bump will leave it behind");
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.mjs" },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/tests/acceptance/recorded-candidate.test.mjs
+++ b/tests/acceptance/recorded-candidate.test.mjs
@@ -50,8 +50,15 @@ test("the changelog's digest describes the code that is here now", async () => {
     return;
   }
 
-  const changed = (await git("diff", "--name-only", `${recorded}..HEAD`, "--", ...PACKED))
-    .split("\n").filter(Boolean);
+  // Commits, and the working tree beside them. Comparing only commits meant
+  // `npm test` passed on an edited README and the pre-push hook caught it a
+  // moment later - the right answer at the wrong time, when the fix is a
+  // re-record and the commit is already made.
+  const changed = [...new Set([
+    ...(await git("diff", "--name-only", `${recorded}..HEAD`, "--", ...PACKED)).split("\n"),
+    ...(await git("status", "--porcelain", "--", ...PACKED))
+      .split("\n").map(line => line.slice(3)),
+  ])].filter(Boolean).sort();
 
   assert.deepEqual(changed, [],
     `shipped code changed since ${recorded}, so the recorded digest describes nothing `

--- a/tests/docs/skills.test.mjs
+++ b/tests/docs/skills.test.mjs
@@ -71,7 +71,10 @@ test("the taught set stays honest about what the CLI offers", async () => {
   // added to the CLI has to be classified here on purpose, which is the moment
   // to notice it also needs teaching.
   const known = new Set([...TAUGHT, ...OPTIONAL,
-    "install", "uninstall", "doctor", "config", "attach", "heartbeat", "detach"]);
+    "install", "uninstall", "doctor", "config", "attach", "heartbeat", "detach",
+    // Describe the program rather than the workspace: nothing to teach an agent,
+    // which already receives the command list in its skill.
+    "help", "version"]);
   const unclassified = Object.keys(COMMANDS).filter(command => !known.has(command));
 
   assert.deepEqual(unclassified, [],

--- a/tests/helpers/plugin-version.mjs
+++ b/tests/helpers/plugin-version.mjs
@@ -1,0 +1,20 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packages = fileURLToPath(new URL("../../packages/", import.meta.url));
+
+/**
+ * The version a client caches a plugin under.
+ *
+ * Read from the manifest that ships it rather than written out. Every one of
+ * these paths was spelled `0.0.0` by hand, and the first version bump broke five
+ * tests that were describing a real behaviour perfectly well.
+ */
+export async function pluginVersion(manifest) {
+  return JSON.parse(await readFile(path.join(packages, manifest), "utf8")).version;
+}
+
+export const CLAUDE_PLUGIN = "adapter-claude-code/plugin/.claude-plugin/plugin.json";
+export const CODEX_PLUGIN = "adapter-codex/plugin/.codex-plugin/plugin.json";
+export const KIMI_PLUGIN = "adapter-kimi/plugin/.kimi-plugin/plugin.json";

--- a/tests/process/hook-wiring.test.mjs
+++ b/tests/process/hook-wiring.test.mjs
@@ -4,6 +4,8 @@ import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+
+import { CLAUDE_PLUGIN, pluginVersion } from "../helpers/plugin-version.mjs";
 import { promisify } from "node:util";
 
 import { createClaudeCodeAdapter } from "@agents-can-communicate/adapter-claude-code";
@@ -39,7 +41,7 @@ const ADAPTERS = [
       // The copy the client runs from, under the marketplace cache. Reading the
       // marketplace source instead would test a tree the client never loads.
       const root = path.join(home, "plugins", "cache", "acc-local",
-        "agents-can-communicate", "0.0.0");
+        "agents-can-communicate", await pluginVersion(CLAUDE_PLUGIN));
       const wired = JSON.parse(await readFile(path.join(root, "hooks", "hooks.json"),
         "utf8"));
       return Object.values(wired.hooks)

--- a/tests/process/session-resolution.test.mjs
+++ b/tests/process/session-resolution.test.mjs
@@ -164,7 +164,10 @@ const AGENT_FACING = Object.freeze([
 // Setup and lifecycle: a model should not be running the installer, and these
 // three are the adapter's own calls, which pass their identity explicitly.
 const NOT_AGENT_FACING = Object.freeze(["install", "uninstall", "doctor", "config",
-  "attach", "heartbeat", "detach"]);
+  "attach", "heartbeat", "detach",
+  // These answer about the program itself, so they need no session and must
+  // work in a directory that is no workspace.
+  "help", "version"]);
 
 test("the list above is every command an agent can run", async () => {
   // Remembered lists rot. `acc decide` was added, needed an identity like the


### PR DESCRIPTION
Everything the release needs, so that publishing is one command against a merged `main`.

> Stacked on #52 — this branch is built from it, so GitHub shows both diffs until that one lands. Merging #52 first makes this the delta alone.

## The version

`0.1.0`, across seventeen manifests including the four plugin bundles. `0.x` because the surfaces are young: several changed in the week before this, and a version promising otherwise would be the first thing in the changelog that was not measured.

The README's install line changes with it — it said the package was not published, because it was not.

## The bump broke five tests, correctly

All five described real behaviour and spelled the cached plugin version `0.0.0` by hand:

```
✖ install registers the plugin and preserves the user's own hook
✖ install finishes the job the client's own command would have done
✖ the cached copy carries the same absolute hook command
✖ claude_code: every installed hook command names a file that exists
```

They read it from the manifest that ships it now, so the next bump does not break them again.

## Verification

```
npm ci · npm test · npm run check · npm pack · verify-package · git diff --check
```

- 800 tests passing, 0 failing · `syntax ok in 170 file(s)`
- `PASS  agents-can-communicate-0.1.0.tgz  sha256 d43d2bf3…635e27  built from e861a20` — 121 KB, 104 entries
- `npm publish --dry-run` contents checked
- npm name is free, and `npm whoami` is `mmykola87`

## After this merges

`npm publish` from `main`, then the tag and the GitHub release. Per `docs/RELEASING.md` those are external mutations and stay deliberate acts.
