### PR TITLE
fix: a home directory is refused in words a reader can act on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 | | |
 |---|---|
-| Built from | `e9b58e5` |
+| Built from | `537211c` |
 | Tarball | `agents-can-communicate-0.1.2.tgz`, 135 KB, 109 entries |
-| sha256 | `ca630e0197475601d3de0daa5f366886242583bf1945d6621bd5175c830f2246` |
-| Tests | 864 passing, 0 failing |
+| sha256 | `fc7279c065bdfff8892f04c2a9ff4f873c3ec52bd482ab135bfe47c10101dc31` |
+| Tests | 868 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not
 rewritten, so shipped code that changes after a release is measured here instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
 Not published. A published record says what the registry serves and is not
 rewritten, so shipped code that changes after a release is measured here instead.
 
+Running `acc` in a home directory says what is wrong with that. A home is no
+checkout, so discovery falls back to the directory you are standing in - and the
+platform's own state directory is inside a home by definition, so every command
+that opens a workspace refused with "runtime state must not live inside the
+workspace". True, and written for somebody who had put the state in a project on
+purpose. It names the directory, the state it holds, and the two ways out now.
+
 The Codex install is an install. `acc install` reported success for this client
 and `codex plugin list` said `not installed`, which is the failure the adapter's
 own doc-comment warns about: placing files is not installing.

--- a/packages/cli/src/runtime-paths.mjs
+++ b/packages/cli/src/runtime-paths.mjs
@@ -23,11 +23,24 @@ export function runtimePaths({ dataHome, workspaceId, workspaceRoots = [] }) {
   // Enforced here rather than only asserted in a test, because "just put it in
   // .agents next to the project" is the exact regression this design exists to
   // prevent, and it would otherwise look like it works.
+  //
+  // The message names both paths and what to do, because the case a person
+  // actually meets is not the one this was written for. Running `acc` in a home
+  // directory makes that directory the workspace - it is no checkout, so
+  // discovery falls back to where you are - and the platform's own state
+  // directory is inside a home by definition. So `acc status` in `~` answered
+  // "runtime state must not live inside the workspace", which reads as a
+  // misconfiguration and tells the reader nothing they can act on.
   for (const workspaceRoot of workspaceRoots) {
     const relative = path.relative(workspaceRoot, root);
     if (relative === "" || (!path.isAbsolute(relative) && !relative.startsWith(".."))) {
-      throw new AccError(EXIT.USAGE, "runtime state must not live inside the workspace",
-        { root, workspaceRoot });
+      throw new AccError(EXIT.USAGE,
+        // The data home rather than the workspace's own directory inside it:
+        // that is the one a reader can move, and the one the remedy names.
+        `${workspaceRoot} holds ACC's own state at ${path.join(dataHome, "acc")}, `
+        + "so it cannot be a workspace. Run acc inside a project, or point "
+        + "ACC_DATA_HOME outside this directory.",
+        { root, dataHome, workspaceRoot });
     }
   }
   return Object.freeze(Object.fromEntries([["root", root],

--- a/packages/cli/test/runtime-paths.test.mjs
+++ b/packages/cli/test/runtime-paths.test.mjs
@@ -38,10 +38,38 @@ test("a data home inside the workspace is refused outright", () => {
   assert.throws(() => runtimePaths({ dataHome: path.join(workspaceRoot, ".agents"),
     workspaceId: WORKSPACE, workspaceRoots: [workspaceRoot] }),
   error => error.code === EXIT.USAGE
-    && error.message.includes("must not live inside the workspace"));
+    && error.message.includes("cannot be a workspace"));
 
   assert.throws(() => runtimePaths({ dataHome: workspaceRoot, workspaceId: WORKSPACE,
     workspaceRoots: [workspaceRoot] }), error => error.code === EXIT.USAGE);
+});
+
+test("the refusal names the directory, the state, and what to do about it", () => {
+  // The case a person actually meets is not the one the rule was written for.
+  // A home directory is no checkout, so discovery falls back to it - and the
+  // platform's own state directory is inside a home by definition. `acc status`
+  // in `~` answered "runtime state must not live inside the workspace", which
+  // reads as a misconfiguration and gives the reader nothing to act on.
+  const home = "/home/example";
+  const thrown = (() => {
+    try {
+      runtimePaths({ dataHome: path.join(home, ".local", "share"),
+        workspaceId: WORKSPACE, workspaceRoots: [home] });
+      return null;
+    } catch (error) {
+      return error;
+    }
+  })();
+
+  assert.notEqual(thrown, null, "a home directory was accepted as a workspace");
+  assert.equal(thrown.message.includes(home), true, "the directory is not named");
+  assert.equal(thrown.message.includes(path.join(home, ".local", "share", "acc")), true,
+    "the state it holds is not named");
+  assert.match(thrown.message, /Run acc inside a project/);
+  assert.match(thrown.message, /ACC_DATA_HOME/);
+  // The workspace's own directory inside the data home is not what a reader can
+  // move, so it is in the details rather than the sentence.
+  assert.equal(thrown.details.workspaceRoot, home);
 });
 
 test("a sibling directory sharing a name prefix is not treated as inside", () => {

--- a/tests/process/home-is-not-a-workspace.test.mjs
+++ b/tests/process/home-is-not-a-workspace.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+const acc = path.join(path.resolve(import.meta.dirname, "..", ".."), "bin", "acc.mjs");
+
+/**
+ * Running `acc` where you live.
+ *
+ * A home directory is no checkout, so discovery falls back to the directory you
+ * are in - and the platform's own state directory is inside a home by
+ * definition. Every command that opens a workspace then refused, with a
+ * sentence about runtime state that reads as a misconfiguration and names
+ * nothing the reader can do.
+ */
+async function home(t) {
+  const directory = await realpath(await mkdtemp(path.join(tmpdir(), "acc-home-")));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  // No ACC_DATA_HOME, so the platform default applies - which is what a person
+  // has. XDG is cleared for the same reason on Linux.
+  const env = { ...process.env, HOME: directory, ACC_DATA_HOME: "", XDG_DATA_HOME: "",
+    GIT_DIR: "", GIT_WORK_TREE: "" };
+  return { directory, env };
+}
+
+test("the refusal names the directory, its state, and what to do", async t => {
+  const place = await home(t);
+
+  const failed = await run(process.execPath, [acc, "status", "--cwd", place.directory],
+    { env: place.env }).then(() => null, error => error);
+
+  assert.notEqual(failed, null, "a home directory was accepted as a workspace");
+  assert.match(failed.stderr, new RegExp(place.directory.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(failed.stderr, /cannot be a workspace/);
+  assert.match(failed.stderr, /Run acc inside a project/);
+  assert.match(failed.stderr, /ACC_DATA_HOME/);
+  assert.doesNotMatch(failed.stderr, /must not live inside the workspace/,
+    "the sentence written for a different reader is still the one printed");
+});
+
+test("the commands that describe the program still answer there", async t => {
+  const place = await home(t);
+  // `acc help` in the directory you are standing in should not be a usage
+  // error, whatever that directory is.
+  for (const command of ["help", "version"]) {
+    const { stdout } = await run(process.execPath, [acc, command, "--cwd", place.directory],
+      { env: place.env });
+    assert.notEqual(stdout.trim(), "");
+  }
+});
+
+test("a project inside that home works as it always did", async t => {
+  const place = await home(t);
+  const project = await mkdtemp(path.join(place.directory, "project-"));
+
+  const { stdout } = await run(process.execPath,
+    [acc, "status", "--cwd", project, "--json"], { env: place.env });
+
+  assert.equal(JSON.parse(stdout).ok, true);
+});


### PR DESCRIPTION
The second defect from installing 0.1.2 and using it. Every command that opens a workspace stopped, from the one directory a person is most likely to be standing in:

```
$ cd ~ && acc status
runtime state must not live inside the workspace
```

## The rule is right; the sentence was written for somebody else

A home is no checkout, so discovery falls back to the directory you are in — and the platform's own state directory is inside a home by definition. So that directory genuinely cannot be a workspace, and refusing is correct.

But the sentence was written for the regression the rule exists to prevent: *"just put it in `.agents` next to the project"*. That reader chose where the state goes. The reader in `~` chose nothing, and is told about "runtime state" as though they had misconfigured something.

```
$ cd ~ && acc status
/Users/…  holds ACC's own state at /Users/…/Library/Application Support/acc,
so it cannot be a workspace. Run acc inside a project, or point ACC_DATA_HOME
outside this directory.
```

The data home rather than the workspace's own directory inside it — that is the one the remedy names, and the one a reader can move. The per-workspace path stays in the error's details.

## Verification

- 868 tests passing, 0 failing · `syntax ok in 184 file(s)`
- recorded: `sha256 fc7279c0…01dc31` built from `537211c`

Three end-to-end tests, run against the real binary with a temp home and no `ACC_DATA_HOME`:

| | |
|---|---|
| the refusal names the directory, its state, and what to do | and asserts the old sentence is **not** what gets printed |
| `acc help` and `acc version` still answer there | the directory you stand in should not decide whether the program can describe itself |
| a project inside that home works as it always did | the rule still applies where it was meant to |

Putting the old message back fails all three, plus the unit test on the refusal itself.
