### PR TITLE
release: 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,28 @@
 # Changelog
 
-## Unreleased
+## 0.1.1
+
+Four defects that 0.1.0 shipped with, all of them found by installing the
+published tarball and using it rather than by running the tests again. Every one
+of them survived because everything was green: the tests knew which command to
+run, the record's own gate watched the wrong set of files, an uninstall was
+planned from the wrong source, and the byte-for-byte claim was proved on a
+different file format than the one that broke it.
 
 | | |
 |---|---|
-| Built from | `47a9b24` |
-| Tarball | `agents-can-communicate-0.1.0.tgz`, 123 KB, 105 entries |
-| sha256 | `144fba47a46202f04320d063fb8e1630cd78c5935fab540fe0bf03fd80cf13bf` |
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
 | Tests | 828 passing, 0 failing |
+| Node | 24 (current production LTS) |
+| Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
+| Not supported | Windows — untested rather than known-broken |
 
-Not published. A published record says what the registry serves and is not
-rewritten, so shipped code that changes after a release is measured here instead.
+`acc --version` and `acc help` answer. Neither existed: the first two things a
+person types after installing from a registry were both "unknown command", and
+`acc` on its own asked for a command without naming one. The list is generated
+from the command table, so a command that exists is always listed.
 
 A config ACC edits is edited rather than reprinted. Reading the style back out
 of the file kept the indentation and still reformatted what the style could not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ different file format than the one that broke it.
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `de01634` |
+| Tarball | `agents-can-communicate-0.1.1.tgz`, 127 KB, 106 entries |
+| sha256 | `fbe2c3e0f169159af447e3a48428181b77e0cc89acbf3da5884d33db78a8bda7` |
 | Tests | 828 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -102,51 +102,51 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.1.0"
+      "version": "0.1.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "Model- and harness-agnostic coordination for independent AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-claude-code/plugin/.claude-plugin/plugin.json
+++ b/packages/adapter-claude-code/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Coordinate this Claude Code session with other AI agent sessions working in the same workspace: shared presence, resource claims, typed messages, and handoffs."
 }

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/plugin/.codex-plugin/plugin.json
+++ b/packages/adapter-codex/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Coordinate this Codex session with other AI agent sessions working in the same workspace.",
   "license": "UNLICENSED",
   "keywords": ["coordination", "multi-agent", "claims", "handoff"],

--- a/packages/adapter-gemini-cli/extension/gemini-extension.json
+++ b/packages/adapter-gemini-cli/extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Coordinate this Gemini CLI session with other AI agent sessions working in the same workspace.",
   "contextFileName": "skills/acc/SKILL.md"
 }

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/plugin/.kimi-plugin/plugin.json
+++ b/packages/adapter-kimi/plugin/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Coordinate this Kimi Code session with other AI agent sessions working in the same workspace: shared presence, resource claims, typed messages, and handoffs.",
   "skills": "./skills/",
   "sessionStart": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.mjs" },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Everything 0.1.0 shipped without. Publishing is one command against a merged `main`.

## What is in it

Four defects, all found by installing the published tarball and using it rather than by running the tests again — and every one of them survived because everything was green.

| | |
|---|---|
| #53 | `acc --version` and `acc help` were both "unknown command", in the package that was about to go on a public registry. Every test knew which command to run |
| #54 | The record's own gate did not watch `package.json`, which npm packs whatever `files` says. Editing the manifest moved the digest while every gate stayed green |
| #55 | An install could not be removed once its client left the machine. `acc uninstall` skipped exactly the client it had written to, reported success, and said so on every run afterwards |
| #56 | ACC reformatted configs it edited — a one-line nested object came back as three, a blank line went. Plus a `__proto__` key set the prototype instead of being read as a key |

Also in it: `--dry-run` on `acc uninstall`, and `uninstalled N adapter(s)` counting the adapters it changed rather than the ones it visited.

## The bump broke nothing

It broke five tests at 0.1.0, all of them spelling the cached plugin version by hand. They read it from the manifest that ships it since — this run is what proves that fix, and the gate from #54 is what noticed the seventeen manifests changing at all.

## Verified on the artifact, not in the tests

`npm pack`, `npm install -g` from the tgz, then the things this release claims:

```
1. acc --version       → 0.1.1
2. acc help            → 33 lines
3. uninstall --dry-run → would uninstall:
4. after install, the user's own settings.json
     one-line object: intact
     blank line:      intact
5. uninstall with the client removed from PATH
     uninstalled 1 adapter(s)
     acc paths left: 0
6. file restored byte for byte? yes
```

Step 5 is the #55 defect and step 4 the #56 one, exercised through the installed binary against a real client config.

## Record

```
PASS  agents-can-communicate-0.1.1.tgz  sha256 fbe2c3e0…a8bda7  built from de01634
```

127 KB, 106 entries. 828 tests passing, 0 failing · `syntax ok in 175 file(s)`.

0.1.0's entry in the changelog is left exactly as it was: it says what the registry serves, and a published record is not rewritten.

## After this merges

`npm publish` from `main`, then the tag and the GitHub release. Two-factor is `auth-and-writes` on this account, so it needs the token that is already in `~/.npmrc` — noted in `docs/RELEASING.md` since #54.
