### PR TITLE
fix: the manifest is shipped code, and nothing was watching it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Unreleased
+
+| | |
+|---|---|
+| Built from | `1c08754` |
+| Tarball | `agents-can-communicate-0.1.0.tgz`, 123 KB, 105 entries |
+| sha256 | `d61b4d516e4a43cd97f19b5a43ae0f7f47f2e9ce17ab6837607e3aba64145790` |
+| Tests | 809 passing, 0 failing |
+
+Not published. A published record says what the registry serves and is not
+rewritten, so shipped code that changes after a release is measured here instead.
+
+`package.json` is shipped code: npm packs the manifest whatever `files` says.
+It was not in the set the record's own test watches, so editing the manifest
+changed the digest while every gate stayed green. The set is asked of `npm pack
+--dry-run` now rather than copied by hand, and any path that reaches the tarball
+unwatched fails by name.
+
+The manifest itself carries `npm pkg fix`: npm rewrote `./bin/acc.mjs` to
+`bin/acc.mjs` in the registry metadata on every publish and warned about it. The
+tarball was never affected.
+
 ## 0.1.0 — first release
 
 Published to npm. `0.x` because the surfaces are young: several of them changed
@@ -8,7 +30,7 @@ thing in here that was not measured.
 
 | | |
 |---|---|
-| Built from | `c318458` |
+| Built from | `c318458`, published from `b428ca7` — the merge changed nothing packed |
 | Tarball | `agents-can-communicate-0.1.0.tgz`, 123 KB, 105 entries |
 | sha256 | `e4ed773feb25dd40a0fb5d2bb010f66261613a3cac14882750b431f3ab2a3480` |
 | Tests | 808 passing, 0 failing |
@@ -21,6 +43,14 @@ tarball, so any change to shipped code changes the digest — and the commit nam
 necessarily an ancestor of the one recording it, because no commit can contain its own
 hash. Only `bin/`, `README.md`, `LICENSE`, `docs/CAPABILITIES.md`, and the workspaces are
 packed, so changes to tests, scripts, or the rest of `docs/` leave the digest alone.
+
+The registry serves that digest. Checked after publishing by downloading the
+tarball back rather than by trusting the local pack:
+
+```bash
+curl -sSL -O "$(npm view agents-can-communicate dist.tarball)"
+shasum -a 256 agents-can-communicate-0.1.0.tgz
+```
 
 To check it, or to record a newer candidate:
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -53,6 +53,16 @@ the working tree is dirty:
 PASS  agents-can-communicate-0.0.0.tgz  sha256 a5c8bb1d…  built from 39d0dcf
 ```
 
+`package.json` is part of shipped code for this purpose. npm packs the manifest
+whatever `files` says, so a version bump or an `npm pkg fix` changes the digest —
+and for a while the check watched every packed path except that one.
+
+Once a version is published its record is history: it describes what the registry
+serves and is not rewritten. Shipped code that changes afterwards gets a new
+`## Unreleased` entry at the top of `CHANGELOG.md` carrying its own measurement.
+The check reads the first record in the file, so an unreleased tree is held to
+the same standard without disturbing the published one.
+
 It went stale four times in a row anyway, each caught by hand and only because
 someone happened to run the script. So `npm test` now checks it:
 `tests/acceptance/recorded-candidate.test.mjs` fails when shipped code has
@@ -63,6 +73,18 @@ record, not of the checkout depth.
 ## Then stop
 
 Publishing, tagging, and cutting a GitHub release are **external mutations**.
-They need explicit approval from the maintainer, every time. The `Release`
+They need explicit approval from the maintainer, every time.
+
+With two-factor authentication set to `auth-and-writes` — which is what `npm
+profile get` reports for this account — every publish needs a code, and npm does
+not prompt for one:
+
+```bash
+npm publish --otp=123456
+```
+
+An npm *Automation* token, or a granular token with write access, publishes
+without a code. A granular token scoped to selected packages cannot create a
+package that does not exist yet, which is the case exactly once per package. The `Release`
 workflow builds and verifies a candidate and uploads it as an artifact; it does
 not publish.

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "node": ">=24"
   },
   "bin": {
-    "acc": "./bin/acc.mjs",
-    "acc-mcp": "./bin/acc-mcp.mjs",
-    "acc-hook": "./bin/acc-hook.mjs"
+    "acc": "bin/acc.mjs",
+    "acc-mcp": "bin/acc-mcp.mjs",
+    "acc-hook": "bin/acc-hook.mjs"
   },
   "files": [
     "bin/",

--- a/tests/acceptance/recorded-candidate.test.mjs
+++ b/tests/acceptance/recorded-candidate.test.mjs
@@ -25,7 +25,14 @@ const repo = path.resolve(import.meta.dirname, "..", "..");
  * the CI matrix builds on two platforms.
  */
 const PACKED = Object.freeze(["bin/", "packages/", "README.md", "LICENSE",
-  "docs/CAPABILITIES.md"]);
+  "docs/CAPABILITIES.md", "package.json"]);
+
+// npm packs these whatever `files` says, which is why `files` cannot be the
+// whole answer: the manifest always travels, and the bundled workspaces come
+// from the dependency list. `package.json` was missing from the list above, so
+// editing the manifest - a version bump, `npm pkg fix` - changed the digest
+// while this file reported the record still described the tree.
+const UNDECLARED = Object.freeze(["packages/", "package.json"]);
 
 const git = async (...argv) => {
   const env = { ...process.env };
@@ -72,9 +79,10 @@ test("the packed set this checks is the packed set that ships", async () => {
   // The list above is a copy, and a copy drifts. `packages/` stands in for every
   // bundled workspace, which npm packs from the dependency list rather than
   // from `files`.
+  //
   const declared = new Set(manifest.files);
   for (const entry of PACKED) {
-    if (entry === "packages/") continue;
+    if (UNDECLARED.includes(entry)) continue;
     assert.equal(declared.has(entry), true, `${entry} is no longer published`);
   }
   for (const entry of declared) {
@@ -83,4 +91,29 @@ test("the packed set this checks is the packed set that ships", async () => {
   }
   assert.equal((manifest.bundleDependencies ?? []).length > 0, true,
     "nothing is bundled, so `packages/` no longer stands for anything shipped");
+});
+
+test("nothing reaches the tarball that this file would not notice changing", async () => {
+  // Asks npm what it would pack rather than reading `files` and reasoning about
+  // it. `--dry-run` writes nothing and answers in a fifth of a second, and it is
+  // the only account of the tarball that cannot drift from the tarball.
+  //
+  // Listing entries is portable in a way comparing digests is not: a gzip stream
+  // carries mtimes, and the CI matrix builds on two platforms.
+  const { stdout } = await run("npm", ["pack", "--dry-run", "--json"], { cwd: repo });
+  const [packed] = JSON.parse(stdout);
+  // Bundled workspaces arrive under `node_modules/` and are built from
+  // `packages/`, which the list above already watches.
+  const bundled = "node_modules/@agents-can-communicate/";
+
+  const unwatched = packed.files.map(file => file.path)
+    .filter(entry => !entry.startsWith(bundled))
+    .filter(entry => !PACKED.some(watched => (watched.endsWith("/")
+      ? entry.startsWith(watched) : entry === watched)))
+    .sort();
+
+  assert.deepEqual(unwatched, [],
+    "these travel in the tarball and nothing above watches them, so a change to "
+    + "one would leave the recorded digest describing a tarball nobody can build:"
+    + `\n  ${unwatched.join("\n  ")}`);
 });


### PR DESCRIPTION
Publishing 0.1.0 printed a warning the release checks had no opinion about:

```
npm warn publish npm auto-corrected some errors in your package.json when publishing.
npm warn publish "bin[acc]" script name was cleaned
```

npm rewrites `./bin/acc.mjs` to `bin/acc.mjs` in the **registry metadata**. That part is cosmetic, and I checked before publishing rather than assuming: the tarball keeps whatever the manifest says, and the digest recorded for 0.1.0 matches the tarball the registry serves byte for byte. `npm pkg fix` is what silences it.

## The defect is what applying it revealed

`package.json` was not in the packed set `tests/acceptance/recorded-candidate.test.mjs` watches:

```js
const PACKED = Object.freeze(["bin/", "packages/", "README.md", "LICENSE",
  "docs/CAPABILITIES.md"]);
```

npm packs the manifest **whatever `files` says**. So editing it changes the tarball while the test reports the record still describes the tree. Measured, not reasoned about:

```
── does the gate notice?
✔ the changelog's digest describes the code that is here now
✔ the packed set this checks is the packed set that ships
ℹ pass 2  fail 0

── does the tarball digest change?
now:       d61b4d516e4a43cd97f19b5a43ae0f7f47f2e9ce17ab6837607e3aba64145790
published: e4ed773feb25dd40a0fb5d2bb010f66261613a3cac14882750b431f3ab2a3480
```

Green, and describing a different tarball. This is the exact failure the file's own comment calls out — *"a stale digest is worse than none"* — arriving through the one path it did not watch. The version bump tripped it earlier only by accident, through `packages/*/package.json`.

## The fix

The packed set is asked of npm instead of copied by hand:

```js
const { stdout } = await run("npm", ["pack", "--dry-run", "--json"], { cwd: repo });
```

`--dry-run` writes nothing and answers in ~0.2 s. Any path that reaches the tarball and is not watched fails by name. Listing entries stays portable in a way comparing digests is not — a gzip stream carries mtimes, and the matrix builds on two platforms, which is why the file compares history rather than re-packing.

Mutation check — dropping `package.json` from the list again:

```
✖ nothing reaches the tarball that this file would not notice changing
  +   'package.json'
```

## Recording after a release

A published record says what the registry serves, so it is not rewritten. Post-release changes get a `## Unreleased` entry with their own measurement, and the check reads the first record in the file. `docs/RELEASING.md` says so now, along with two things this release cost three attempts to learn: `auth-and-writes` 2FA needs `--otp=` on every publish and npm never prompts, and a granular token scoped to selected packages cannot create a package that does not exist yet.

The 0.1.0 entry additionally records that the registry was checked by downloading the tarball back:

```bash
curl -sSL -O "$(npm view agents-can-communicate dist.tarball)"
shasum -a 256 agents-can-communicate-0.1.0.tgz   # e4ed773f…a3480
```

## Verification

- 809 tests passing, 0 failing · `syntax ok in 172 file(s)`
- recorded: `sha256 d61b4d51…145790` built from `1c08754`
