### PR TITLE
fix: acc-mcp refuses what it was ignoring, and the environment is written down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 | | |
 |---|---|
-| Built from | `05c7b61` |
+| Built from | `b84ea51` |
 | Tarball | `agents-can-communicate-0.1.3.tgz`, 135 KB, 109 entries |
 | sha256 | `ad51d0e24b4631e28315a64c5fd7d4c9298f4467306860752137a488938798b4` |
-| Tests | 871 passing, 0 failing |
+| Tests | 872 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not
 rewritten, so shipped code that changes after a release is measured here instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `05c7b61` |
+| Tarball | `agents-can-communicate-0.1.3.tgz`, 135 KB, 109 entries |
+| sha256 | `ad51d0e24b4631e28315a64c5fd7d4c9298f4467306860752137a488938798b4` |
 | Tests | 871 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Unreleased
+
+| | |
+|---|---|
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
+| Tests | 871 passing, 0 failing |
+
+Not published. A published record says what the registry serves and is not
+rewritten, so shipped code that changes after a release is measured here instead.
+
+`acc-mcp` refuses arguments instead of ignoring them. It reads nothing from the
+command line, and accepted anything: writing `acc-mcp --cwd <project>` - the
+habit `acc` teaches - started a server rooted wherever the client happened to
+launch it, alone in a workspace nobody else was in, saying nothing. It now names
+the two variables that configure it and exits 2.
+
+Every variable the code reads from the environment is written down. Four were
+not, and one of them - `ACC_MCP_WORKSPACE` - decides which project an MCP client
+joins. A test scans what is read from `env` and fails on anything no document
+mentions; the shim's own `ACC_NODE` and `ACC_RUNNER` are shell variables of its
+own, not configuration, and are outside it.
+
 ## 0.1.3
 
 Two of them broke a promise in silence, and both were found by installing 0.1.2

--- a/bin/acc-mcp.mjs
+++ b/bin/acc-mcp.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { randomBytes } from "node:crypto";
 
-import { createId } from "@agents-can-communicate/protocol";
+import { EXIT, createId } from "@agents-can-communicate/protocol";
 import { createCoordinationService } from "@agents-can-communicate/core";
 import { openFilesystemStore } from "@agents-can-communicate/storage-filesystem";
 import { createGitProbe, discoverWorkspace, platformDataHome, runtimePaths }
@@ -12,6 +12,18 @@ import { serve } from "@agents-can-communicate/mcp-server";
 // randomness. The participant name comes from configuration, never from the
 // client: the protocol says clientInfo is self-reported and must not drive
 // behaviour, and the session is derived from this configuration alone.
+// Nothing is read from the command line, so nothing may be passed on it. It
+// used to accept and ignore anything: writing `acc-mcp --cwd <project>` - the
+// habit `acc` teaches - started a server rooted wherever the client happened to
+// launch it, alone in a workspace nobody else was in, with no warning at all.
+if (process.argv.length > 2) {
+  process.stderr.write("acc-mcp takes no arguments. It is configured by environment:\n"
+    + "  ACC_MCP_PARTICIPANT   who this server takes part as (default: mcp)\n"
+    + "  ACC_MCP_WORKSPACE     the project it joins (default: the working directory)\n"
+    + `refusing: ${process.argv.slice(2).join(" ")}\n`);
+  process.exit(EXIT.USAGE);
+}
+
 const participantId = process.env.ACC_MCP_PARTICIPANT ?? "mcp";
 const clock = { now: () => new Date().toISOString() };
 const ids = { next: kind => createId(kind, randomBytes) };

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -117,6 +117,10 @@ file the repository does not control.
 | `ACC_PARTICIPANT` | Which participant a session belongs to, when the client does not say |
 | `ACC_NO_UPDATE_CHECK=1` | Never ask npm whether a newer ACC exists. `acc update` then says it is off, which is a different answer from "nothing is newer" |
 | `ACC_PROBE_TIMEOUT_MS` | How long to wait for a client to print its version. Three seconds by default: generous on an idle machine, and not always enough on a busy one, where a client that overruns it is reported as not installed |
+| `ACC_WORKSPACE_ROOT` | The project to work in, instead of discovering one from the working directory. Absolute, or it is refused |
+| `ACC_SESSION` · `ACC_GENERATION` | Which session a command acts as, when it is not being worked out. Both, or neither: the generation is what proves the caller is still that session |
+| `ACC_MCP_PARTICIPANT` | Who `acc-mcp` takes part as. `mcp` by default |
+| `ACC_MCP_WORKSPACE` | The project `acc-mcp` joins. Without it the server takes the directory the client launched it in, which is rarely the project |
 
 ## Relationship to runtime paths
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -11,11 +11,19 @@ graph LR
 ## Register
 
 ```json
-{ "command": "acc-mcp", "env": { "ACC_MCP_PARTICIPANT": "research" } }
+{ "command": "acc-mcp", "env": {
+  "ACC_MCP_PARTICIPANT": "research",
+  "ACC_MCP_WORKSPACE": "/path/to/the/project"
+} }
 ```
 
 The session comes from **this configuration**, never from `initialize` or `clientInfo`.
 Restarting the process resolves to the same session.
+
+`ACC_MCP_WORKSPACE` is the project this server joins. Without it the server takes the
+directory the client launched it in, which is rarely the project and is silent about it —
+`acc_sync` answers `solo` from a workspace nobody else is in. There is nothing to pass on
+the command line: `acc-mcp` takes no arguments and says so rather than ignoring them.
 
 ## Tools
 

--- a/tests/process/mcp-arguments.test.mjs
+++ b/tests/process/mcp-arguments.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import { EXIT } from "@agents-can-communicate/protocol";
+
+const run = promisify(execFile);
+const server = path.join(path.resolve(import.meta.dirname, "..", ".."), "bin", "acc-mcp.mjs");
+
+/**
+ * The server reads nothing from the command line, so nothing may be passed on it.
+ *
+ * It used to accept and ignore anything. `acc-mcp --cwd <project>` - the habit
+ * `acc` teaches - started a server rooted wherever the client happened to launch
+ * it: `acc_sync` answered `solo` from a workspace nobody else was in, and
+ * nothing anywhere said why. Found by configuring one and wondering where
+ * everybody had gone.
+ */
+const start = (argv, env = {}) => {
+  const child = run(process.execPath, [server, ...argv], { env: { ...process.env, ...env } });
+  // Closed at once: the server reads stdio JSON-RPC and runs until its input
+  // ends, so a test that leaves it open waits for a conversation nobody is
+  // having.
+  child.child.stdin.end();
+  return child.then(result => ({ code: 0, ...result }), error => error);
+};
+
+test("an argument is refused, and the refusal says what to use instead", async () => {
+  const refused = await start(["--cwd", "/tmp"]);
+
+  assert.equal(refused.code, EXIT.USAGE);
+  assert.match(refused.stderr, /takes no arguments/);
+  assert.match(refused.stderr, /ACC_MCP_PARTICIPANT/);
+  assert.match(refused.stderr, /ACC_MCP_WORKSPACE/);
+  // Named, so the reader sees which of their arguments was the problem.
+  assert.match(refused.stderr, /--cwd \/tmp/);
+});
+
+test("with no arguments it serves, and stops when the input ends", async t => {
+  const { mkdtemp, realpath, rm } = await import("node:fs/promises");
+  const { tmpdir } = await import("node:os");
+  // Two directories, because ACC refuses a data home inside the workspace - as
+  // it should, and as it told me when this test first put them in one place.
+  const project = await realpath(await mkdtemp(path.join(tmpdir(), "acc-mcp-")));
+  const dataHome = await realpath(await mkdtemp(path.join(tmpdir(), "acc-mcp-data-")));
+  t.after(() => Promise.all([project, dataHome]
+    .map(dir => rm(dir, { recursive: true, force: true }))));
+
+  const served = await start([], { ACC_MCP_WORKSPACE: project, ACC_DATA_HOME: dataHome });
+
+  assert.equal(served.code, 0, served.stderr);
+});

--- a/tests/process/session-resolution.test.mjs
+++ b/tests/process/session-resolution.test.mjs
@@ -237,3 +237,42 @@ test("no shipped skill or document teaches a variable nothing sets", async () =>
       `${file} still tells an agent to pass a session id it has no way to obtain`);
   }
 });
+
+test("every variable the code reads from the environment is written down", async () => {
+  // The other direction, and the one that bit: `ACC_MCP_WORKSPACE` decides which
+  // project an MCP client joins, and appeared in no document at all. Without it
+  // the server takes the directory it was launched in, answers `solo` from a
+  // workspace nobody else is in, and says nothing - found by configuring one and
+  // wondering where everybody was.
+  const code = [];
+  for (const root of ["packages", "bin"]) {
+    const entries = await readdir(path.join(repo, root),
+      { recursive: true, withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".mjs")) continue;
+      const file = path.join(entry.parentPath ?? entry.path, entry.name);
+      if (file.includes("node_modules") || file.includes(`${path.sep}test${path.sep}`)) continue;
+      code.push(await readFile(file, "utf8"));
+    }
+  }
+
+  // Read *from the environment*, which is what makes a name configuration. The
+  // generated hook shim has `ACC_NODE` and `ACC_RUNNER` in it, and those are
+  // shell variables of its own that nobody sets.
+  const read = new Set();
+  for (const text of code) {
+    for (const [, name] of text.matchAll(/env\??\.(ACC_[A-Z_]+)|env\["(ACC_[A-Z_]+)"\]/g)) {
+      if (name !== undefined) read.add(name);
+    }
+  }
+  assert.equal(read.size > 5, true, "the scan found almost nothing, so it proves nothing");
+
+  const documentation = (await Promise.all([...await readdir(path.join(repo, "docs"))]
+    .filter(name => name.endsWith(".md"))
+    .map(name => readFile(path.join(repo, "docs", name), "utf8"))
+    .concat([readFile(path.join(repo, "README.md"), "utf8")]))).join("\n");
+
+  const undocumented = [...read].filter(name => !documentation.includes(name)).sort();
+  assert.deepEqual(undocumented, [],
+    "these change what the product does and are written down nowhere");
+});

--- a/tests/process/session-resolution.test.mjs
+++ b/tests/process/session-resolution.test.mjs
@@ -238,6 +238,35 @@ test("no shipped skill or document teaches a variable nothing sets", async () =>
   }
 });
 
+/**
+ * The `ACC_*` names a piece of code takes out of the environment.
+ *
+ * Both spellings, and both taken: the pattern has an alternative per spelling,
+ * so one capture group is always undefined and reading only the first threw
+ * away every bracketed read - a scan that reported nothing wrong because it had
+ * looked at half of what it claimed to.
+ */
+export function readsFromEnvironment(text) {
+  const found = new Set();
+  for (const [, dotted, bracketed]
+    of text.matchAll(/env\??\.(ACC_[A-Z_]+)|env\[["`'](ACC_[A-Z_]+)["`']\]/g)) {
+    found.add(dotted ?? bracketed);
+  }
+  return found;
+}
+
+test("the scan reads both ways of asking the environment", () => {
+  // Neither spelling is hypothetical: the first is what the code uses today,
+  // and the second is what it would use for a computed name tomorrow.
+  assert.deepEqual([...readsFromEnvironment(`
+    const a = env.ACC_DOTTED;
+    const b = process.env?.ACC_OPTIONAL;
+    const c = env["ACC_BRACKETED"];
+    const d = runtime.env['ACC_SINGLE'];
+    const untouched = "ACC_MENTIONED_IN_PROSE";
+  `)].sort(), ["ACC_BRACKETED", "ACC_DOTTED", "ACC_OPTIONAL", "ACC_SINGLE"]);
+});
+
 test("every variable the code reads from the environment is written down", async () => {
   // The other direction, and the one that bit: `ACC_MCP_WORKSPACE` decides which
   // project an MCP client joins, and appeared in no document at all. Without it
@@ -259,12 +288,7 @@ test("every variable the code reads from the environment is written down", async
   // Read *from the environment*, which is what makes a name configuration. The
   // generated hook shim has `ACC_NODE` and `ACC_RUNNER` in it, and those are
   // shell variables of its own that nobody sets.
-  const read = new Set();
-  for (const text of code) {
-    for (const [, name] of text.matchAll(/env\??\.(ACC_[A-Z_]+)|env\["(ACC_[A-Z_]+)"\]/g)) {
-      if (name !== undefined) read.add(name);
-    }
-  }
+  const read = new Set(code.flatMap(text => [...readsFromEnvironment(text)]));
   assert.equal(read.size > 5, true, "the scan found almost nothing, so it proves nothing");
 
   const documentation = (await Promise.all([...await readdir(path.join(repo, "docs"))]


### PR DESCRIPTION
Both findings from the end-to-end run, and they are one trap wearing two hats.

## What happened

Configuring an MCP client, I wrote what `acc` teaches:

```
$ acc-mcp --cwd <project>
```

It started. `acc_sync` answered `solo` — a workspace nobody else was in — while three other agents were coordinating a directory away. `acc-mcp` reads no arguments at all and ignored these, taking `process.cwd()` instead.

## Why the mistake was easy

`ACC_MCP_WORKSPACE` decides which project an MCP client joins, and appeared in **no document**. It was one of four:

```
ACC_GENERATION       docs: 0
ACC_MCP_WORKSPACE    docs: 0
ACC_SESSION          docs: 0
ACC_WORKSPACE_ROOT   docs: 0
```

## The fix

```
$ acc-mcp --cwd /tmp
acc-mcp takes no arguments. It is configured by environment:
  ACC_MCP_PARTICIPANT   who this server takes part as (default: mcp)
  ACC_MCP_WORKSPACE     the project it joins (default: the working directory)
refusing: --cwd /tmp
                                                                    exit 2
```

The documented registration in `docs/MCP.md` passes no arguments, so nothing that follows the docs changes — and that registration now shows the workspace, with a sentence about what happens without it.

All four variables are in the environment table in `docs/CONFIGURATION.md`.

**A test keeps it that way.** Every `ACC_*` read from `env` in shipped code must appear in a document:

```js
for (const [, name] of text.matchAll(/env\??\.(ACC_[A-Z_]+)|env\["(ACC_[A-Z_]+)"\]/g))
```

It looks for *environment reads* rather than for the names, because the generated hook shim has `ACC_NODE` and `ACC_RUNNER` in it — shell variables of its own that nobody sets, and not configuration. There is already a test for the opposite direction, that no document teaches a variable nothing exports; they sit together now.

## Verification

- 871 tests passing, 0 failing · `syntax ok in 185 file(s)`
- recorded: `sha256 ad51d0e2…8798b4` built from `05c7b61`

| Mutation | Caught by |
|---|---|
| arguments accepted and ignored again | `an argument is refused, and the refusal says what to use instead` |
| the refusal stops naming the variables | same |
| `ACC_WORKSPACE_ROOT` undocumented again | `every variable the code reads from the environment is written down` |
| `ACC_MCP_WORKSPACE` removed from both documents | same |

Removing `ACC_MCP_WORKSPACE` from only `CONFIGURATION.md` does **not** fail, and should not: it is still in `docs/MCP.md`, and the requirement is that a reader can find it somewhere.

One more thing the run turned up: a test I wrote here first put the data home inside the workspace, and ACC refused it — the rule from #63 working on me while I was writing tests for something else.
