### PR TITLE
fix: say what was written, and let the question be answered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `621bab2` |
+| Tarball | `agents-can-communicate-0.1.1.tgz`, 129 KB, 107 entries |
+| sha256 | `04d058e2e2b099a38eb27342335480438ee0bf1a43836787c31a44ce17263eab` |
 | Tests | 837 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## Unreleased
+
+| | |
+|---|---|
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
+| Tests | 837 passing, 0 failing |
+
+Not published. A published record says what the registry serves and is not
+rewritten, so shipped code that changes after a release is measured here instead.
+
+`acc install` says what it wrote. `installed 3 adapter(s)` was the whole account
+of a command that had just written into three other tools' configuration inside
+someone's home; the list existed all along, since `--dry-run` prints it, and the
+run that did the work printed a number. An uninstall says what it removed and
+what it held back, which is decided while it runs: bytes that stopped matching
+what ACC wrote are someone's, and are kept.
+
+`--yes` is gone from `acc install` and `acc uninstall`. Neither has ever asked
+anything, and the flag was read by no code at all - a promise that a
+confirmation exists to be skipped. It stays on `acc config init`, which does ask.
+
+`acc config init` can be answered. It had the code to ask, but no confirmation
+port was ever handed to it, so the question went to a fallback that always
+answered no: in a real terminal the command printed `not written` and never said
+why, and `--yes` - documented for runs with nobody to ask - was the only way to
+write the file. Verified against a pseudo-terminal: `y` writes, `n` does not,
+and closing the input is a refusal rather than an error. A build assembled
+without a way to ask now says so instead of declining on the reader's behalf.
+
+The README leads with `acc install` rather than `acc install --dry-run`. The
+preview is for scripts, for CI, and for anyone who wants to look first - not the
+first thing a person should have to run to install something.
+
+One test raced the clock. `the owner is told when its claim runs out` took a
+two-second lease, then asserted the expiry was not reported yet; under a loaded
+suite the turn began after the lease had already lapsed. The two halves hold
+separate leases now.
+
 ## 0.1.1
 
 Four defects that 0.1.0 shipped with, all of them found by installing the

--- a/README.md
+++ b/README.md
@@ -75,13 +75,21 @@ npm install -g agents-can-communicate
 
 Then wire up the clients you have:
 
+```bash
+acc install
+```
+
+It names every file it wrote, in your own home-relative paths, and how to undo it. Open your
+clients in the project afterwards — in one directory or in several worktrees — and work
+normally.
+
+If you would rather look before it writes, `acc install --dry-run` prints the same list and
+changes nothing. `acc uninstall` takes it all back out.
+
 <!-- test:command -->
 ```bash
 acc install --dry-run
 ```
-
-This prints every file it would touch. Run `acc install` to apply it, then open your clients
-in the project — in one directory or in several worktrees — and work normally.
 
 ## Commands
 

--- a/bin/acc.mjs
+++ b/bin/acc.mjs
@@ -3,7 +3,7 @@ import { randomBytes } from "node:crypto";
 import { readFile } from "node:fs/promises";
 
 import { createId } from "@agents-can-communicate/protocol";
-import { main } from "@agents-can-communicate/cli";
+import { askConfirmation, main } from "@agents-can-communicate/cli";
 
 // The composition root is the only place allowed to reach for ambient time and
 // randomness; everything below it receives them as ports.
@@ -15,6 +15,13 @@ const runtime = {
   stderr: process.stderr,
   clock: { now: () => new Date().toISOString() },
   ids: { next: kind => createId(kind, randomBytes) },
+  // Asked only by `acc config init`, and only when stdout is a terminal. There
+  // was no port here at all, so the question went to the fallback that always
+  // answers no: in a real terminal the command printed "not written" and never
+  // said why, and `--yes` - the flag documented for runs with nobody to ask -
+  // was the only way to write the file.
+  confirm: question => askConfirmation(question,
+    { input: process.stdin, output: process.stdout }),
   // Asked for only by `acc version`, so a package missing its own manifest
   // fails that one command rather than every command.
   version: async () => JSON.parse(

--- a/packages/cli/src/args.mjs
+++ b/packages/cli/src/args.mjs
@@ -56,11 +56,14 @@ export const COMMANDS = Object.freeze({
   // inside a handler that has already decided what to do.
   config: { required: [], optional: [], flags: ["yes", "force"],
     subcommands: ["init", "validate"] },
-  install: { required: [], optional: ["adapter", "home"], flags: ["dry-run", "yes"] },
+  // No `--yes`: neither of these ever asked, so the flag agreed to nothing. It
+  // was accepted and read by nobody, which is a promise that a confirmation
+  // exists to be skipped.
+  install: { required: [], optional: ["adapter", "home"], flags: ["dry-run"] },
   // `--dry-run` on both, because the preview was computed for either action and
   // only `install` could ask for it. Removal is the side that reaches into a
   // client's configuration - including a client that has left the machine.
-  uninstall: { required: [], optional: ["adapter", "home"], flags: ["dry-run", "yes"] },
+  uninstall: { required: [], optional: ["adapter", "home"], flags: ["dry-run"] },
   // The two things a person types first after installing from a registry. The
   // CLI answered neither: `acc --version` and `acc --help` were both "unknown
   // command", and `acc` on its own asked for a command without naming one.

--- a/packages/cli/src/confirm.mjs
+++ b/packages/cli/src/confirm.mjs
@@ -1,0 +1,33 @@
+import { once } from "node:events";
+import { createInterface } from "node:readline/promises";
+
+/**
+ * Ask a yes-or-no question and wait for the answer.
+ *
+ * A port rather than a call to the terminal, so the composition root hands it
+ * in and a test hands in two streams instead. There was no port at all:
+ * `runtime.confirm` fell back to a function that always answered no, so `acc
+ * config init` in a real terminal printed `not written` and never said why -
+ * and `--yes`, documented for runs with nobody to ask, was the only way to
+ * write the file.
+ *
+ * Anything that is not yes is no. A confirmation that reads a stray newline as
+ * agreement is not a confirmation.
+ */
+export async function askConfirmation(question, { input, output }) {
+  const dialogue = createInterface({ input, output });
+  try {
+    const asked = dialogue.question(`${question}\n[y/N] `);
+    // The input closing before an answer arrives is the reader leaving - Ctrl+D,
+    // or a pipe that ended - which is a refusal rather than a failure. Raced
+    // rather than caught: the question simply never settles on a stream that
+    // ends, so waiting for it alone hangs.
+    asked.catch(() => {});
+    const answer = await Promise.race([asked, once(dialogue, "close").then(() => "")]);
+    return /^y(es)?$/i.test(answer.trim());
+  } catch {
+    return false;
+  } finally {
+    dialogue.close();
+  }
+}

--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -1,6 +1,7 @@
 // Composition root: discovery, runtime locations, and the CLI surface.
 export { main } from "./main.mjs";
 export { COMMANDS, parseArgs } from "./args.mjs";
+export { askConfirmation } from "./confirm.mjs";
 // Exported so a test can hold every adapter to where it plans to write and
 // which binary decides it runs at all.
 export { ALL_ADAPTERS, clientContext } from "./install-command.mjs";

--- a/packages/cli/src/install-command.mjs
+++ b/packages/cli/src/install-command.mjs
@@ -60,11 +60,52 @@ function selectAdapters(requested) {
  * carries one per skipped adapter and the result one per failure - and only
  * `--json` ever showed them.
  */
-export function describeOutcome({ action, acted, failed = [], skipped = [] }) {
+const shorten = (file, home) =>
+  typeof home === "string" && home !== "" && file.startsWith(`${home}/`)
+    ? `~${file.slice(home.length)}`
+    : file;
+
+/**
+ * What one adapter did, path by path.
+ *
+ * `installed 3 adapter(s)` was the whole account of a command that had just
+ * written into three other tools' configuration inside someone's home. The list
+ * existed all along - it is what `--dry-run` prints - and the run that actually
+ * did the work printed a number.
+ *
+ * An install says what it wrote from the plan it carried out, in the same words
+ * the preview uses. An uninstall says what was removed and what was held back,
+ * because those are decided while it runs: bytes that stopped matching what ACC
+ * wrote are someone's now, and are kept.
+ */
+export function describeChanges(operation, home) {
+  const artifacts = operation.artifacts ?? [];
+  const edited = artifacts.filter(artifact => artifact.kind === "merge")
+    .map(artifact => `  edited  ${shorten(artifact.path, home)}`);
+  if (operation.action !== "uninstall") {
+    return [...artifacts.filter(artifact => artifact.kind !== "merge")
+      .map(artifact => `  created ${shorten(artifact.path, home)}`), ...edited];
+  }
+  return [
+    ...(operation.removed ?? []).map(file => `  removed ${shorten(file, home)}`),
+    ...edited,
+    ...(operation.kept ?? [])
+      .map(file => `  kept    ${shorten(file, home)} - changed since ACC wrote it`),
+  ];
+}
+
+export function describeOutcome({ action, acted, failed = [], skipped = [],
+  operations = [], home }) {
   return [`${action}ed ${acted} adapter(s)`
     + (failed.length > 0 ? `; ${failed.length} failed` : ""),
+  ...operations.filter(operation => operation.applied)
+    .flatMap(operation => describeChanges(operation, home)),
   ...skipped.map(entry => `  skip ${entry.adapterId}: ${entry.reason}`),
-  ...failed.map(entry => `  ${entry.adapterId}: ${entry.error}`)].join("\n");
+  ...failed.map(entry => `  ${entry.adapterId}: ${entry.error}`),
+  // Said once, where it is needed: the reader has just been shown a list of
+  // their own files with ACC's name in them.
+  ...(action === "install" && acted > 0 ? ["", "undo with: acc uninstall"] : []),
+  ].join("\n");
 }
 
 /**
@@ -123,6 +164,6 @@ export async function runInstallCommand({ options, runtime, action = "install" }
 
   return { data: { ...result, plan, dataHome },
     text: describeOutcome({ action, acted, failed: result.failed,
-      skipped: plan.skipped }),
+      skipped: plan.skipped, operations: result.operations, home }),
     error: failureOf({ action, acted, failed: result.failed }) };
 }

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -252,7 +252,12 @@ const HANDLERS = Object.freeze({
       // command demands --yes rather than hanging or assuming consent.
       interactive: runtime.stdout?.isTTY === true,
       yes: options.yes === true,
-      confirm: runtime.confirm ?? (async () => false),
+      // Not a silent no. A build that cannot ask says so: falling back to
+      // "declined" is how `acc config init` came to print `not written` in a
+      // terminal where nobody had been asked anything.
+      confirm: runtime.confirm ?? (async () => {
+        throw new AccError(EXIT.DATA, "this build was assembled without a way to ask");
+      }),
       force: options.force === true,
       // Opened lazily and only by `init`: `config validate` has to work on a
       // workspace discovery cannot open, which is what a reader runs it to

--- a/packages/cli/test/confirm.test.mjs
+++ b/packages/cli/test/confirm.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { PassThrough } from "node:stream";
+import test from "node:test";
+
+import { askConfirmation } from "../src/confirm.mjs";
+
+/**
+ * The question `acc config init` asks.
+ *
+ * There was no port for it, so `runtime.confirm` fell back to a function that
+ * always answered no: in a real terminal the command printed `not written` and
+ * never said why. Proved with a pseudo-terminal, and fixed by making the asking
+ * something a test can hold two streams up to.
+ */
+const ask = async answer => {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const heard = [];
+  output.on("data", chunk => heard.push(String(chunk)));
+
+  const pending = askConfirmation("write ./acc.workspace.json?", { input, output });
+  input.write(`${answer}\n`);
+  return { agreed: await pending, said: heard.join("") };
+};
+
+test("the question is put to the reader, and yes means yes", async () => {
+  const { agreed, said } = await ask("y");
+
+  assert.equal(agreed, true);
+  assert.match(said, /write \.\/acc\.workspace\.json\?/);
+  assert.match(said, /\[y\/N\]/, "the reader is not told which answers count");
+});
+
+test("anything that is not yes is no", async () => {
+  // A confirmation that reads a stray newline as agreement is not one. The
+  // default has to be the answer that writes nothing.
+  for (const [answer, expected] of [["y", true], ["Y", true], ["yes", true], ["YES", true],
+    [" yes ", true], ["", false], ["n", false], ["no", false], ["yep", false],
+    ["   ", false], ["ok", false]]) {
+    assert.equal((await ask(answer)).agreed, expected, JSON.stringify(answer));
+  }
+});
+
+test("a reader who closes the input has declined, not crashed", async () => {
+  // Ctrl+D, or a pipe that ended. Verified against a real terminal, where it
+  // used to come back as `Aborted with Ctrl+D` - an error report for somebody
+  // deciding not to.
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const pending = askConfirmation("write ./acc.workspace.json?", { input, output });
+  input.end();
+
+  assert.equal(await pending, false);
+});
+
+test("a build with no way to ask says so instead of answering for the reader", async t => {
+  const { main } = await import("../src/main.mjs");
+  const { mkdtemp, realpath, rm } = await import("node:fs/promises");
+  const { tmpdir } = await import("node:os");
+  const path = (await import("node:path")).default;
+
+  const cwd = await realpath(await mkdtemp(path.join(tmpdir(), "acc-ask-")));
+  const dataHome = await realpath(await mkdtemp(path.join(tmpdir(), "acc-ask-data-")));
+  t.after(() => Promise.all([cwd, dataHome].map(dir => rm(dir, { recursive: true, force: true }))));
+
+  const said = [];
+  const stream = list => ({ isTTY: true, write: (text, done) => { list.push(text); done(); } });
+  // No `confirm` port, and a terminal on the other end: the question would be
+  // asked of nobody. It used to be answered "no" on the reader's behalf and
+  // reported as `not written`, which reads like a decision they made.
+  const code = await main(["config", "init", "--cwd", cwd],
+    { cwd, env: { HOME: cwd, ACC_DATA_HOME: dataHome }, platform: process.platform,
+      stdout: stream(said), stderr: stream(said),
+      clock: { now: () => new Date().toISOString() }, ids: { next: kind => `${kind}_x` } });
+
+  assert.notEqual(code, 0);
+  assert.match(said.join(""), /without a way to ask/);
+});
+
+test("the binary hands the asking in", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const { fileURLToPath } = await import("node:url");
+  // The port is wired at the composition root, and nothing else here would
+  // notice it being dropped: every test above supplies its own streams.
+  const source = await readFile(
+    fileURLToPath(new URL("../../../bin/acc.mjs", import.meta.url)), "utf8");
+
+  assert.match(source, /confirm:/, "the CLI is built without a confirmation port");
+  assert.match(source, /askConfirmation/);
+});

--- a/packages/cli/test/install-command.test.mjs
+++ b/packages/cli/test/install-command.test.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { recordInstall } from "@agents-can-communicate/installer";
+import { EXIT } from "@agents-can-communicate/protocol";
 
 import { runInstallCommand } from "../src/install-command.mjs";
 
@@ -106,4 +107,62 @@ test("a removal can be previewed, the same way an install can", async t => {
   // The whole point of a preview.
   assert.equal((await readFile(path.join(extension, "gemini-extension.json"), "utf8"))
     .includes("acc"), true, "the dry run removed the thing it was previewing");
+});
+
+test("a command that wrote into someone's home says what it wrote", async () => {
+  const { describeOutcome } = await import("../src/install-command.mjs");
+  const home = "/Users/someone";
+  const text = describeOutcome({ action: "install", acted: 1, home, operations: [{
+    adapterId: "claude_code", action: "install", applied: true, artifacts: [
+      { path: `${home}/.claude/plugins/cache/acc-local`, kind: "tree" },
+      { path: `${home}/.claude/settings.json`, kind: "merge" }] }] });
+
+  // `installed 1 adapter(s)` was the whole account of a command that had just
+  // written into another tool's configuration inside someone's home.
+  assert.equal(text, ["installed 1 adapter(s)",
+    "  created ~/.claude/plugins/cache/acc-local",
+    "  edited  ~/.claude/settings.json",
+    "",
+    "undo with: acc uninstall"].join("\n"));
+});
+
+test("an uninstall says what it removed and what it would not", async () => {
+  const { describeOutcome } = await import("../src/install-command.mjs");
+  const home = "/Users/someone";
+  const text = describeOutcome({ action: "uninstall", acted: 1, home, operations: [{
+    adapterId: "claude_code", action: "uninstall", applied: true,
+    artifacts: [{ path: `${home}/.claude/settings.json`, kind: "merge" }],
+    removed: [`${home}/.claude/plugins/cache/acc-local`],
+    kept: [`${home}/.claude/plugins/marketplaces/acc-local`] }] });
+
+  // What was held back is the line that matters: those bytes stopped matching
+  // what ACC wrote, so they are someone's now and were left alone.
+  assert.equal(text, ["uninstalled 1 adapter(s)",
+    "  removed ~/.claude/plugins/cache/acc-local",
+    "  edited  ~/.claude/settings.json",
+    "  kept    ~/.claude/plugins/marketplaces/acc-local - changed since ACC wrote it",
+  ].join("\n"));
+});
+
+test("nothing done is still reported as nothing done", async () => {
+  const { describeOutcome } = await import("../src/install-command.mjs");
+
+  assert.equal(describeOutcome({ action: "uninstall", acted: 0, operations: [
+    { adapterId: "kimi", action: "uninstall", applied: true, artifacts: [],
+      removed: [], kept: [] }],
+    skipped: [{ adapterId: "gemini_cli", reason: "Gemini CLI is not installed" }] }),
+  ["uninstalled 0 adapter(s)",
+    "  skip gemini_cli: Gemini CLI is not installed"].join("\n"));
+});
+
+test("`--yes` is gone from the commands that never asked", async () => {
+  const { parseArgs } = await import("../src/args.mjs");
+  // It agreed to nothing: neither command has ever had a confirmation to skip,
+  // and the flag was read by no code at all.
+  for (const command of ["install", "uninstall"]) {
+    assert.throws(() => parseArgs([command, "--yes"]),
+      error => error.code === EXIT.USAGE && error.message.includes("--yes"), command);
+  }
+  // `config init` does ask, so there it still means something.
+  assert.equal(parseArgs(["config", "init", "--yes"]).options.yes, true);
 });

--- a/tests/process/lapsed-claim.test.mjs
+++ b/tests/process/lapsed-claim.test.mjs
@@ -49,11 +49,17 @@ async function workspace(t) {
 test("the owner is told when its claim runs out", async t => {
   const place = await workspace(t);
   await place.attach("holder");
+  // Two leases, because the two halves want opposite things from the clock. The
+  // first used to share the two-second lease with the second and raced it: under
+  // a loaded suite the turn started after the lease had already lapsed, and the
+  // test failed saying the report came too early.
+  await place.cli("claim", "--resource", "file:src/held.mjs", "--reason", "editing",
+    "--lease", "600");
+  assert.equal((await place.turn("holder")).includes("claim_expired"), false,
+    "reported while the claim was still held");
+
   await place.cli("claim", "--resource", "file:src/x.mjs", "--reason", "editing",
     "--lease", "2");
-  assert.equal((await place.turn("holder")).includes("claim_expired"), false,
-    "reported before the lease had run out");
-
   await place.lapse();
 
   assert.match(await place.turn("holder"),

--- a/tests/security/broken-client-config.test.mjs
+++ b/tests/security/broken-client-config.test.mjs
@@ -47,7 +47,7 @@ async function home(t, { broken } = {}) {
     await mkdir(path.join(place, path.dirname(broken)), { recursive: true });
     await writeFile(path.join(place, broken), BROKEN);
   }
-  const cli = (...argv) => run(process.execPath, [acc, ...argv, "--home", place, "--yes"],
+  const cli = (...argv) => run(process.execPath, [acc, ...argv, "--home", place],
     { env });
   const ours = async () => (await readdir(place, { recursive: true }))
     .filter(entry => entry.includes("agents-can-communicate"));


### PR DESCRIPTION
Mykola asked why the README opens with `acc install --dry-run` — what does a person need a preview for? The honest answer was that nothing else would tell them what happened.

## What was actually wrong

```
$ acc install
installed 3 adapter(s)          ← after writing into three tools' config in your home
```

The list existed all along; `--dry-run` prints it. The run that did the work printed a number, so the README had to send people through a preview first to see anything.

**And `--yes` was read by no code at all.** Neither `install` nor `uninstall` has ever asked anything, so the flag promised a confirmation that does not exist.

**Meanwhile the one command that does ask could not be answered.** `acc config init` has the asking, but no confirmation port was ever handed in, so `runtime.confirm` fell back to `async () => false`. Proved on a pseudo-terminal:

```
$ acc config init
not written: …/acc.workspace.json     ← nothing was asked; the answer was given for you
```

`--yes` — documented for runs with nobody to ask — was the only way to write the file.

## Now

```
$ acc install
installed 3 adapter(s)
  created ~/.claude/plugins/cache/acc-local
  edited  ~/.claude/settings.json
  created ~/.codex/plugins/cache/acc-local
  edited  ~/.codex/config.toml
  …
  skip gemini_cli: Gemini CLI is not installed on this machine

undo with: acc uninstall
```

An uninstall says what it removed **and what it held back** — bytes that stopped matching what ACC wrote are someone else's, and are kept:

```
  removed ~/.claude/plugins/cache/acc-local
  kept    ~/.claude/plugins/marketplaces/acc-local - changed since ACC wrote it
```

`acc config init` asks, and the answer counts. Verified on a real terminal, not in theory:

```
  y      → wrote SANDBOX/y/acc.workspace.json · created
  n      → not written                        · none
  Ctrl+D → not written                        · none
```

Closing the input used to come back as `Aborted with Ctrl+D` — an error report for somebody deciding not to. The silent fallback is gone: a build assembled without a way to ask says so rather than declining on the reader's behalf.

The README leads with `acc install`. The preview is for scripts, CI, and anyone who wants to look first — not the first thing a person runs to install something.

## Compatibility

`acc install --yes` and `acc uninstall --yes` become usage errors. They are documented nowhere — `docs/CONFIGURATION.md` mentions `--yes` only for `config init`, where it still works — and no shipped skill teaches them. One test passed it; nothing else in the repo did. Anyone's private script that passes it will need it dropped.

## A test that raced the clock

Adding these tests made the suite heavier and `the owner is told when its claim runs out` began failing — consistently in the full run, passing alone:

```
AssertionError: reported before the lease had run out
```

It took a two-second lease and then asserted the expiry was not reported *yet*; under load the turn started after the lease had already lapsed. Its two halves hold separate leases now — one long enough that no load outruns it, one short enough to lapse. Not caused by this change, but surfaced by it, and it would have gone red on CI.

## Verification

- 837 tests passing, 0 failing · `syntax ok in 177 file(s)`
- recorded: `sha256 04d058e2…263eab` built from `621bab2`

Seven mutations, every one caught:

| Mutation | Caught by |
|---|---|
| the report goes back to a count | `a command that wrote into someone's home says what it wrote` |
| home paths no longer shortened | same |
| what was kept no longer mentioned | `an uninstall says what it removed and what it would not` |
| `--yes` accepted again | `` `--yes` is gone from the commands that never asked `` |
| any answer taken as yes | `anything that is not yes is no` |
| the missing port answers no again | `a build with no way to ask says so instead of answering for the reader` |
| the port dropped from the binary | `the binary hands the asking in` |

The last two close the gap that let this defect live: the asking is a port in `packages/cli` that a test holds two streams up to, and the wiring at the composition root is asserted separately.
