### PR TITLE
fix: edit a user's config instead of reprinting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,23 @@
 
 | | |
 |---|---|
-| Built from | `2690761` |
+| Built from | `47a9b24` |
 | Tarball | `agents-can-communicate-0.1.0.tgz`, 123 KB, 105 entries |
-| sha256 | `017dd35976535010784fa5c5754108fabfc41932815cf2a3ad7027aa0ba70d67` |
-| Tests | 817 passing, 0 failing |
+| sha256 | `144fba47a46202f04320d063fb8e1630cd78c5935fab540fe0bf03fd80cf13bf` |
+| Tests | 828 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not
 rewritten, so shipped code that changes after a release is measured here instead.
+
+A config ACC edits is edited rather than reprinted. Reading the style back out
+of the file kept the indentation and still reformatted what the style could not
+describe: a nested object written on one line came back as three, and a blank
+line between sections was gone. Unchanged values are copied across verbatim now,
+so the byte-for-byte round trip the security tests have claimed since before
+this - and proved on `config.toml` - holds for JSON as well.
+
+Reading a config with a `__proto__` key set the prototype of the object being
+built instead of adding a key to it, so the key vanished from what was read.
 
 An install could not be removed once its client left the machine. `acc
 uninstall` skipped exactly the client ACC had written to, reported success, and

--- a/packages/adapter-sdk/src/config-merge.mjs
+++ b/packages/adapter-sdk/src/config-merge.mjs
@@ -1,5 +1,7 @@
 import path from "node:path";
 
+import { editJson } from "./json-text.mjs";
+
 const MARKER = "acc:owned";
 // Ownership of single entries inside a container someone else also writes to.
 // `enabledPlugins` in a Claude Code settings file holds every plugin the user
@@ -150,10 +152,23 @@ export function jsonStyleOf(text) {
  * Unchanged content is not rewritten at all, so a second install touches
  * nothing. A file that does not exist yet is ACC's to create, and gets the
  * conventional trailing newline.
+ *
+ * What is there is edited rather than re-emitted. Reading the style back out of
+ * the file kept the indentation, and still reformatted everything the style
+ * could not describe: a nested object a person had written on one line came
+ * back as three, and a blank line between sections was gone. The bytes are
+ * theirs, and the diff ACC leaves should be of what it changed.
  */
 export async function writeForeignJson(file, value, { readFile, writeFile, mkdir }) {
   const current = await readFile(file, "utf8").catch(() => null);
-  const text = formatJsonAs(value, jsonStyleOf(current));
+  const style = jsonStyleOf(current);
+  // Null when the original cannot be read, or when the edit came back meaning
+  // something other than it was asked to write. Then this is the whole-file
+  // re-emit it has always been.
+  const spliced = typeof current === "string" ? editJson(current, value, style.indent) : null;
+  const text = spliced === null
+    ? formatJsonAs(value, style)
+    : (style.trailingNewline === false ? spliced : `${spliced}\n`);
   if (current === text) return false;
   await mkdir(path.dirname(file), { recursive: true });
   await writeFile(file, text);

--- a/packages/adapter-sdk/src/index.mjs
+++ b/packages/adapter-sdk/src/index.mjs
@@ -8,6 +8,7 @@ export { assertRunner, bakeSkillCommand, defaultCli, defaultRunner, removeInstal
 export { BEGIN, END, removeTomlBlock, renderBlock, stripBlock, tomlString, writeTomlBlock }
   from "./toml-block.mjs";
 export { projectContext } from "./context-projector.mjs";
+export { editJson, readJson } from "./json-text.mjs";
 export { formatJsonAs, jsonStyleOf, mergeOwnedConfig, mergeOwnedEntries, ownedEntries, ownedKeys,
   acccreatedFile, removeIfEmpty, removeOwnedConfig, removeOwnedEntries, writeForeignJson,
   blankJson, blankText } from "./config-merge.mjs";

--- a/packages/adapter-sdk/src/json-text.mjs
+++ b/packages/adapter-sdk/src/json-text.mjs
@@ -1,0 +1,195 @@
+/**
+ * Edit a JSON document as text, so what was not changed is not rewritten.
+ *
+ * `JSON.parse` then `JSON.stringify` re-emits every byte of a file, which
+ * reformats the parts ACC was not asked to touch: a nested object a person kept
+ * on one line comes back as three, and a blank line between sections is gone.
+ * The bytes are the user's, and a tool that edits their settings should leave a
+ * diff of what it changed rather than of how it prints.
+ *
+ * So the original text is kept and spliced. Anything whose value is unchanged is
+ * copied across verbatim - not re-serialised and hoped to match - and only a
+ * member that was added, removed or replaced is written fresh.
+ *
+ * The result is parsed back and compared to the value it was asked to write. A
+ * splice that would change meaning is discarded rather than written, and the
+ * caller falls back to plain `JSON.stringify`: the worst this can do is what
+ * was already being done.
+ */
+
+const WHITESPACE = " \t\n\r";
+const same = (left, right) => JSON.stringify(left) === JSON.stringify(right);
+
+const isObject = value =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+/**
+ * Read a JSON document into a tree that remembers where everything was.
+ *
+ * @returns the root node, or null for anything this cannot read - which the
+ * caller treats the same way as a file it must not touch.
+ */
+export function readJson(text) {
+  if (typeof text !== "string") return null;
+  let at = 0;
+
+  const skip = () => { while (at < text.length && WHITESPACE.includes(text[at])) at += 1; };
+  const fail = () => { throw new SyntaxError(`unreadable JSON at ${at}`); };
+  const expect = character => { if (text[at] !== character) fail(); at += 1; };
+
+  const readString = () => {
+    expect('"');
+    while (at < text.length) {
+      if (text[at] === "\\") { at += 2; continue; }
+      if (text[at] === '"') { at += 1; return; }
+      at += 1;
+    }
+    fail();
+  };
+
+  const readValue = () => {
+    skip();
+    const start = at;
+    if (text[at] === "{") return readObject(start);
+    if (text[at] === "[") return readArray(start);
+    if (text[at] === '"') { readString(); }
+    else {
+      // Numbers, true, false, null: read to the next structural character and
+      // let `JSON.parse` below be the judge of what was read.
+      while (at < text.length && !",}]".includes(text[at]) && !WHITESPACE.includes(text[at])) {
+        at += 1;
+      }
+      if (at === start) fail();
+    }
+    const slice = text.slice(start, at);
+    return { kind: "scalar", start, end: at, value: JSON.parse(slice) };
+  };
+
+  function readObject(start) {
+    expect("{");
+    const members = [];
+    const value = {};
+    for (;;) {
+      // Everything between the previous member and this one - the comma, the
+      // newline, the indentation - is kept as it was written.
+      const gapStart = at;
+      skip();
+      if (text[at] === "}") { at += 1; break; }
+      if (members.length > 0) { expect(","); skip(); }
+      if (text[at] === "}") { at += 1; break; }
+      const keyStart = at;
+      readString();
+      const key = JSON.parse(text.slice(keyStart, at));
+      skip();
+      expect(":");
+      const node = readValue();
+      members.push({ key, gapStart, keyStart, valueStart: node.start, end: node.end, node });
+      // Defined rather than assigned: `value.__proto__ = …` sets the prototype
+      // of an ordinary object instead of adding a key to it, so a config with
+      // that key read back without it - and the comparison that decides whether
+      // a subtree changed would be answering about a different document than
+      // the one on disk. This is what `JSON.parse` does with the same input.
+      Object.defineProperty(value, key,
+        { value: node.value, writable: true, enumerable: true, configurable: true });
+    }
+    return { kind: "object", start, end: at, value, members };
+  }
+
+  function readArray(start) {
+    expect("[");
+    const items = [];
+    const value = [];
+    for (;;) {
+      skip();
+      if (text[at] === "]") { at += 1; break; }
+      if (items.length > 0) { expect(","); skip(); }
+      if (text[at] === "]") { at += 1; break; }
+      const node = readValue();
+      items.push(node);
+      value.push(node.value);
+    }
+    return { kind: "array", start, end: at, value, items };
+  }
+
+  try {
+    const root = readValue();
+    skip();
+    // Trailing content means this is not the document it appears to be.
+    return at === text.length ? root : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write `value` into `text`, changing only what differs.
+ *
+ * @returns the edited document, or null when it cannot be done safely - an
+ * unreadable original, or a splice that came back meaning something else.
+ */
+export function editJson(text, value, indent) {
+  const root = readJson(text);
+  if (root === null) return null;
+
+  const unit = typeof indent === "number" ? " ".repeat(indent) : (indent ?? "  ");
+  const pad = depth => unit.repeat(depth);
+  const broken = unit !== "";
+
+  // A value with no original to preserve: printed the way this file prints,
+  // then moved to the depth it sits at.
+  const fresh = (subject, depth) => {
+    const printed = JSON.stringify(subject, null, unit);
+    return broken ? printed.split("\n").join(`\n${pad(depth)}`) : printed;
+  };
+
+  const render = (node, subject, depth) => {
+    if (node !== null && same(node.value, subject)) return text.slice(node.start, node.end);
+    if (node?.kind === "object" && isObject(subject)) return spliceObject(node, subject, depth);
+    return fresh(subject, depth);
+  };
+
+  function spliceObject(node, subject, depth) {
+    const byKey = new Map(node.members.map(member => [member.key, member]));
+    const pieces = [];
+
+    for (const key of Object.keys(subject)) {
+      const member = byKey.get(key);
+      if (member === undefined) {
+        // New: written in this file's own shape rather than copied from nowhere.
+        pieces.push(broken
+          ? `\n${pad(depth + 1)}${JSON.stringify(key)}: ${fresh(subject[key], depth + 1)}`
+          : `${JSON.stringify(key)}:${fresh(subject[key], depth + 1)}`);
+        continue;
+      }
+      // The separator that preceded it, the key as it was spelled, and the
+      // colon and spacing after it: all of it is the user's, and none of it is
+      // what changed.
+      const separator = text.slice(member.gapStart, member.keyStart);
+      const label = text.slice(member.keyStart, member.valueStart);
+      pieces.push(separator.replace(",", "") + label + render(member.node, subject[key], depth + 1));
+    }
+
+    // The comma belongs between members, so it is placed rather than copied:
+    // a member that used to be first no longer is, and one that is now first
+    // must not arrive with the comma it used to carry.
+    const body = pieces.join(",");
+    // What sat between the last member and the brace, when the last member is
+    // still the one that was there; otherwise this file's own closing shape.
+    const last = node.members.at(-1);
+    const closing = last !== undefined && Object.keys(subject).at(-1) === last.key
+      ? text.slice(last.end, node.end - 1)
+      : (broken ? `\n${pad(depth)}` : "");
+    if (pieces.length === 0) return "{}";
+    return `{${body}${closing}}`;
+  }
+
+  const edited = render(root, value, 0);
+  // The safety net. A splice that parses to something else is not written.
+  let read;
+  try {
+    read = JSON.parse(edited);
+  } catch {
+    return null;
+  }
+  return same(read, value) ? edited : null;
+}

--- a/packages/adapter-sdk/test/json-text.test.mjs
+++ b/packages/adapter-sdk/test/json-text.test.mjs
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { editJson, readJson } from "../src/json-text.mjs";
+
+/**
+ * Editing someone else's file.
+ *
+ * The style was already read back out of the file, which kept the indentation
+ * and reformatted everything the style could not describe. What a person writes
+ * is not only an indent: a nested object kept on one line, a blank line between
+ * sections, a space after a brace. None of it is ACC's to normalise.
+ */
+const settings = `{
+\t"theme": "dark",
+
+\t"mcpServers": {
+\t\t"mine": { "command": "my-server", "args": ["--fast"] }
+\t}
+}`;
+
+test("a document that has not changed is handed back exactly", () => {
+  assert.equal(editJson(settings, JSON.parse(settings), "\t"), settings);
+});
+
+test("adding a key leaves every other byte alone", () => {
+  const value = { ...JSON.parse(settings), hooks: { SessionStart: [] } };
+  const edited = editJson(settings, value, "\t");
+
+  // The parts nobody asked to change, still spelled the way they were written.
+  assert.match(edited, /\n\n\t"mcpServers"/, "the blank line went");
+  assert.match(edited, /"mine": \{ "command": "my-server", "args": \["--fast"\] \}/,
+    "a nested object written on one line came back expanded");
+  assert.match(edited, /\n\t"hooks": \{/, "the new key is not in the file's own indent");
+  // What is written fresh is written at the depth it sits at, not at column 0.
+  assert.match(edited, /\n\t\t"SessionStart"/, "a new nested value was left unindented");
+  assert.deepEqual(JSON.parse(edited), value);
+});
+
+test("removing what was added restores the file byte for byte", () => {
+  const original = JSON.parse(settings);
+  const installed = editJson(settings,
+    { ...original, "acc:owned": ["hooks"], hooks: { SessionStart: [] } }, "\t");
+
+  assert.equal(editJson(installed, original, "\t"), settings);
+});
+
+test("a member is removed without leaving the comma that held it", () => {
+  const text = '{\n  "a": 1,\n  "b": 2,\n  "c": 3\n}';
+
+  assert.equal(editJson(text, { b: 2, c: 3 }, "  "), '{\n  "b": 2,\n  "c": 3\n}');
+  assert.equal(editJson(text, { a: 1, c: 3 }, "  "), '{\n  "a": 1,\n  "c": 3\n}');
+  assert.equal(editJson(text, { a: 1, b: 2 }, "  "), '{\n  "a": 1,\n  "b": 2\n}');
+  assert.equal(editJson(text, {}, "  "), "{}");
+});
+
+test("a file written on one line is edited on one line", () => {
+  assert.equal(editJson('{"a":1}', { a: 1, b: 2 }, 0), '{"a":1,"b":2}');
+});
+
+test("only the value that changed is written again", () => {
+  // The object around it changed, so it is spliced rather than copied - and
+  // splicing keeps the shape it was written in.
+  assert.equal(editJson('{\n  "a": { "x": 1 },\n  "b": 2\n}', { a: { x: 9 }, b: 2 }, "  "),
+    '{\n  "a": { "x": 9 },\n  "b": 2\n}');
+});
+
+test("what cannot be read is refused rather than guessed at", () => {
+  // The caller falls back to re-emitting the whole file, which is what it did
+  // before this existed. Returning something half-understood would be worse
+  // than reformatting.
+  assert.equal(editJson("{ not json", { a: 1 }, "  "), null);
+  assert.equal(editJson('{\n  // a comment\n  "a": 1\n}', { a: 1, b: 2 }, "  "), null);
+  assert.equal(editJson('{"a":1} trailing', { a: 1 }, "  "), null);
+  assert.equal(readJson("[1, 2"), null);
+  assert.equal(readJson(undefined), null);
+});
+
+test("strings that contain the punctuation are not mistaken for it", () => {
+  const text = '{\n  "a": "}, \\" not the end",\n  "b": 2\n}';
+  const value = JSON.parse(text);
+
+  assert.deepEqual(readJson(text).value, value);
+  assert.equal(editJson(text, { ...value, c: 3 }, "  "),
+    '{\n  "a": "}, \\" not the end",\n  "b": 2,\n  "c": 3\n}');
+});
+
+test("every JSON scalar survives the round trip", () => {
+  const text = '{\n  "n": -1.5e3,\n  "t": true,\n  "f": false,\n  "z": null,\n  "e": []\n}';
+
+  assert.deepEqual(readJson(text).value,
+    { n: -1500, t: true, f: false, z: null, e: [] });
+  assert.equal(editJson(text, JSON.parse(text), "  "), text);
+});
+
+test("a key called __proto__ is a key, not an instruction", () => {
+  // Read into an ordinary object, `value["__proto__"] = …` sets the prototype
+  // rather than adding a member: the key disappeared from what was read, and
+  // `same()` would then be comparing against a document that is not on disk -
+  // answering "unchanged" for a subtree ACC had just been asked to change.
+  const text = '{\n  "__proto__": { "polluted": true },\n  "a": 1\n}';
+  const node = readJson(text);
+
+  // The contract in one line: what this reads is what `JSON.parse` reads.
+  assert.deepEqual(node.value, JSON.parse(text));
+  assert.deepEqual(Object.keys(node.value), ["__proto__", "a"]);
+  assert.equal({}.polluted, undefined, "reading a config changed every object");
+
+  const value = { ...JSON.parse(text), b: 2 };
+  assert.equal(editJson(text, value, "  "),
+    '{\n  "__proto__": { "polluted": true },\n  "a": 1,\n  "b": 2\n}');
+});

--- a/tests/security/installer.test.mjs
+++ b/tests/security/installer.test.mjs
@@ -125,6 +125,29 @@ test("install and uninstall restore a foreign config byte for byte", async t => 
   assert.equal(await readFile(path.join(home, "config.toml"), "utf8"), original);
 });
 
+test("install and uninstall restore a foreign JSON config byte for byte", async t => {
+  const { context, home } = await machine(t);
+  const adapter = ALL_ADAPTERS().find(item => item.id === "gemini_cli");
+  const settings = path.join(home, ".gemini", "settings.json");
+  // Written the way a person writes one, not the way a serialiser prints one:
+  // tabs, a blank line between sections, and a small object kept on its line.
+  const original = ["{", '\t"theme": "dark",', "",
+    '\t"mcpServers": {', '\t\t"mine": { "command": "my-server" }', "\t}", "}", ""].join("\n");
+  await mkdir(path.dirname(settings), { recursive: true });
+  await writeFile(settings, original);
+
+  await adapter.install(context);
+  const installed = await readFile(settings, "utf8");
+  assert.match(installed, /"mine": \{ "command": "my-server" \}/,
+    "an install reformatted a line it was not asked to touch");
+  assert.match(installed, /\n\n\t"mcpServers"/, "an install removed the user's blank line");
+
+  await adapter.uninstall(context);
+
+  // The claim the TOML test above makes, made for the other three clients too.
+  assert.equal(await readFile(settings, "utf8"), original);
+});
+
 /**
  * The user's own entries in a container ACC had to create.
  *


### PR DESCRIPTION
The follow-up named at the end of #55. ACC read a config's style back out of the file — indent character, trailing newline, one-line files — and then reprinted the whole document, which reformatted everything the style could not describe.

```diff
-		"mine": { "command": "my-server", "args": ["--fast"] }
+		"mine": {
+			"command": "my-server",
+			"args": [
+				"--fast"
+			]
+		}
```

A blank line between sections went the same way. The bytes are the user's, and the diff ACC leaves should be of what it changed, not of how it prints.

## The claim that was already being made

`tests/security/installer.test.mjs` has asserted a byte-for-byte round trip since before this, and `verify-package.mjs` prints `ok client config restored byte for byte` on every release. It was proved on **`config.toml`** — the JSON path was never held to it. It is now, with a file written the way a person writes one: tabs, a blank line, a nested object kept on its line.

## How

The original text is kept and spliced instead of re-serialised. A value that did not change is copied across verbatim — not printed again and hoped to match — and only a member that was added, removed or replaced is written fresh, in the file's own indent, at the depth it sits at.

`readJson` records where every value and every separator was. `editJson` walks the new value against it. The merges this serves are exactly three operations — add, remove, replace an object member at depth 1 or 2 — and the comma is placed between members rather than copied with them, so a member that used to be first does not arrive carrying one.

**The result is parsed back and compared to the value it was asked to write.** A splice that would change meaning is discarded and the caller re-emits the whole file, which is what it did before this existed. An unreadable original — JSONC, trailing content — takes the same path. The worst this can do is what was already being done.

## A prototype hazard, found on the way

```
parsed own keys:      [ 'a' ]
JSON.parse own keys:  [ '__proto__', 'a' ]
prototype touched?    true
```

Reading `{"__proto__": …}` set the prototype of the object being built instead of adding a key to it, so the key vanished from what was read. That matters beyond the missing key: the comparison deciding whether a subtree changed would be answering about a different document than the one on disk, and a change ACC needed to write could have been judged unnecessary. Defined rather than assigned now — what `JSON.parse` does with the same input.

## Verification

- 828 tests passing, 0 failing · `syntax ok in 175 file(s)`
- recorded: `sha256 144fba47…cf13bf` built from `47a9b24`

Eight mutations, seven caught by the test written for each:

| Mutation | Caught by |
|---|---|
| the splice never used | `install and uninstall restore a foreign JSON config byte for byte` |
| unchanged subtrees not copied verbatim | `adding a key leaves every other byte alone` |
| the comma left on a member that is now first | `a member is removed without leaving the comma that held it` |
| members no longer separated by a comma | four tests |
| trailing content accepted | `what cannot be read is refused rather than guessed at` |
| fresh values written at column zero | `adding a key leaves every other byte alone` |
| `__proto__` assigned instead of defined | `a key called __proto__ is a key, not an instruction` |
| **the safety net removed** | **nothing — see below** |

The survivor is honest rather than hidden: reaching that line requires the splicer to be wrong, and no test can produce that without introducing the defect it guards. It is a fallback, not a behaviour. Every path *into* it is covered — unreadable input, trailing content, JSONC — through the branch that returns null before it.
