### PR TITLE
fix: the skill every agent is given names a command that runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## Unreleased
+
+| | |
+|---|---|
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
+| Tests | 872 passing, 0 failing |
+
+Not published. A published record says what the registry serves and is not
+rewritten, so shipped code that changes after a release is measured here instead.
+
+The skill every agent is given names a command that runs. It named
+`<package>/node_modules/bin/acc.mjs`, which does not exist, so an agent that
+followed the skill got `MODULE_NOT_FOUND` - in every client, on every install
+from the registry.
+
+The path was counted out in `../` from the SDK's own directory, which is right
+in a development checkout and one level shallow once the workspaces are bundled.
+That was found once for the hook runner and fixed for the runner alone; the CLI
+kept the count. Both are found by walking up now, through one function, so the
+next binary cannot inherit the count. The packaging test checks the installed
+layout for both rather than for the runner alone.
+
+Found by asking a real Claude Code session to edit a file another agent had
+claimed. The guard refused it, and the agent said so - and reported, on the way,
+that the command in the skill had failed and that it had gone looking for the
+real one.
+
 ## 0.1.4
 
 The public documentation rewritten around what a reader is trying to do, and one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `065beb1` |
+| Tarball | `agents-can-communicate-0.1.4.tgz`, 135 KB, 109 entries |
+| sha256 | `3fc727eb2158d66415635b4d63bd6a44d94e4df2c5fe8055c45ab1d8b690337c` |
 | Tests | 872 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not

--- a/packages/adapter-sdk/src/hook-shim.mjs
+++ b/packages/adapter-sdk/src/hook-shim.mjs
@@ -29,20 +29,35 @@ import { AccError, EXIT } from "@agents-can-communicate/protocol";
  * nearest `bin/acc-hook.mjs` above this file is the one that belongs to this
  * copy of the package.
  */
-export const defaultRunner = () => {
+/**
+ * A binary of this package's own, found by walking up rather than counted to.
+ *
+ * `../../../bin/<name>` is the answer in a development checkout and only there.
+ * Published, this module sits at
+ * `<package>/node_modules/@agents-can-communicate/adapter-sdk/src/`, one level
+ * deeper - so the count landed on `node_modules/bin/<name>`, which does not
+ * exist. That was found once for the hook runner and fixed for the runner
+ * alone. The CLI kept the count, and every skill installed for every agent
+ * named a command that could not run: an agent that followed it got
+ * `MODULE_NOT_FOUND`. Found by asking a real client to edit a claimed file and
+ * reading what it reported.
+ */
+const ownBinary = name => {
   let directory = fileURLToPath(new URL(".", import.meta.url));
   for (;;) {
-    const candidate = path.join(directory, "bin", "acc-hook.mjs");
+    const candidate = path.join(directory, "bin", name);
     if (existsSync(candidate)) return candidate;
     const parent = path.dirname(directory);
     // Reached the root without finding one. The development answer is returned
     // so the refusal that follows names a path a reader can recognise.
     if (parent === directory) {
-      return fileURLToPath(new URL("../../../bin/acc-hook.mjs", import.meta.url));
+      return fileURLToPath(new URL(`../../../bin/${name}`, import.meta.url));
     }
     directory = parent;
   }
 };
+
+export const defaultRunner = () => ownBinary("acc-hook.mjs");
 
 export const runnerExists = async runner => {
   try {
@@ -137,8 +152,7 @@ export async function removeInstalledTree(target, keep = []) {
 }
 
 /** Where the CLI lives, resolved from this package rather than from PATH. */
-export const defaultCli = () =>
-  fileURLToPath(new URL("../../../bin/acc.mjs", import.meta.url));
+export const defaultCli = () => ownBinary("acc.mjs");
 
 /**
  * Bake the runnable command into the skill this adapter installs.

--- a/tests/acceptance/packaging.test.mjs
+++ b/tests/acceptance/packaging.test.mjs
@@ -174,7 +174,7 @@ test("the committed lockfile is the one these manifests produce", async t => {
     "`npm install` rewrites the lockfile, so a clone is dirty before anyone edits it");
 });
 
-test("the installed package can find its own hook runner", async t => {
+test("the installed package can find the binaries it names", async t => {
   const { tarball } = await packed(t);
   const consumer = await realpath(await mkdtemp(path.join(tmpdir(), "acc-runner-")));
   t.after(() => rm(consumer, { recursive: true, force: true }));
@@ -193,15 +193,23 @@ test("the installed package can find its own hook runner", async t => {
   const sdk = path.join(consumer, "node_modules", "agents-can-communicate",
     "node_modules", "@agents-can-communicate", "adapter-sdk", "src", "hook-shim.mjs");
   const { stdout } = await run(process.execPath, ["--input-type=module", "--eval",
-    `import { defaultRunner } from ${JSON.stringify(pathToFileURL(sdk).href)};
+    `import { defaultCli, defaultRunner } from ${JSON.stringify(pathToFileURL(sdk).href)};
      import { existsSync } from "node:fs";
      const runner = defaultRunner();
-     console.log(JSON.stringify({ runner, exists: existsSync(runner) }));`],
+     const cli = defaultCli();
+     console.log(JSON.stringify({ runner, cli,
+       runnerExists: existsSync(runner), cliExists: existsSync(cli) }));`],
   { cwd: consumer });
 
   const found = JSON.parse(stdout);
-  assert.equal(found.exists, true,
+  assert.equal(found.runnerExists, true,
     `the installed package looks for its hook runner at ${found.runner}`);
+  // The same count, the same mistake, and it was fixed for the runner alone.
+  // The CLI is what every installed skill tells an agent to run: with the count
+  // left in, the path named `node_modules/bin/acc.mjs` and an agent following
+  // the skill got `MODULE_NOT_FOUND`.
+  assert.equal(found.cliExists, true,
+    `the installed package looks for its CLI at ${found.cli}`);
 });
 
 test("the manifest declares the binaries and the engine it was certified on", async t => {


### PR DESCRIPTION
Found by asking a real Claude Code session to edit a file another agent had claimed. It was refused — correctly — and reported this on the way:

> The ACC command **as documented in the skill failed** — `MODULE_NOT_FOUND`. The skill's path contains a spurious `node_modules/` segment: it documents `.../agents-can-communicate/node_modules/bin/acc.mjs`, but the real entrypoint is `.../agents-can-communicate/bin/acc.mjs`. I found the correct path and continued.

Confirmed on the installed 0.1.4:

```
skill teaches:  ~/.nvm/.../agents-can-communicate/node_modules/bin/acc.mjs   MISSING
really at:      ~/.nvm/.../agents-can-communicate/bin/acc.mjs
```

Every client. Every install from the registry. The skill is how an agent learns to use ACC at all, so the first thing it is told to run is the thing that cannot.

## The same count, the second time

```js
export const defaultCli = () =>
  fileURLToPath(new URL("../../../bin/acc.mjs", import.meta.url));
```

Right in a development checkout. Published, the SDK sits at `<package>/node_modules/@agents-can-communicate/adapter-sdk/src/` — one level deeper — so the count lands on `node_modules/bin/acc.mjs`.

That is the defect that was found for the **hook runner** and fixed for the runner alone: `defaultRunner` walks up until it finds the file, `defaultCli` kept counting. Both go through one function now, so the next binary cannot inherit it.

## Why the tests missed it

`tests/process/skill-command.test.mjs` takes the command out of the installed skill and runs it — the right test, and it passed, because it runs in the development tree where the count is correct.

`tests/acceptance/packaging.test.mjs` installs the tarball and asks the package to resolve its own binaries — the right layout, and it asked about the runner only.

It asks about both now:

```js
assert.equal(found.cliExists, true,
  `the installed package looks for its CLI at ${found.cli}`);
```

Putting the count back fails it.

## Proved on a real install

```
$ npm pack && npm install -g <tgz> && acc install --adapter claude_code
── the command the installed skill teaches:
   ".../node" ".../agents-can-communicate/bin/acc.mjs"
── does it exist? yes
── does it run?   {"envelope_version":1,"ok":true,…}
```

## Verification

- 872 tests passing, 0 failing · `syntax ok in 185 file(s)`
- recorded: `sha256 3fc727eb…90337c` built from `065beb1`

No test I wrote would have found this. Letting an agent follow the instructions did — which is the same lesson as the four defects before the first release, arriving through the one surface I had not yet driven with a real model.
