### PR TITLE
fix: an install nothing could remove once its client was gone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,26 @@
 
 | | |
 |---|---|
-| Built from | `1c08754` |
+| Built from | `2690761` |
 | Tarball | `agents-can-communicate-0.1.0.tgz`, 123 KB, 105 entries |
-| sha256 | `d61b4d516e4a43cd97f19b5a43ae0f7f47f2e9ce17ab6837607e3aba64145790` |
-| Tests | 809 passing, 0 failing |
+| sha256 | `017dd35976535010784fa5c5754108fabfc41932815cf2a3ad7027aa0ba70d67` |
+| Tests | 817 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not
 rewritten, so shipped code that changes after a release is measured here instead.
+
+An install could not be removed once its client left the machine. `acc
+uninstall` skipped exactly the client ACC had written to, reported success, and
+said the same thing on every run afterwards - leaving ACC's tree in the client's
+configuration directory and ACC's entries in the user's own settings file. The
+plan was built from detection; it is built from the installation record as well
+now, which is the only account of what was written.
+
+`uninstalled N adapter(s)` counted every adapter whose uninstall ran, which on a
+machine ACC had never touched was all of them. It counts the ones it changed.
+
+`--dry-run` works on `acc uninstall`. The preview was computed for either action
+from the start and only `install` had a flag to ask for it.
 
 `package.json` is shipped code: npm packs the manifest whatever `files` says.
 It was not in the set the record's own test watches, so editing the manifest

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -9,6 +9,7 @@ Both work anywhere, including a directory that is no workspace at all.
 ```bash
 acc help
 acc version
+acc uninstall --dry-run
 ```
 
 ```mermaid
@@ -31,7 +32,8 @@ graph LR
 | `acc install` | Install adapters for the clients on this machine |
 | `acc install --dry-run` | Print the exact plan, change nothing |
 | `acc install --adapter kimi` | One client only |
-| `acc uninstall` | Remove what ACC wrote, keep what you edited |
+| `acc uninstall` | Remove what ACC wrote, keep what you edited — including for a client that has since left the machine |
+| `acc uninstall --dry-run` | Print exactly what would be removed, change nothing |
 | `acc doctor` | Clients, versions, install health, what to run next |
 | `acc doctor --repair` | Repair store state; refuses if it is ambiguous |
 | `acc config init` | Write `acc.workspace.json` after showing it |

--- a/packages/cli/src/args.mjs
+++ b/packages/cli/src/args.mjs
@@ -57,7 +57,10 @@ export const COMMANDS = Object.freeze({
   config: { required: [], optional: [], flags: ["yes", "force"],
     subcommands: ["init", "validate"] },
   install: { required: [], optional: ["adapter", "home"], flags: ["dry-run", "yes"] },
-  uninstall: { required: [], optional: ["adapter", "home"], flags: ["yes"] },
+  // `--dry-run` on both, because the preview was computed for either action and
+  // only `install` could ask for it. Removal is the side that reaches into a
+  // client's configuration - including a client that has left the machine.
+  uninstall: { required: [], optional: ["adapter", "home"], flags: ["dry-run", "yes"] },
   // The two things a person types first after installing from a registry. The
   // CLI answered neither: `acc --version` and `acc --help` were both "unknown
   // command", and `acc` on its own asked for a command without naming one.

--- a/packages/cli/src/install-command.mjs
+++ b/packages/cli/src/install-command.mjs
@@ -5,7 +5,7 @@ import { createClaudeCodeAdapter } from "@agents-can-communicate/adapter-claude-
 import { createCodexAdapter } from "@agents-can-communicate/adapter-codex";
 import { createGeminiCliAdapter } from "@agents-can-communicate/adapter-gemini-cli";
 import { createKimiAdapter } from "@agents-can-communicate/adapter-kimi";
-import { applyPlan, detectInstallation, planInstallation }
+import { applyPlan, detectInstallation, loadOwnership, planInstallation }
   from "@agents-can-communicate/installer";
 import { AccError, EXIT } from "@agents-can-communicate/protocol";
 
@@ -80,6 +80,21 @@ export function failureOf({ action, acted, failed = [] }) {
     describeOutcome({ action, acted, failed }), { failed });
 }
 
+/**
+ * How many adapters this actually did something to.
+ *
+ * `applied` means the adapter's own step ran, which on an uninstall is true of
+ * every client on the machine whether ACC had ever written to it or not. So
+ * `uninstalled 3 adapter(s)` was the report on a machine where ACC had installed
+ * nothing at all - printed by the same run that skipped the one client it had
+ * actually written to.
+ */
+export function actedOn(result) {
+  return result.operations.filter(operation => operation.applied
+    && (result.action === "install"
+      || (operation.removed?.length ?? 0) + (operation.changes?.length ?? 0) > 0)).length;
+}
+
 export async function runInstallCommand({ options, runtime, action = "install" }) {
   const adapters = selectAdapters(options.adapter);
   const home = options.home ?? runtime.env?.HOME ?? homedir();
@@ -88,12 +103,18 @@ export async function runInstallCommand({ options, runtime, action = "install" }
     env: runtime.env ?? {} });
 
   const detected = await detectInstallation({ adapters, context });
-  const plan = planInstallation({ adapters, detected, context, action });
+  // An uninstall is planned from what ACC recorded writing, not only from what
+  // is on the machine now. A client can be removed after ACC installed into it,
+  // and its configuration directory - with ACC's files in it - stays behind.
+  const recorded = action === "uninstall"
+    ? (await loadOwnership({ dataHome })).installs
+    : [];
+  const plan = planInstallation({ adapters, detected, context, action, recorded });
 
   const dryRun = options.dryRun === true;
   const result = await applyPlan({ plan, adapters, context, dataHome, dryRun });
 
-  const acted = result.operations.filter(operation => operation.applied).length;
+  const acted = actedOn(result);
   if (dryRun) {
     return { data: { ...result, plan, dataHome },
       text: [`would ${action}:`, ...plan.operations.flatMap(operation => operation.summary),

--- a/packages/cli/test/install-command.test.mjs
+++ b/packages/cli/test/install-command.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { recordInstall } from "@agents-can-communicate/installer";
+
+import { runInstallCommand } from "../src/install-command.mjs";
+
+/**
+ * The command's own wiring.
+ *
+ * The plan knows how to remove an install whose client has left the machine -
+ * but only when it is handed the record. Nothing else would notice that argument
+ * being dropped: the tests that cover the rule pass the record in themselves,
+ * and this is the only place that reads it off the disk.
+ */
+test("uninstall is planned from the record, not only from the machine", async t => {
+  const home = await realpath(await mkdtemp(path.join(tmpdir(), "acc-cmd-home-")));
+  const dataHome = await realpath(await mkdtemp(path.join(tmpdir(), "acc-cmd-data-")));
+  t.after(() => Promise.all([home, dataHome]
+    .map(dir => rm(dir, { recursive: true, force: true }))));
+
+  // What a Gemini install leaves behind, recorded the way the installer records
+  // it. The fingerprints matter: an artifact whose hash does not match is held
+  // back rather than removed, so a hand-written record would prove nothing.
+  const extension = path.join(home, ".gemini", "extensions", "agents-can-communicate");
+  const settings = path.join(home, ".gemini", "settings.json");
+  await mkdir(extension, { recursive: true });
+  await writeFile(path.join(extension, "gemini-extension.json"), '{"name":"acc"}\n');
+  await writeFile(settings, '{"theme":"dark"}\n');
+  await recordInstall({ dataHome, adapterId: "gemini_cli", version: "0.55.1",
+    artifacts: [{ path: extension, kind: "tree" }, { path: settings, kind: "merge" }] });
+
+  const { data, error } = await runInstallCommand({
+    options: { home, adapter: "gemini_cli", yes: true },
+    runtime: { platform: process.platform,
+      env: { HOME: home, ACC_DATA_HOME: dataHome } },
+    action: "uninstall" });
+
+  assert.equal(error ?? null, null);
+  const operation = data.plan.operations.find(one => one.adapterId === "gemini_cli");
+  if (operation?.clientPresent === true) {
+    // Gemini CLI is on this machine, so the case this test is about did not run.
+    // Said out loud rather than passed quietly on a false premise.
+    t.skip("Gemini CLI is installed here, so the client never left the machine");
+    return;
+  }
+
+  assert.equal(operation?.clientPresent, false,
+    "the record was not consulted, so this install cannot be removed by anything");
+  await assert.rejects(readFile(path.join(extension, "gemini-extension.json")),
+    "the recorded tree survived the uninstall");
+  assert.equal((await readFile(settings, "utf8")).includes("theme"), true,
+    "the user's own file did not survive");
+});
+
+test("uninstall counts the adapters it changed, not the ones it visited", async () => {
+  const { actedOn } = await import("../src/install-command.mjs");
+
+  // Three clients on the machine, none of them ever written to by ACC: the
+  // adapter's uninstall runs and finds nothing, which is not an uninstall.
+  assert.equal(actedOn({ action: "uninstall", operations: [
+    { adapterId: "claude_code", applied: true, removed: [], changes: [] },
+    { adapterId: "codex", applied: true, removed: [], changes: [] },
+    { adapterId: "kimi", applied: true, removed: [], changes: [] }] }), 0);
+
+  assert.equal(actedOn({ action: "uninstall", operations: [
+    { adapterId: "gemini_cli", applied: true, removed: ["/a/tree"], changes: [] },
+    { adapterId: "kimi", applied: true, removed: [], changes: ["unpicked an entry"] },
+    { adapterId: "codex", applied: true, removed: [], changes: [] }] }), 2);
+
+  // An install that ran wrote something by definition, so it is counted as it was.
+  assert.equal(actedOn({ action: "install", operations: [
+    { adapterId: "kimi", applied: true, removed: [], changes: [] },
+    { adapterId: "codex", applied: false }] }), 1);
+});
+
+test("a removal can be previewed, the same way an install can", async t => {
+  const { parseArgs } = await import("../src/args.mjs");
+  // The preview was computed for either action from the start, and only
+  // `install` had a flag to ask for it - an operation the product could do and
+  // nothing could reach.
+  assert.equal(parseArgs(["uninstall", "--dry-run"]).options.dryRun, true);
+
+  const home = await realpath(await mkdtemp(path.join(tmpdir(), "acc-dry-home-")));
+  const dataHome = await realpath(await mkdtemp(path.join(tmpdir(), "acc-dry-data-")));
+  t.after(() => Promise.all([home, dataHome]
+    .map(dir => rm(dir, { recursive: true, force: true }))));
+
+  const extension = path.join(home, ".gemini", "extensions", "agents-can-communicate");
+  await mkdir(extension, { recursive: true });
+  await writeFile(path.join(extension, "gemini-extension.json"), '{"name":"acc"}\n');
+  await recordInstall({ dataHome, adapterId: "gemini_cli", version: "0.55.1",
+    artifacts: [{ path: extension, kind: "tree" }] });
+
+  const { text } = await runInstallCommand({
+    options: { home, adapter: "gemini_cli", dryRun: true },
+    runtime: { platform: process.platform,
+      env: { HOME: home, ACC_DATA_HOME: dataHome } },
+    action: "uninstall" });
+
+  assert.match(text, /^would uninstall:/);
+  assert.match(text, new RegExp(`remove ${extension}`));
+  // The whole point of a preview.
+  assert.equal((await readFile(path.join(extension, "gemini-extension.json"), "utf8"))
+    .includes("acc"), true, "the dry run removed the thing it was previewing");
+});

--- a/packages/installer/src/plan.mjs
+++ b/packages/installer/src/plan.mjs
@@ -7,11 +7,16 @@ import { AccError, EXIT } from "@agents-can-communicate/protocol";
  * makes `--dry-run` worth reading - a plan computed differently from the thing
  * it previews is a decoration, and the operator would find out only afterwards.
  */
-export function planInstallation({ adapters, detected, context, action = "install" }) {
+export function planInstallation({ adapters, detected, context, action = "install",
+  recorded = [] }) {
   if (!["install", "uninstall"].includes(action)) {
     throw new AccError(EXIT.USAGE, `unknown installation action: ${action}`, { action });
   }
   const byId = new Map(adapters.map(adapter => [adapter.id, adapter]));
+  // What ACC recorded writing, by client. For an uninstall this is the
+  // authority rather than detection: the record is the only account of what was
+  // written, and a client's configuration directory outlives the client.
+  const recordedById = new Map(recorded.map(install => [install.adapterId, install]));
   const operations = [];
   const skipped = [];
 
@@ -24,20 +29,32 @@ export function planInstallation({ adapters, detected, context, action = "instal
       skipped.push({ adapterId: entry.adapterId, reason: "no adapter for this client" });
       continue;
     }
-    if (!entry.present) {
+    // A client that has left the machine is still worth visiting when ACC wrote
+    // to it. Skipping it made that install permanently unremovable: `acc
+    // uninstall` reported success and exit 0, left ACC's tree in the client's
+    // configuration directory and ACC's entries in the user's own settings
+    // file, and said the same thing on every run afterwards.
+    const record = action === "uninstall" && !entry.present
+      ? recordedById.get(entry.adapterId)
+      : undefined;
+
+    if (!entry.present && record === undefined) {
       // Named rather than dropped: "nothing happened" and "that client is not
       // installed on this machine" look the same in an empty list.
       skipped.push({ adapterId: entry.adapterId,
         reason: `${entry.displayName ?? entry.adapterId} is not installed on this machine` });
       continue;
     }
-    if (typeof adapter.planInstall !== "function") {
+    if (record === undefined && typeof adapter.planInstall !== "function") {
       skipped.push({ adapterId: entry.adapterId,
         reason: "this adapter cannot describe what it would write" });
       continue;
     }
 
-    const artifacts = adapter.planInstall(context)
+    // From the record when the client is gone, because that is what was written
+    // and so what will be removed. Asking the adapter instead would describe an
+    // install for a machine this one no longer is.
+    const artifacts = (record?.artifacts ?? adapter.planInstall(context))
       .map(artifact => ({ path: artifact.path, kind: artifact.kind ?? "file" }))
       .sort((a, b) => a.path.localeCompare(b.path));
 
@@ -45,12 +62,18 @@ export function planInstallation({ adapters, detected, context, action = "instal
       adapterId: adapter.id,
       displayName: adapter.displayName,
       action,
-      clientVersion: entry.version ?? null,
+      clientVersion: entry.version ?? record?.version ?? null,
+      // "Remove these files for a client that is not here" is a different thing
+      // to approve than an ordinary uninstall, so it is said rather than left
+      // to be inferred from a client version that is null.
+      clientPresent: entry.present === true,
       alreadyInstalled: entry.installed === true,
       artifacts,
       // Said in the operator's terms, not in paths: which files ACC creates
       // outright and which belong to the user and are only edited.
       summary: [
+        ...(entry.present ? [] : [`${adapter.displayName ?? adapter.id} is no longer on `
+          + "this machine; removing what ACC recorded writing"]),
         ...artifacts.filter(a => a.kind === "tree")
           .map(a => `${action === "install" ? "create" : "remove"} ${a.path}`),
         ...artifacts.filter(a => a.kind === "merge")

--- a/packages/installer/test/recovery.test.mjs
+++ b/packages/installer/test/recovery.test.mjs
@@ -122,3 +122,114 @@ test("uninstall after a crash removes only what is still ACC's", async t => {
   assert.equal(await readFile(path.join(plugin, "skills", "acc", "SKILL.md"), "utf8"),
     "my own notes\n");
 });
+
+/**
+ * The machine changing under a recorded install.
+ *
+ * A client can be uninstalled after ACC has written into it, and its
+ * configuration directory outlives it. Planning an uninstall from detection
+ * alone meant ACC skipped exactly the client it had written to, reported
+ * success, and said the same thing on every run afterwards - so the tree it
+ * created and the entries it added to the user's own settings could never be
+ * removed by the tool that put them there.
+ */
+const absent = adapter => [{ adapterId: adapter.id, displayName: adapter.displayName,
+  present: false, version: null, versionOutput: null, installed: false,
+  diagnostics: [], capabilities: adapter.capabilities, error: null }];
+
+test("an install can still be removed after the client leaves the machine", async t => {
+  const place = await machine(t);
+  const [gemini] = adapters();
+  const extension = path.join(place.home, ".gemini", "extensions",
+    "agents-can-communicate", "gemini-extension.json");
+  const settings = path.join(place.home, ".gemini", "settings.json");
+
+  const install = planInstallation({ adapters: [gemini], detected: detected([gemini]),
+    context: place.context, action: "install" });
+  await applyPlan({ plan: install, adapters: [gemini], context: place.context,
+    dataHome: place.dataHome });
+  assert.equal((await readFile(settings, "utf8")).includes("agents-can-communicate"), true,
+    "the install wrote nothing to unpick, so the test proves nothing");
+
+  // The client is removed from the machine. Everything ACC wrote stays where it is.
+  const recorded = (await loadOwnership({ dataHome: place.dataHome })).installs;
+  const plan = planInstallation({ adapters: [gemini], detected: absent(gemini),
+    context: place.context, action: "uninstall", recorded });
+
+  assert.deepEqual(plan.skipped, [], "the one client ACC wrote to was skipped");
+  assert.equal(plan.operations.length, 1);
+  assert.equal(plan.operations[0].clientPresent, false, "the plan does not say the client is gone");
+
+  await applyPlan({ plan, adapters: [gemini], context: place.context,
+    dataHome: place.dataHome });
+
+  await assert.rejects(readFile(extension), "ACC's own tree outlived the uninstall");
+  assert.equal((await readFile(settings, "utf8")).includes("agents-can-communicate"), false,
+    "ACC's entries were left in a file the user owns");
+  assert.deepEqual((await loadOwnership({ dataHome: place.dataHome })).installs, [],
+    "the record still claims an install that nothing can act on");
+});
+
+test("removing for a client that is gone keeps what the user wrote", async t => {
+  const place = await machine(t);
+  const [gemini] = adapters();
+  const settings = path.join(place.home, ".gemini", "settings.json");
+
+  const install = planInstallation({ adapters: [gemini], detected: detected([gemini]),
+    context: place.context, action: "install" });
+  await applyPlan({ plan: install, adapters: [gemini], context: place.context,
+    dataHome: place.dataHome });
+
+  const recorded = (await loadOwnership({ dataHome: place.dataHome })).installs;
+  await applyPlan({
+    plan: planInstallation({ adapters: [gemini], detected: absent(gemini),
+      context: place.context, action: "uninstall", recorded }),
+    adapters: [gemini], context: place.context, dataHome: place.dataHome });
+
+  // The file was the user's before ACC edited it, so it is still theirs after.
+  assert.deepEqual(JSON.parse(await readFile(settings, "utf8")), { theme: "dark" });
+});
+
+test("a client that is not here is still never installed into", async t => {
+  const place = await machine(t);
+  const [gemini] = adapters();
+
+  // The record is what makes an uninstall visit an absent client. An install
+  // must not read it the same way and write to a machine that has no client.
+  const plan = planInstallation({ adapters: [gemini], detected: absent(gemini),
+    context: place.context, action: "install",
+    recorded: [{ adapterId: gemini.id, version: "1.0.0", artifacts: [] }] });
+
+  assert.deepEqual(plan.operations, []);
+  assert.equal(plan.skipped.length, 1);
+  assert.match(plan.skipped[0].reason, /not installed on this machine/);
+});
+
+test("an absent client ACC never wrote to is still skipped, and said so", async t => {
+  const place = await machine(t);
+  const [gemini] = adapters();
+
+  const plan = planInstallation({ adapters: [gemini], detected: absent(gemini),
+    context: place.context, action: "uninstall", recorded: [] });
+
+  assert.deepEqual(plan.operations, []);
+  assert.match(plan.skipped[0].reason, /not installed on this machine/);
+});
+
+test("what is removed is what was written, not what would be written today", async t => {
+  const place = await machine(t);
+  const old = path.join(place.home, ".gemini", "where-it-went");
+  // An adapter whose layout has moved since the install. Planning the removal
+  // from the adapter would name today's path and leave the install where it
+  // actually is - the record is the only account of that.
+  const moved = { ...createGeminiCliAdapter(),
+    planInstall: () => [{ path: path.join(place.home, ".gemini", "where-it-goes-now"),
+      kind: "tree" }] };
+
+  const plan = planInstallation({ adapters: [moved], detected: absent(moved),
+    context: place.context, action: "uninstall",
+    recorded: [{ adapterId: moved.id, version: "0.55.1",
+      artifacts: [{ path: old, kind: "tree" }] }] });
+
+  assert.deepEqual(plan.operations[0].artifacts.map(artifact => artifact.path), [old]);
+});


### PR DESCRIPTION
Found while clearing ACC off a real machine, not by a test. `acc uninstall` said this — and had been saying it since the install:

```
uninstalled 3 adapter(s)
  skip gemini_cli: Gemini CLI is not installed on this machine
```

It skipped the one client it had actually written to, and counted three it had never touched.

## Reproduced end to end

Stub `gemini` on PATH → install → remove the binary → uninstall:

```
── ACC tree in ~/.gemini?          STILL THERE
── ACC entries in settings.json:   5
── registry claims:                ['gemini_cli'] — both artifacts EXISTS
── exit code:                      0
```

Every later run said the same thing, so nothing could ever clear it: ACC's tree stayed in the client's configuration directory, ACC's entries stayed in a file **the user owns**, and the record went on claiming an install that the tool which made it could not remove.

## Where it was

Not in the removal — in the planning.

`applyPlan` was already record-driven: `removeOwned({dataHome, adapterId})` reads what was written and removes exactly that. It would have worked. It was never called, because `planInstallation` builds operations from the detection report, and `!entry.present` skipped the adapter for **both** actions. Right for install, wrong for uninstall — a client's configuration directory outlives the client.

An uninstall is planned from the record as well now, and its artifacts come from the record rather than from asking the adapter what it would write today. An install is deliberately unchanged: the record must not make ACC write to a machine that has no client, and there is a test for that.

## Two things next to it

**The count.** `uninstalled N adapter(s)` counted every adapter whose uninstall ran, which on a machine ACC had never touched was all of them — measured: `applied=True removed=0 changes=0 kept=0`, three times. It counts the ones it changed now, so the same run reports `uninstalled 0 adapter(s)`.

**`--dry-run` on `uninstall`.** The preview was computed for either action from the start — `would ${action}:` — and only `install` had the flag to ask for it. An operation the product could do and nothing could reach, which is the same shape as the bug above. It matters most here: removal is the side that reaches into a client's configuration, including a client that is gone.

```
would uninstall:
Gemini CLI is no longer on this machine; removing what ACC recorded writing
remove …/.gemini/extensions/agents-can-communicate
remove ACC entries from …/.gemini/settings.json
```

## Verification

Mutation-proved, each mutation caught by the test written for it:

| Mutation | Caught by |
|---|---|
| absent clients skipped again | `an install can still be removed after the client leaves the machine` |
| the record read for installs too | `a client that is not here is still never installed into` |
| artifacts taken from the adapter | `what is removed is what was written, not what would be written today` |
| the command stops reading the record | `uninstall is planned from the record, not only from the machine` |

That last one matters: the unit tests hand the record in themselves, so nothing else would notice the wiring being dropped.

The user's own file is checked, not assumed — after an uninstall for a client that is gone, `~/.gemini/settings.json` is still `{ theme: "dark" }`.

- 817 tests passing, 0 failing · `syntax ok in 173 file(s)`
- recorded: `sha256 017dd359…a70d67` built from `2690761`

## Not in this PR

ACC rewrites a config it edits with `JSON.stringify`, so a nested one-line object is expanded — `"mine": { "command": "x" }` becomes three lines. Semantically identical, indentation character preserved. Measured on `main` as well, so it predates this change; worth its own PR.
