### PR TITLE
release: 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ reported as not installed, and a message that told the reader nothing.
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `8679ae8` |
+| Tarball | `agents-can-communicate-0.1.3.tgz`, 135 KB, 109 entries |
+| sha256 | `b3821785071c578a5198d869c2dfb03c25226c34a14a8669ba8882f153477c6d` |
 | Tests | 868 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,20 @@
 # Changelog
 
-## Unreleased
+## 0.1.3
+
+Two of them broke a promise in silence, and both were found by installing 0.1.2
+and using it rather than by running the tests again: an install this client
+reported as not installed, and a message that told the reader nothing.
 
 | | |
 |---|---|
-| Built from | `537211c` |
-| Tarball | `agents-can-communicate-0.1.2.tgz`, 135 KB, 109 entries |
-| sha256 | `fc7279c065bdfff8892f04c2a9ff4f873c3ec52bd482ab135bfe47c10101dc31` |
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
 | Tests | 868 passing, 0 failing |
-
-Not published. A published record says what the registry serves and is not
-rewritten, so shipped code that changes after a release is measured here instead.
+| Node | 24 (current production LTS) |
+| Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
+| Not supported | Windows — untested rather than known-broken |
 
 Running `acc` in a home directory says what is wrong with that. A home is no
 checkout, so discovery falls back to the directory you are standing in - and the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -102,51 +102,51 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.1.2"
+      "version": "0.1.3"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "description": "Model- and harness-agnostic coordination for independent AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-claude-code/plugin/.claude-plugin/plugin.json
+++ b/packages/adapter-claude-code/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Coordinate this Claude Code session with other AI agent sessions working in the same workspace: shared presence, resource claims, typed messages, and handoffs."
 }

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/plugin/.codex-plugin/plugin.json
+++ b/packages/adapter-codex/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Coordinate this Codex session with other AI agent sessions working in the same workspace.",
   "license": "UNLICENSED",
   "keywords": ["coordination", "multi-agent", "claims", "handoff"],

--- a/packages/adapter-gemini-cli/extension/gemini-extension.json
+++ b/packages/adapter-gemini-cli/extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Coordinate this Gemini CLI session with other AI agent sessions working in the same workspace.",
   "contextFileName": "skills/acc/SKILL.md"
 }

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/plugin/.kimi-plugin/plugin.json
+++ b/packages/adapter-kimi/plugin/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Coordinate this Kimi Code session with other AI agent sessions working in the same workspace: shared presence, resource claims, typed messages, and handoffs.",
   "skills": "./skills/",
   "sessionStart": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.mjs" },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Four fixes, two of which broke a promise in silence. All four came out of installing 0.1.2 and using it, not from running the tests again.

| | |
|---|---|
| **#62** | `acc install` reported success for Codex and `codex plugin list` said **`not installed`**. ACC wrote into the marketplace this client discovers by itself, then named the id, the cache and the tree after itself — three misses, one cause. It registers a marketplace of its own now |
| **#63** | Every command that opens a workspace refused from a home directory with `runtime state must not live inside the workspace` — true, and written for a reader who had chosen where the state goes. It names the directory, the state and the two ways out |
| #60 | Hooks survive a node version manager |
| #58/#59 | (already in 0.1.2) |

Also from #62: uninstall stopped removing a directory it shared. While ACC was a guest in the user's marketplace, the cache root it deleted belonged to that marketplace — and on a real machine it took a plugin the user had installed themselves.

## Verified on the artifact, against the real client

`npm pack`, `npm install -g` from the tgz, then:

```
1. acc --version → 0.1.3
2. in a home directory:
     …/home holds ACC's own state at …/home/Library/Application Support/acc, so it
     cannot be a workspace. Run acc inside a project, or point ACC_DATA_HOME outside
     this directory.
3. acc help there → 34 lines            (the program can still describe itself)
4. acc install --adapter codex, on this machine:
     created ~/.agents/acc-local/plugins/agents-can-communicate
     created ~/.codex/plugins/cache/acc-local/agents-can-communicate
5. codex plugin list:
     agents-can-communicate@acc-local  installed, enabled  0.1.3
     simplify@local-marketplace        installed, enabled  0.1.0   ← the user's, untouched
6. acc uninstall --adapter codex:
     0 acc rows in codex · 0 directories left · user's marketplace untouched
```

Step 5 is the whole point of #62: **the client agrees**. It said `not installed` for the same command in 0.1.2.

One honest note on step 6: `config.toml` no longer matches the snapshot I took before the first install — but not because of ACC. Codex added a `[projects."…"]` trust entry of its own and bumped its bundled browser version in the hours since. `grep -c 'acc-local|agents-can-communicate@'` on that file is **0**.

## Record

```
PASS  agents-can-communicate-0.1.3.tgz  sha256 b3821785…477c6d  built from 8679ae8
```

135 KB, 109 entries. 868 tests passing, 0 failing · `syntax ok in 184 file(s)`.

The bump broke nothing — fourth release in a row. 0.1.2, 0.1.1 and 0.1.0 keep their entries: they say what the registry serves.
