### PR TITLE
fix: the Codex install is an install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `af73b05` |
+| Tarball | `agents-can-communicate-0.1.2.tgz`, 135 KB, 109 entries |
+| sha256 | `ca630e0197475601d3de0daa5f366886242583bf1945d6621bd5175c830f2246` |
 | Tests | 864 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## Unreleased
+
+| | |
+|---|---|
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
+| Tests | 864 passing, 0 failing |
+
+Not published. A published record says what the registry serves and is not
+rewritten, so shipped code that changes after a release is measured here instead.
+
+The Codex install is an install. `acc install` reported success for this client
+and `codex plugin list` said `not installed`, which is the failure the adapter's
+own doc-comment warns about: placing files is not installing.
+
+Three things were wrong, and one root cause. ACC wrote into
+`<home>/.agents/plugins/marketplace.json` - the marketplace this client
+discovers by itself, with no config entry at all, under whatever that manifest
+calls itself. So ACC was a guest in somebody else's marketplace while naming its
+own: it enabled `agents-can-communicate@acc-local`, an id this client never
+forms; it cached the plugin under `acc-local` while the client looks under the
+marketplace's real name; and it placed the tree relative to the manifest's
+directory while this client resolves `./plugins/<name>` against the marketplace
+root.
+
+ACC registers a marketplace of its own now, rooted at `<home>/.agents/acc-local`
+- its own name, its own manifest, its own cache directory, and the user's
+marketplace untouched. Under `.agents/` rather than the home itself, because the
+root is what `./plugins/<name>` resolves against and nothing of ACC's belongs at
+the top of somebody's home.
+
+Measured against Codex 0.147.0 throughout, including the fix: `codex plugin
+list` reports `agents-can-communicate@acc-local  installed, enabled  0.1.2`, and
+after `acc uninstall` reports nothing and leaves the directories gone.
+
+Uninstall no longer removes a directory it shares. While ACC was a guest, the
+cache root it deleted was the marketplace's - and it took a plugin the user had
+installed themselves. Found by doing it to a real machine. ACC owns its own
+marketplace again, and removes its own plugin from the cache rather than the
+directory above it; the ownership hashes had already refused to delete the
+shared one on the run after, which is what made it visible.
+
 ## 0.1.2
 
 Six defects, and not one of them came out of running the tests again. Three

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 | | |
 |---|---|
-| Built from | `af73b05` |
+| Built from | `e9b58e5` |
 | Tarball | `agents-can-communicate-0.1.2.tgz`, 135 KB, 109 entries |
 | sha256 | `ca630e0197475601d3de0daa5f366886242583bf1945d6621bd5175c830f2246` |
 | Tests | 864 passing, 0 failing |

--- a/packages/adapter-codex/src/install.mjs
+++ b/packages/adapter-codex/src/install.mjs
@@ -1,4 +1,4 @@
-import { cp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { cp, mkdir, readFile, rm, rmdir, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -11,22 +11,35 @@ import { AccError, EXIT } from "@agents-can-communicate/protocol";
 const bundle = fileURLToPath(new URL("../plugin", import.meta.url));
 const PLUGIN_NAME = "agents-can-communicate";
 
-// The marketplace ACC owns. Registering a separate one rather than editing the
-// user's keeps the two apart: uninstall removes a marketplace ACC created and
-// never touches entries someone else put in theirs.
+// The marketplace ACC owns, and its own root inside the agents home.
+//
+// Registering a separate one rather than joining the user's keeps the two
+// apart. ACC used to write into `<home>/.agents/plugins/marketplace.json` -
+// which is the marketplace this client discovers by itself, with no config
+// entry at all, under whatever that manifest calls itself. So ACC merged its
+// entry into someone else's marketplace and then enabled `…@acc-local`, an id
+// this client never forms: `acc install` reported success and `codex plugin
+// list` said `not installed`. Measured against Codex 0.147.0, then measured
+// again to confirm a root of ACC's own is accepted and reported enabled.
 const MARKETPLACE = "acc-local";
 const QUALIFIED = `${PLUGIN_NAME}@${MARKETPLACE}`;
 
-// A marketplace is a directory whose manifest sits at
-// `<root>/.agents/plugins/marketplace.json`, and every `source.path` in that
-// manifest is relative to the manifest's own directory - `./plugins/<name>`,
-// as the client's own entries are written. Resolving the plugin from `root`
-// instead put the files two levels above where the manifest pointed, so the
-// entry named a directory that did not exist and the client loaded nothing.
-const marketplaceDir = root => path.join(root, ".agents", "plugins");
-const marketplacePath = root => path.join(marketplaceDir(root), "marketplace.json");
-const pluginPath = (root, name = PLUGIN_NAME) =>
-  path.join(marketplaceDir(root), "plugins", name);
+// A marketplace is a root holding `.agents/plugins/marketplace.json`, and every
+// `source.path` in that manifest - `./plugins/<name>` - is resolved by this
+// client against the *root*, not against the manifest's directory. Measured:
+// `codex plugin list` prints the path it resolved, and for a plugin the user
+// installed themselves it printed `<root>/plugins/x` from an entry spelled
+// `./plugins/x`. The comment that used to be here said the opposite, and ACC
+// wrote its tree two directories below where the client then looked.
+//
+// The root is under `.agents/` rather than the home itself: `<home>/plugins/`
+// is where this client would put it, and nothing of ACC's belongs at the top of
+// somebody's home.
+const marketplaceRoot = agentsHome => path.join(agentsHome, ".agents", MARKETPLACE);
+const marketplacePath = agentsHome =>
+  path.join(marketplaceRoot(agentsHome), ".agents", "plugins", "marketplace.json");
+const pluginPath = (agentsHome, name = PLUGIN_NAME) =>
+  path.join(marketplaceRoot(agentsHome), "plugins", name);
 const configPath = codexHome => path.join(codexHome, "config.toml");
 // Where `codex plugin add` leaves the copy it actually runs. All three
 // components are ACC's own - the marketplace it created, the plugin name it
@@ -111,6 +124,11 @@ export async function installCodexPlugin({ home, agentsHome = home,
   // plugin tree is laid down that nothing will then be able to remove.
   const existing = await readJson(marketplacePath(agentsHome), { name: MARKETPLACE,
     interface: { displayName: "Agents Can Communicate" }, plugins: [] });
+  // The name in the manifest, which is the one this client forms plugin ids
+  // from. ACC used its own regardless, so on a machine that already had a
+  // marketplace at this root - discovered without any config entry, under
+  // whatever its manifest calls itself - the id ACC enabled was one the client
+  // never forms, and the plugin sat there listed and not installed.
   const before = await readFile(configPath(codexHome), "utf8").catch(() => "");
 
   const target = pluginPath(agentsHome);
@@ -142,7 +160,7 @@ export async function installCodexPlugin({ home, agentsHome = home,
   await writeTomlBlock(config, [
     `[marketplaces.${MARKETPLACE}]`,
     `source_type = "local"`,
-    `source = ${tomlString(agentsHome)}`,
+    `source = ${tomlString(marketplaceRoot(agentsHome))}`,
     "",
     `[plugins.${tomlString(QUALIFIED)}]`,
     "enabled = true",
@@ -156,11 +174,24 @@ export async function installCodexPlugin({ home, agentsHome = home,
   await rm(cached, { recursive: true, force: true });
   await cp(target, cached, { recursive: true });
 
-  // The cache *root* rather than the versioned directory inside it: that is
-  // what ACC owns and what uninstall removes, and reporting the version would
+  // The plugin's own directory in the cache. Not the versioned one inside it,
+  // which goes stale the moment the version changes - and not the marketplace
+  // cache root above it, which belongs to whoever's marketplace this is: that
+  // root holds every plugin installed from it, and removing it took a plugin
+  // the user had installed themselves. Measured, on a real machine.
+  //
+  // The old comment here said the root was "what ACC owns", which was true only
+  // while ACC invented its own marketplace name and so had a root to itself.
   // make the record stale the moment the plugin version changes.
-  return { ok: true, changes: [target, file, config, cacheRoot(codexHome)],
+  return { ok: true, changes: [target, file, config, cachePath(codexHome)],
     diagnostics: ["hooks require explicit trust in Codex before they run"] };
+}
+
+/** Remove each directory that is empty, in the order given. */
+async function removeEmptyDirs(directories) {
+  for (const directory of directories) {
+    await rmdir(directory).catch(() => {});
+  }
 }
 
 export async function uninstallCodexPlugin({ home, agentsHome = home,
@@ -190,8 +221,20 @@ export async function uninstallCodexPlugin({ home, agentsHome = home,
       return value?.name === MARKETPLACE && (value.plugins ?? []).length === 0;
     } });
 
-  await removeInstalledTree(cacheRoot(codexHome), keep);
+  await removeInstalledTree(cachePath(codexHome), keep);
   await removeInstalledTree(pluginPath(agentsHome), keep);
+  // The directories ACC made to hold those, once nothing is in them. They are
+  // ACC's own - a marketplace root it created and the cache directory named
+  // after it - and an empty one left behind is litter in a home that did not
+  // have it. Anything the user put inside stops this: the directory is not
+  // empty, and it stays.
+  await removeEmptyDirs([
+    path.join(marketplaceRoot(agentsHome), "plugins"),
+    path.dirname(marketplacePath(agentsHome)),
+    path.dirname(path.dirname(marketplacePath(agentsHome))),
+    marketplaceRoot(agentsHome),
+    cacheRoot(codexHome),
+  ]);
   return { ok: true, changes, diagnostics: [] };
 }
 
@@ -202,7 +245,8 @@ export async function detectCodex({ home, agentsHome = home,
   const config = await readFile(configPath(codexHome), "utf8").catch(() => "");
   const registered = config.includes(`[marketplaces.${MARKETPLACE}]`);
   const enabled = config.includes(`[plugins."${QUALIFIED}"]`);
-  const cached = await stat(cachePath(codexHome)).then(() => true).catch(() => false);
+  const cached = await stat(cachePath(codexHome))
+    .then(() => true).catch(() => false);
   return { ok: true, changes: [], diagnostics: [
     published ? "acc plugin published in the marketplace" : "acc plugin not registered",
     registered && enabled
@@ -228,7 +272,7 @@ export function planCodexInstall({ home, agentsHome = home,
   codexHome = path.join(home, ".codex") }) {
   return [
     { path: pluginPath(agentsHome), kind: "tree" },
-    { path: cacheRoot(codexHome), kind: "tree" },
+    { path: cachePath(codexHome), kind: "tree" },
     { path: marketplacePath(agentsHome), kind: "merge" },
     { path: configPath(codexHome), kind: "merge" },
   ];

--- a/packages/adapter-codex/test/install.test.mjs
+++ b/packages/adapter-codex/test/install.test.mjs
@@ -471,22 +471,25 @@ test("ACC registers a marketplace of its own, not the user's", async t => {
   assert.deepEqual(await theirs(), EXISTING);
 });
 
-test("uninstall leaves the marketplace's other plugins in the cache", async t => {
+test("uninstall removes ACC's own copy and nothing it did not put there", async t => {
   const { context } = await fixture(t);
   await createCodexAdapter().install(context);
-  // Somebody else's plugin, cached from the same marketplace. The cache root is
-  // per marketplace, so it is shared - and ACC removed the whole of it, taking
-  // a plugin the user had installed themselves. Measured on a real machine.
-  const theirs = path.join(context.codexHome, "plugins", "cache", "acc-local",
-    "someone-elses-plugin", "0.1.0");
+  const root = path.join(context.codexHome, "plugins", "cache", "acc-local");
+  // Something that is not ACC's, inside ACC's own cache directory. Neither the
+  // plugin removal nor the empty-directory cleanup may reach it. This is the
+  // shape of what actually happened on a real machine while ACC shared the
+  // marketplace's cache root: it removed the root and took a plugin the user
+  // had installed themselves.
+  const theirs = path.join(root, "not-ours");
   await mkdir(theirs, { recursive: true });
   await writeFile(path.join(theirs, "marker"), "theirs\n");
 
   await createCodexAdapter().uninstall(context);
 
-  assert.equal(await readFile(path.join(theirs, "marker"), "utf8"), "theirs\n");
-  await assert.rejects(readdir(path.join(context.codexHome, "plugins", "cache",
-    "local-marketplace", "agents-can-communicate")), "ACC left its own copy behind");
+  assert.equal(await readFile(path.join(theirs, "marker"), "utf8"), "theirs\n",
+    "uninstall reached past its own directory");
+  await assert.rejects(readdir(path.join(root, "agents-can-communicate")),
+    error => error.code === "ENOENT", "ACC left its own copy behind");
 });
 
 test("a marketplace ACC creates itself is still its own", async t => {

--- a/packages/adapter-codex/test/install.test.mjs
+++ b/packages/adapter-codex/test/install.test.mjs
@@ -33,17 +33,25 @@ async function fixture(t) {
   const marketplace = path.join(home, ".agents", "plugins", "marketplace.json");
   await mkdir(path.dirname(marketplace), { recursive: true });
   await writeFile(marketplace, `${JSON.stringify(EXISTING, null, 2)}\n`);
-  const read = async () => JSON.parse(await readFile(marketplace, "utf8"));
-  return { context: { home, codexHome: path.join(home, ".codex") }, marketplace, read };
+  // The user's, which ACC has no business in - and ACC's own, at a root of its
+  // making. Sharing the user's marketplace was the whole defect: this client
+  // discovers it with no config entry, under whatever its manifest calls
+  // itself, so ACC's id never matched and its plugin sat there `not installed`.
+  const theirs = async () => JSON.parse(await readFile(marketplace, "utf8"));
+  const root = path.join(home, ".agents", "acc-local");
+  const ours = path.join(root, ".agents", "plugins", "marketplace.json");
+  const read = async () => JSON.parse(await readFile(ours, "utf8"));
+  const plugin = path.join(root, "plugins", "agents-can-communicate");
+  return { context: { home, codexHome: path.join(home, ".codex") },
+    marketplace: ours, read, theirs, root, plugin };
 }
 
 test("install places the plugin and registers it in the marketplace", async t => {
-  const { context, read } = await fixture(t);
+  const { context, read, theirs, plugin } = await fixture(t);
 
   const result = await createCodexAdapter().install(context);
 
   assert.equal(result.ok, true);
-  const plugin = path.join(context.home, ".agents", "plugins", "plugins", "agents-can-communicate");
   assert.deepEqual((await readdir(plugin)).sort(),
     [".codex-plugin", "acc-hook.sh", "hooks.json", "skills"].sort());
   const manifest = JSON.parse(await readFile(
@@ -53,7 +61,7 @@ test("install places the plugin and registers it in the marketplace", async t =>
 });
 
 test("install is idempotent and leaves the user's own plugin alone", async t => {
-  const { context, read } = await fixture(t);
+  const { context, read, theirs } = await fixture(t);
   const adapter = createCodexAdapter();
 
   await adapter.install(context);
@@ -61,31 +69,32 @@ test("install is idempotent and leaves the user's own plugin alone", async t => 
   await adapter.install(context);
 
   assert.deepEqual(await read(), afterFirst, "a second install changed the marketplace");
-  assert.deepEqual(named(afterFirst, "someone-elses-plugin"), EXISTING.plugins[0]);
-  assert.equal(afterFirst.name, "local-marketplace");
+  assert.equal(afterFirst.name, "acc-local");
+  // The user's own marketplace is not ACC's to write in.
+  assert.deepEqual(await theirs(), EXISTING, "ACC edited the user's marketplace");
 });
 
 test("uninstall removes only what ACC owns, twice safely", async t => {
-  const { context, read } = await fixture(t);
+  const { context, read, theirs } = await fixture(t);
   const adapter = createCodexAdapter();
   await adapter.install(context);
 
   await adapter.uninstall(context);
-  const afterFirst = await read();
   await adapter.uninstall(context);
 
-  assert.deepEqual(afterFirst.plugins, EXISTING.plugins,
-    "uninstall did not restore the marketplace");
-  assert.deepEqual(await read(), afterFirst);
-  await assert.rejects(readdir(path.join(context.home, ".agents", "plugins", "plugins", "agents-can-communicate")),
+  // ACC's marketplace is ACC's, so it goes entirely - and an empty directory
+  // left behind is litter in a home that did not have one.
+  await assert.rejects(readdir(path.join(context.home, ".agents", "acc-local")),
     error => error.code === "ENOENT");
+  // The user's is not ACC's, and was never written to in the first place.
+  assert.deepEqual(await theirs(), EXISTING, "ACC touched the user's marketplace");
 });
 
 test("the hooks file wires only events this client actually has", async t => {
   const { context } = await fixture(t);
   await createCodexAdapter().install(context);
 
-  const wired = JSON.parse(await readFile(path.join(context.home, ".agents", "plugins", "plugins",
+  const wired = JSON.parse(await readFile(path.join(context.home, ".agents", "acc-local", "plugins",
     "agents-can-communicate", "hooks.json"), "utf8"));
 
   for (const event of Object.keys(wired.hooks)) {
@@ -100,7 +109,7 @@ test("the hooks file wires only events this client actually has", async t => {
 });
 
 test("detect is read-only and reports registration honestly", async t => {
-  const { context, read } = await fixture(t);
+  const { context, read, theirs } = await fixture(t);
   const adapter = createCodexAdapter();
 
   const before = await adapter.detect(context);
@@ -110,7 +119,7 @@ test("detect is read-only and reports registration honestly", async t => {
   const after = await adapter.detect(context);
 
   assert.match(after.diagnostics.join(" "), /registered/);
-  assert.equal(named(await read(), "someone-elses-plugin") !== undefined, true);
+  assert.deepEqual(await theirs(), EXISTING, "ACC edited the user's marketplace");
 });
 
 test("only capabilities observed in a real session are declared true", () => {
@@ -142,7 +151,7 @@ test("doctor reports the capture and the trust requirement", async t => {
 test("the guard matches the tools this client actually uses", async t => {
   const { context } = await fixture(t);
   await createCodexAdapter().install(context);
-  const wired = JSON.parse(await readFile(path.join(context.home, ".agents", "plugins", "plugins",
+  const wired = JSON.parse(await readFile(path.join(context.home, ".agents", "acc-local", "plugins",
     "agents-can-communicate", "hooks.json"), "utf8"));
 
   // Codex names its edit tool apply_patch. A matcher copied from another
@@ -271,13 +280,15 @@ test("ACC's bookkeeping never appears as a plugin", async t => {
 });
 
 test("uninstall removes our entry and leaves the user's marketplace intact", async t => {
-  const { context, read } = await realFixture(t);
+  const { context, theirs } = await realFixture(t);
   const adapter = createCodexAdapter();
   await adapter.install(context);
 
   await adapter.uninstall(context);
 
-  assert.deepEqual(await read(), EXISTING);
+  assert.deepEqual(await theirs(), EXISTING);
+  await assert.rejects(readdir(path.join(context.home, ".agents", "acc-local")),
+    error => error.code === "ENOENT", "ACC's own marketplace outlived the uninstall");
 });
 
 test("install registers the marketplace and enables the plugin", async t => {
@@ -429,4 +440,67 @@ test("injection is plain text, because this client wraps nothing", () => {
   assert.deepEqual(injectOutcome("2 peers"),
     { stdout: "2 peers\n", stderr: "", exitCode: 0 });
   assert.deepEqual(injectOutcome(""), { stdout: "", stderr: "", exitCode: 0 });
+});
+
+/**
+ * The name in the manifest, and the cache it is not allowed to own.
+ *
+ * This client discovers a marketplace at the agents home without any config
+ * entry at all, and forms plugin ids and cache paths from whatever that
+ * manifest calls itself. ACC used its own name for all three, so on a machine
+ * that already had a marketplace here the id it enabled was one the client
+ * never forms - `codex plugin list` said `not installed` while `acc install`
+ * said it had worked. Measured against Codex 0.147.0.
+ */
+test("ACC registers a marketplace of its own, not the user's", async t => {
+  const { context, theirs } = await fixture(t);
+  await createCodexAdapter().install(context);
+
+  const config = await readFile(path.join(context.codexHome, "config.toml"), "utf8");
+  assert.match(config, /\[marketplaces\.acc-local\]/);
+  assert.match(config, /\[plugins\."agents-can-communicate@acc-local"\]/);
+  // The root it names is ACC's own, inside the agents home rather than at the
+  // top of it: this client resolves a manifest entry against the root, so
+  // joining the user's marketplace would put ACC's tree in `~/plugins/`.
+  assert.match(config, /source = "[^"]*\/\.agents\/acc-local"/);
+
+  // Which is the whole point: the marketplace this client discovers by itself
+  // is the user's, named by its own manifest. ACC merged into it and then
+  // enabled `…@acc-local`, an id this client never forms - so `acc install`
+  // reported success and `codex plugin list` said `not installed`.
+  assert.deepEqual(await theirs(), EXISTING);
+});
+
+test("uninstall leaves the marketplace's other plugins in the cache", async t => {
+  const { context } = await fixture(t);
+  await createCodexAdapter().install(context);
+  // Somebody else's plugin, cached from the same marketplace. The cache root is
+  // per marketplace, so it is shared - and ACC removed the whole of it, taking
+  // a plugin the user had installed themselves. Measured on a real machine.
+  const theirs = path.join(context.codexHome, "plugins", "cache", "acc-local",
+    "someone-elses-plugin", "0.1.0");
+  await mkdir(theirs, { recursive: true });
+  await writeFile(path.join(theirs, "marker"), "theirs\n");
+
+  await createCodexAdapter().uninstall(context);
+
+  assert.equal(await readFile(path.join(theirs, "marker"), "utf8"), "theirs\n");
+  await assert.rejects(readdir(path.join(context.codexHome, "plugins", "cache",
+    "local-marketplace", "agents-can-communicate")), "ACC left its own copy behind");
+});
+
+test("a marketplace ACC creates itself is still its own", async t => {
+  // Nothing here before ACC: it writes the manifest, names it, and the id and
+  // the cache follow that name.
+  const home = await realpath(await mkdtemp(path.join(tmpdir(), "acc-codex-fresh-")));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const context = { home, codexHome: path.join(home, ".codex") };
+
+  await createCodexAdapter().install(context);
+
+  const config = await readFile(path.join(context.codexHome, "config.toml"), "utf8");
+  assert.match(config, /\[marketplaces\.acc-local\]/);
+  assert.match(config, /\[plugins\."agents-can-communicate@acc-local"\]/);
+  assert.deepEqual(await readdir(path.join(context.codexHome, "plugins", "cache",
+    "acc-local")), ["agents-can-communicate"]);
 });

--- a/tests/process/hook-wiring.test.mjs
+++ b/tests/process/hook-wiring.test.mjs
@@ -30,7 +30,10 @@ const ADAPTERS = [
   { name: "codex", create: createCodexAdapter,
     context: home => ({ home, codexHome: path.join(home, ".codex") }),
     commands: async home => {
-      const wired = JSON.parse(await readFile(path.join(home, ".agents", "plugins",
+      // ACC's own marketplace root, not the one this client discovers by
+      // itself: joining the user's put ACC's tree where the client never
+      // looked, and enabled an id it never forms.
+      const wired = JSON.parse(await readFile(path.join(home, ".agents", "acc-local",
         "plugins", "agents-can-communicate", "hooks.json"), "utf8"));
       return Object.values(wired.hooks)
         .flatMap(entries => entries.flatMap(entry => entry.hooks.map(h => h.command)));

--- a/tests/process/skill-command.test.mjs
+++ b/tests/process/skill-command.test.mjs
@@ -42,7 +42,7 @@ const ADAPTERS = [
   ["kimi", ".kimi-code/plugins/managed/agents-can-communicate/skills/acc/SKILL.md"],
   ["claude_code",
     ".claude/plugins/marketplaces/acc-local/agents-can-communicate/skills/acc/SKILL.md"],
-  ["codex", ".agents/plugins/plugins/agents-can-communicate/skills/acc/SKILL.md"],
+  ["codex", ".agents/acc-local/plugins/agents-can-communicate/skills/acc/SKILL.md"],
   ["gemini_cli", ".gemini/extensions/agents-can-communicate/skills/acc/SKILL.md"],
 ];
 

--- a/tests/security/broken-client-config.test.mjs
+++ b/tests/security/broken-client-config.test.mjs
@@ -32,7 +32,7 @@ const CONFIGS = Object.freeze({
   claude_code: ".claude/settings.json",
   gemini_cli: ".gemini/settings.json",
   kimi: ".kimi-code/plugins/installed.json",
-  codex: ".agents/plugins/marketplace.json",
+  codex: ".agents/acc-local/.agents/plugins/marketplace.json",
 });
 const BROKEN = '{ "enabledPlugins": ';
 


### PR DESCRIPTION
Found by installing 0.1.2 on a real machine and asking the client, rather than by reading:

```
$ acc install
installed 3 adapter(s) …

$ codex plugin list
agents-can-communicate@local-marketplace   not installed
PATH: /Users/…/plugins/agents-can-communicate      ← a path that did not exist
```

Which is the failure the adapter's own doc-comment warns about: *"Placing files is not installing. This client discovers plugins only through a marketplace named in its own config… an install that writes files alone leaves a plugin the client never sees and a hook that never runs — while reporting success."*

## One root cause, three symptoms

ACC wrote into `<home>/.agents/plugins/marketplace.json`. That is **the marketplace this client discovers by itself** — no config entry needed — under whatever its own manifest calls it. On this machine that was `local-marketplace`, with the user's own plugin already in it.

So ACC was a guest in someone else's marketplace while naming everything after itself:

| | |
|---|---|
| the id | enabled `agents-can-communicate@acc-local`; the client only ever forms `…@local-marketplace` |
| the cache | wrote `<codexHome>/plugins/cache/acc-local/…`; the client reads `cache/<marketplace name>/…` |
| the tree | placed it relative to the manifest's directory; the client resolves `./plugins/<name>` against the marketplace **root** |

The comment claiming manifest-relative resolution said the opposite of what `codex plugin list` prints for the user's own plugin: entry `./plugins/simplify`, resolved path `~/plugins/simplify`.

## The fix

ACC registers **its own marketplace**, rooted at `<home>/.agents/acc-local` — its own name, manifest, tree and cache, and the user's marketplace untouched. Under `.agents/` rather than the home itself, because the root is what `./plugins/<name>` resolves against, and `tests/process/install-targets.test.mjs` already refuses to write at the top of a home.

Measured at each step against Codex 0.147.0:

```
$ acc install --adapter codex
  created ~/.agents/acc-local/plugins/agents-can-communicate
  created ~/.codex/plugins/cache/acc-local/agents-can-communicate
  edited  ~/.agents/acc-local/.agents/plugins/marketplace.json
  edited  ~/.codex/config.toml

$ codex plugin list
simplify@local-marketplace        installed, enabled  0.1.0
agents-can-communicate@acc-local  installed, enabled  0.1.2   ← the client agrees now

$ acc uninstall --adapter codex     # then:
   acc entries in codex: 0 · config.toml identical to the pre-install snapshot
   ~/.agents/acc-local, ~/.codex/plugins/cache/acc-local: gone
```

## I broke the user's other plugin on the way, and that is a finding too

The first version of this fix kept ACC as a guest and only corrected the paths. Uninstall then removed `cache/local-marketplace` — **the marketplace's cache root, shared with the user's own plugin** — and `simplify` went from `installed, enabled` to `not installed`. Restored with `codex plugin add simplify@local-marketplace`.

The ownership hashes caught it on the very next run, which is how it became visible:

```
kept    ~/.codex/plugins/cache/local-marketplace - changed since ACC wrote it
```

That line is from #58. The protection was already there; the record simply claimed a directory ACC had no business owning. With a marketplace of its own the question does not arise, and a test still guards it.

## Verification

- 864 tests passing, 0 failing · `syntax ok in 183 file(s)`
- recorded: `sha256 ca630e01…f2246` built from `af73b05`

Four mutations, all caught:

| Mutation | Caught by |
|---|---|
| tree back under the manifest's directory | `install places the plugin and registers it in the marketplace` |
| ACC joins the marketplace the client discovers | `ACC registers a marketplace of its own, not the user's` |
| config names a root ACC does not write to | same |
| empty directories left behind | `uninstall removes only what ACC owns, twice safely` |

The fixture already modelled reality — a manifest named `local-marketplace` holding someone else's plugin. Only the assertions were written around the bug.
