### PR TITLE
release: 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,19 @@
 # Changelog
 
-## Unreleased
+## 0.1.5
+
+One fix, and the most serious so far: every published version taught agents a
+command that could not run. `0.1.0` through `0.1.4` are affected.
 
 | | |
 |---|---|
-| Built from | `065beb1` |
-| Tarball | `agents-can-communicate-0.1.4.tgz`, 135 KB, 109 entries |
-| sha256 | `3fc727eb2158d66415635b4d63bd6a44d94e4df2c5fe8055c45ab1d8b690337c` |
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
 | Tests | 872 passing, 0 failing |
-
-Not published. A published record says what the registry serves and is not
-rewritten, so shipped code that changes after a release is measured here instead.
+| Node | 24 (current production LTS) |
+| Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
+| Not supported | Windows — untested rather than known-broken |
 
 The skill every agent is given names a command that runs. It named
 `<package>/node_modules/bin/acc.mjs`, which does not exist, so an agent that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ command that could not run. `0.1.0` through `0.1.4` are affected.
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `479b240` |
+| Tarball | `agents-can-communicate-0.1.5.tgz`, 135 KB, 109 entries |
+| sha256 | `5022560495d527fec8e37cf2ba9ea37ff4df3dcbafa2bef468f22108c7e925f5` |
 | Tests | 872 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -102,51 +102,51 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.1.4"
+      "version": "0.1.5"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.1.4"
+      "version": "0.1.5"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.1.4"
+      "version": "0.1.5"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.1.4"
+      "version": "0.1.5"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.1.4"
+      "version": "0.1.5"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.1.4"
+      "version": "0.1.5"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.1.4"
+      "version": "0.1.5"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.1.4"
+      "version": "0.1.5"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.1.4"
+      "version": "0.1.5"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.1.4"
+      "version": "0.1.5"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.1.4"
+      "version": "0.1.5"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.1.4"
+      "version": "0.1.5"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "description": "Local-first coordination for independently opened AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-claude-code/plugin/.claude-plugin/plugin.json
+++ b/packages/adapter-claude-code/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Coordinate this Claude Code session with other AI agent sessions working in the same workspace: shared presence, resource claims, typed messages, and handoffs."
 }

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/plugin/.codex-plugin/plugin.json
+++ b/packages/adapter-codex/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Coordinate this Codex session with other AI agent sessions working in the same workspace.",
   "license": "UNLICENSED",
   "keywords": ["coordination", "multi-agent", "claims", "handoff"],

--- a/packages/adapter-gemini-cli/extension/gemini-extension.json
+++ b/packages/adapter-gemini-cli/extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Coordinate this Gemini CLI session with other AI agent sessions working in the same workspace.",
   "contextFileName": "skills/acc/SKILL.md"
 }

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/plugin/.kimi-plugin/plugin.json
+++ b/packages/adapter-kimi/plugin/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Coordinate this Kimi Code session with other AI agent sessions working in the same workspace: shared presence, resource claims, typed messages, and handoffs.",
   "skills": "./skills/",
   "sessionStart": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.mjs" },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
One fix, and the most serious so far. **Every published version — `0.1.0` through `0.1.4` — teaches agents a command that cannot run.**

```
skill teaches:  <package>/node_modules/bin/acc.mjs      MODULE_NOT_FOUND
really at:      <package>/bin/acc.mjs
```

The skill is how an agent learns to use ACC at all. Hooks work, injection works, the guard works — but the half of the product where an agent *acts* rather than watches (claim, message, request, hand off) was unreachable through the artifacts on the registry.

## How it was found

By asking a real Claude Code session to edit a file another agent had claimed. It was refused, correctly, and reported this on the way:

> The ACC command **as documented in the skill failed** — `MODULE_NOT_FOUND`. The skill's path contains a spurious `node_modules/` segment… I found the correct path and continued.

It recovered by guessing. That is not something to rely on.

## The cause, and why the tests were green

`defaultCli` counted `../../../` from the SDK's own directory — right in a development checkout, one level shallow once the workspaces are bundled. It is the same defect found for the **hook runner** and fixed for the runner alone.

Two tests were involved and neither could see it:

| Test | Right about | Blind to |
|---|---|---|
| `the command baked into the skill actually runs` | takes the command out of the skill and runs it | runs in the development tree, where the count is correct |
| `the installed package can find its own hook runner` | installs the tarball, asks the package to resolve itself | asked about the runner, not the CLI |

Both binaries now resolve through one function that walks up, and the packaging test asks about both.

## Verified on the artifact, and by a real agent

```
1. acc --version → 0.1.5
2. the skill teaches: …/agents-can-communicate/bin/acc.mjs   exists: yes
3. and it runs:       {"envelope_version":1,"ok":true,…}
```

Then the same live scenario that found the defect, on the packaged 0.1.5:

> **Worked on the first attempt?** Yes — exit 0, valid JSON envelope (`"ok":true`), no retry or path fixup needed.
>
> owner **`bob`** · session `session_j7_y…` · harness `claude_code` · branch `master` · presence online · mode `exclusive`

## Record

```
PASS  agents-can-communicate-0.1.5.tgz  sha256 50225604…e925f5  built from 479b240
```

135 KB, 109 entries. 872 tests passing, 0 failing · `syntax ok in 185 file(s)`.

The bump broke nothing — sixth release in a row.
