### PR TITLE
fix: an agent in Codex can record what it is doing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## Unreleased
+
+| | |
+|---|---|
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
+| Tests | 877 passing, 0 failing |
+
+Not published. A published record says what the registry serves and is not
+rewritten, so shipped code that changes after a release is measured here instead.
+
+An agent in Codex can record what it is doing. That client sandboxes the shell
+commands a model runs to the workspace, and ACC keeps its state outside every
+workspace on purpose - so an agent there could read the roster and write
+nothing: `acc claim`, `acc work` and `acc message` each failed with
+`EPERM ... locks/writer.lock`. Half the product, silently, for one of four
+clients.
+
+The install declares that directory writable in the block it already owns. A
+config that sets `sandbox_workspace_write` itself is left alone - declaring the
+table twice is what makes this client refuse the whole config - and the
+diagnostic says what to add instead.
+
+Measured with `codex exec`, which is how an agent actually runs: the same
+command that failed with EPERM now returns `intent: reviewing the parser` and
+exit 0, with no flags passed by hand.
+
 ## 0.1.5
 
 One fix, and the most serious so far: every published version taught agents a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `f86a5c5` |
+| Tarball | `agents-can-communicate-0.1.5.tgz`, 135 KB, 109 entries |
+| sha256 | `5a5f6b8b73a21c90cd32841d8976be7ea92f232753308a9e1e4f419bc9376bf0` |
 | Tests | 877 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 | | |
 |---|---|
-| Built from | `0465921` |
+| Built from | `3eb048d` |
 | Tarball | `agents-can-communicate-0.1.5.tgz`, 135 KB, 109 entries |
-| sha256 | `5a5f6b8b73a21c90cd32841d8976be7ea92f232753308a9e1e4f419bc9376bf0` |
-| Tests | 877 passing, 0 failing |
+| sha256 | `23f6bb1cac9049c7a5f5b0dd453b7a1bac0e5f3b31bafc0f4566da9179952ec7` |
+| Tests | 878 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not
 rewritten, so shipped code that changes after a release is measured here instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 | | |
 |---|---|
-| Built from | `f86a5c5` |
+| Built from | `0465921` |
 | Tarball | `agents-can-communicate-0.1.5.tgz`, 135 KB, 109 entries |
 | sha256 | `5a5f6b8b73a21c90cd32841d8976be7ea92f232753308a9e1e4f419bc9376bf0` |
 | Tests | 877 passing, 0 failing |

--- a/packages/adapter-codex/src/install.mjs
+++ b/packages/adapter-codex/src/install.mjs
@@ -139,8 +139,13 @@ const sandboxTable = (stateRoot, theirs) => {
     `writable_roots = [${tomlString(stateRoot)}]`];
 };
 
-const declaresSandbox = config => /^\s*\[sandbox_workspace_write\]/m.test(config)
-  || /^\s*sandbox_workspace_write\./m.test(config);
+// Every spelling TOML allows for the same table: the header, a sub-table
+// header, a dotted key, and an inline table on one line. Missing one means ACC
+// appends a second declaration - which is the duplicate this exists to avoid,
+// and the client refuses the whole config over it.
+const declaresSandbox = config =>
+  /^\s*\[sandbox_workspace_write[\].]/m.test(config)
+  || /^\s*sandbox_workspace_write\s*[.=]/m.test(config);
 
 export async function installCodexPlugin({ home, agentsHome = home,
   codexHome = path.join(home, ".codex"), stateRoot, runner, node }) {

--- a/packages/adapter-codex/src/install.mjs
+++ b/packages/adapter-codex/src/install.mjs
@@ -118,8 +118,32 @@ const entryFor = () => ({
  * an install that writes files alone leaves a plugin the client never sees and
  * a hook that never runs - while reporting success.
  */
+/**
+ * The table that lets an agent here record anything at all.
+ *
+ * This client sandboxes the shell commands a model runs to the workspace, and
+ * ACC keeps its state outside every workspace on purpose - so an agent could
+ * read the roster and write nothing: `acc claim`, `acc work`, `acc message` all
+ * failed with `EPERM ... locks/writer.lock`. Measured with `codex exec`, which
+ * is how an agent actually runs, and confirmed by watching the same commands
+ * succeed once this root was declared.
+ *
+ * Left out when the user declares the table themselves. Declaring it twice is
+ * what makes this client refuse the whole config, and their setting is theirs -
+ * the diagnostic says what to add rather than adding it for them.
+ */
+const sandboxTable = (stateRoot, theirs) => {
+  if (typeof stateRoot !== "string" || stateRoot === "") return [];
+  if (theirs) return [];
+  return ["", "[sandbox_workspace_write]",
+    `writable_roots = [${tomlString(stateRoot)}]`];
+};
+
+const declaresSandbox = config => /^\s*\[sandbox_workspace_write\]/m.test(config)
+  || /^\s*sandbox_workspace_write\./m.test(config);
+
 export async function installCodexPlugin({ home, agentsHome = home,
-  codexHome = path.join(home, ".codex"), runner, node }) {
+  codexHome = path.join(home, ".codex"), stateRoot, runner, node }) {
   // Read before writing, so a manifest that will not parse is found before a
   // plugin tree is laid down that nothing will then be able to remove.
   const existing = await readJson(marketplacePath(agentsHome), { name: MARKETPLACE,
@@ -157,6 +181,7 @@ export async function installCodexPlugin({ home, agentsHome = home,
       `marketplace ${MARKETPLACE} is already registered in this config; `
       + "remove it and install again", { config });
   }
+  const theirSandbox = declaresSandbox(stripBlock(before));
   await writeTomlBlock(config, [
     `[marketplaces.${MARKETPLACE}]`,
     `source_type = "local"`,
@@ -164,6 +189,7 @@ export async function installCodexPlugin({ home, agentsHome = home,
     "",
     `[plugins.${tomlString(QUALIFIED)}]`,
     "enabled = true",
+    ...sandboxTable(stateRoot, theirSandbox),
   ]);
 
   // The client runs the cached copy, so this has to happen after the shim and
@@ -184,7 +210,11 @@ export async function installCodexPlugin({ home, agentsHome = home,
   // while ACC invented its own marketplace name and so had a root to itself.
   // make the record stale the moment the plugin version changes.
   return { ok: true, changes: [target, file, config, cachePath(codexHome)],
-    diagnostics: ["hooks require explicit trust in Codex before they run"] };
+    diagnostics: ["hooks require explicit trust in Codex before they run",
+      ...(theirSandbox
+        ? [`this config sets its own sandbox_workspace_write; add ${stateRoot} to `
+          + "writable_roots, or an agent here can read the roster and record nothing"]
+        : [])] };
 }
 
 /** Remove each directory that is empty, in the order given. */

--- a/packages/adapter-codex/test/install.test.mjs
+++ b/packages/adapter-codex/test/install.test.mjs
@@ -570,3 +570,28 @@ test("without a state directory nothing is declared", async t => {
 
   assert.doesNotMatch(await configOf(context), /sandbox_workspace_write/);
 });
+
+test("every spelling of that table counts as the user's", async t => {
+  // TOML says the same thing four ways. Missing one means ACC appends a second
+  // declaration, and this client refuses the whole config over a duplicate -
+  // which is the failure the check exists to prevent, arriving through the
+  // check itself.
+  for (const declaration of [
+    "[sandbox_workspace_write]\nwritable_roots = [\"/tmp/theirs\"]\n",
+    "[sandbox_workspace_write.nested]\nx = 1\n",
+    "sandbox_workspace_write.writable_roots = [\"/tmp/theirs\"]\n",
+    "sandbox_workspace_write = { writable_roots = [\"/tmp/theirs\"] }\n",
+  ]) {
+    const { context } = await fixture(t);
+    const config = path.join(context.codexHome, "config.toml");
+    await mkdir(context.codexHome, { recursive: true });
+    await writeFile(config, declaration);
+
+    await createCodexAdapter().install({ ...context,
+      stateRoot: path.join(context.home, "state", "acc") });
+
+    const text = await readFile(config, "utf8");
+    assert.equal((text.match(/sandbox_workspace_write/g) ?? []).length, 1,
+      `declared twice for:\n${declaration}`);
+  }
+});

--- a/packages/adapter-codex/test/install.test.mjs
+++ b/packages/adapter-codex/test/install.test.mjs
@@ -507,3 +507,66 @@ test("a marketplace ACC creates itself is still its own", async t => {
   assert.deepEqual(await readdir(path.join(context.codexHome, "plugins", "cache",
     "acc-local")), ["agents-can-communicate"]);
 });
+
+/**
+ * The table that lets an agent here record anything.
+ *
+ * This client sandboxes the shell commands a model runs to the workspace, and
+ * ACC keeps its state outside every workspace on purpose. So an agent could
+ * read the roster and write nothing: `acc claim`, `acc work` and `acc message`
+ * all failed with `EPERM ... locks/writer.lock`. Measured with `codex exec`,
+ * which is how an agent actually runs, and again after the fix - the same
+ * command, no flags, exit 0.
+ */
+const configOf = context =>
+  readFile(path.join(context.codexHome, "config.toml"), "utf8");
+
+test("the state directory is declared writable, or agents here cannot record", async t => {
+  const { context } = await fixture(t);
+  const stateRoot = path.join(context.home, "state", "acc");
+
+  await createCodexAdapter().install({ ...context, stateRoot });
+
+  const config = await configOf(context);
+  assert.match(config, /\[sandbox_workspace_write\]/);
+  assert.match(config, new RegExp(`writable_roots = \\[".*${
+    stateRoot.split(path.sep).at(-2)}.*"\\]`));
+});
+
+test("a config that sets its own sandbox is not written over", async t => {
+  const { context } = await fixture(t);
+  const config = path.join(context.codexHome, "config.toml");
+  await mkdir(context.codexHome, { recursive: true });
+  // Theirs, and declaring the table twice is what makes this client refuse the
+  // whole config - so the diagnostic says what to add rather than adding it.
+  await writeFile(config, "[sandbox_workspace_write]\nwritable_roots = [\"/tmp/theirs\"]\n");
+  const stateRoot = path.join(context.home, "state", "acc");
+
+  const result = await createCodexAdapter().install({ ...context, stateRoot });
+
+  const text = await readFile(config, "utf8");
+  assert.equal((text.match(/\[sandbox_workspace_write\]/g) ?? []).length, 1,
+    "the table is declared twice, which this client refuses to load at all");
+  assert.match(text, /writable_roots = \["\/tmp\/theirs"\]/);
+  assert.match(result.diagnostics.join(" "),
+    /sets its own sandbox_workspace_write.*read the roster and record nothing/s);
+});
+
+test("uninstall takes the sandbox declaration back out", async t => {
+  const { context } = await fixture(t);
+  const adapter = createCodexAdapter();
+  await adapter.install({ ...context, stateRoot: path.join(context.home, "state", "acc") });
+
+  await adapter.uninstall(context);
+
+  assert.doesNotMatch(await configOf(context).catch(() => ""), /sandbox_workspace_write/);
+});
+
+test("without a state directory nothing is declared", async t => {
+  const { context } = await fixture(t);
+  // An older caller, or one that has no state of its own to name. Writing an
+  // empty `writable_roots` would be worse than writing nothing.
+  await createCodexAdapter().install(context);
+
+  assert.doesNotMatch(await configOf(context), /sandbox_workspace_write/);
+});

--- a/packages/cli/src/doctor-command.mjs
+++ b/packages/cli/src/doctor-command.mjs
@@ -1,5 +1,6 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
+import path from "node:path";
 
 import { detectInstallation, loadOwnership, verifyOwned }
   from "@agents-can-communicate/installer";
@@ -37,9 +38,9 @@ async function diagnoseAdapters({ options, runtime }) {
   // The same home `acc install --home` writes to, or the real one. Reading a
   // different home than install wrote to reports every adapter as missing.
   const home = options?.home ?? runtime?.env?.HOME ?? homedir();
-  const clients = clientContext(home);
   const { data: dataHome } = platformPaths({ platform: runtime?.platform,
     env: runtime?.env ?? {} });
+  const clients = clientContext(home, path.join(dataHome, "acc"));
   const adapters = ALL_ADAPTERS();
   const detected = await detectInstallation({ adapters, context: clients,
     probeTimeoutMs: probeTimeout(runtime?.env) });

--- a/packages/cli/src/install-command.mjs
+++ b/packages/cli/src/install-command.mjs
@@ -17,12 +17,18 @@ import { platformPaths } from "./platform-paths.mjs";
 // Each client keeps its own directory under the user's home, and an adapter
 // pointed at the home itself writes beside them rather than inside them. That
 // install reports success and the client never reads a byte of it.
-export const clientContext = home => ({
+export const clientContext = (home, stateRoot) => ({
   home,
   configDir: path.join(home, ".claude"),
   agentsHome: home,
   codexHome: path.join(home, ".codex"),
   kimiHome: path.join(home, ".kimi-code"),
+  // Where ACC keeps its own state, for the client that has to be told. Codex
+  // sandboxes the commands a model runs to the workspace, and ACC's state is
+  // outside every workspace on purpose - so an agent there could read the
+  // roster and record nothing, every write failing with EPERM on the writer
+  // lock. Measured with `codex exec`, which is how an agent actually runs.
+  stateRoot,
 });
 
 export const ALL_ADAPTERS = () => [createClaudeCodeAdapter(), createCodexAdapter(),
@@ -153,9 +159,9 @@ export function actedOn(result) {
 export async function runInstallCommand({ options, runtime, action = "install" }) {
   const adapters = selectAdapters(options.adapter);
   const home = options.home ?? runtime.env?.HOME ?? homedir();
-  const context = clientContext(home);
   const { data: dataHome } = platformPaths({ platform: runtime.platform,
     env: runtime.env ?? {} });
+  const context = clientContext(home, path.join(dataHome, "acc"));
 
   const detected = await detectInstallation({ adapters, context,
     probeTimeoutMs: probeTimeout(runtime.env) });

--- a/packages/cli/test/install-command.test.mjs
+++ b/packages/cli/test/install-command.test.mjs
@@ -174,17 +174,23 @@ test("the install tells an adapter where ACC keeps its state", async t => {
   t.after(() => Promise.all([home, dataHome]
     .map(dir => rm(dir, { recursive: true, force: true }))));
 
-  // A client of this test's own, so it asks the same question everywhere.
+  // A client of this test's own, so it asks the same question everywhere. On the
+  // real PATH, because detection spawns the client's binary and a spawn
+  // inherits the process environment - passing a PATH in `runtime.env` looked
+  // like it worked here and found nothing on a machine without Codex.
   const bin = path.join(home, "bin");
   await makeDir(bin, { recursive: true });
   await writeFile(path.join(bin, "codex"), "#!/bin/sh\necho \"codex-cli 0.147.0\"\n");
   await chmod(path.join(bin, "codex"), 0o755);
+  const previous = process.env.PATH;
+  process.env.PATH = `${bin}${path.delimiter}${previous}`;
+  t.after(() => { process.env.PATH = previous; });
 
   await runInstallCommand({
     options: { home, adapter: "codex" },
     runtime: { platform: process.platform,
-      env: { ...process.env, PATH: `${bin}${path.delimiter}${process.env.PATH}`,
-        HOME: home, ACC_DATA_HOME: dataHome, ACC_PROBE_TIMEOUT_MS: "30000" } },
+      env: { ...process.env, HOME: home, ACC_DATA_HOME: dataHome,
+        ACC_PROBE_TIMEOUT_MS: "30000" } },
     action: "install" });
 
   // Codex sandboxes what a model runs to the workspace, and ACC's state is

--- a/packages/cli/test/install-command.test.mjs
+++ b/packages/cli/test/install-command.test.mjs
@@ -166,3 +166,31 @@ test("`--yes` is gone from the commands that never asked", async () => {
   // `config init` does ask, so there it still means something.
   assert.equal(parseArgs(["config", "init", "--yes"]).options.yes, true);
 });
+
+test("the install tells an adapter where ACC keeps its state", async t => {
+  const { chmod, mkdir: makeDir } = await import("node:fs/promises");
+  const home = await realpath(await mkdtemp(path.join(tmpdir(), "acc-state-home-")));
+  const dataHome = await realpath(await mkdtemp(path.join(tmpdir(), "acc-state-data-")));
+  t.after(() => Promise.all([home, dataHome]
+    .map(dir => rm(dir, { recursive: true, force: true }))));
+
+  // A client of this test's own, so it asks the same question everywhere.
+  const bin = path.join(home, "bin");
+  await makeDir(bin, { recursive: true });
+  await writeFile(path.join(bin, "codex"), "#!/bin/sh\necho \"codex-cli 0.147.0\"\n");
+  await chmod(path.join(bin, "codex"), 0o755);
+
+  await runInstallCommand({
+    options: { home, adapter: "codex" },
+    runtime: { platform: process.platform,
+      env: { ...process.env, PATH: `${bin}${path.delimiter}${process.env.PATH}`,
+        HOME: home, ACC_DATA_HOME: dataHome, ACC_PROBE_TIMEOUT_MS: "30000" } },
+    action: "install" });
+
+  // Codex sandboxes what a model runs to the workspace, and ACC's state is
+  // outside every workspace by design - so an adapter that is never told where
+  // that state is cannot declare it, and an agent there writes nothing.
+  const config = await readFile(path.join(home, ".codex", "config.toml"), "utf8");
+  assert.match(config, /\[sandbox_workspace_write\]/);
+  assert.match(config, new RegExp(`writable_roots = \\["${dataHome}/acc"\\]`));
+});


### PR DESCRIPTION
Found by running a real `codex exec` against a claimed file — the first time this project has driven that client with a live model rather than with hand-written payloads.

The guard worked, exactly as it should. The agent's own report:

```
The edit tool refused the patch verbatim:
  Command blocked by PreToolUse hook: file:src/parser.mjs is claimed by alice (session …)

The coordination `work` and `claim` commands each failed with:
  EPERM: operation not permitted, mkdir
  '.../acc/workspaces/<id>/locks/writer.lock'
```

## Two correct designs meeting badly

Codex sandboxes the shell commands a model runs to the workspace. ACC keeps its state **outside** every workspace on purpose — that rule has its own test, its own refusal, and a release entry of its own.

So an agent in Codex could read the roster and record nothing. `acc claim`, `acc work`, `acc message`, `acc request`, `acc finish` — every write. The half of the product where an agent *acts* rather than watches, silently, for one of the four clients.

## The fix

The install declares that directory writable in the block it already owns:

```toml
# >>> agents-can-communicate (managed; edits here are overwritten)
[marketplaces.acc-local]
…
[sandbox_workspace_write]
writable_roots = ["/Users/…/Library/Application Support/acc"]
# <<< agents-can-communicate
```

A config that declares `sandbox_workspace_write` itself is **left alone** — declaring a table twice is what makes this client refuse the whole config, which the adapter already knows about marketplaces — and the diagnostic says what to add instead:

> this config sets its own sandbox_workspace_write; add `<path>` to writable_roots, or an agent here can read the roster and record nothing

The state directory reaches the adapter through the client context, which is also why `doctor` builds the same context.

## Measured the same way it was found

```
$ codex exec -s workspace-write "Publish an ACC intent … and quote its output."
The command succeeded with exit code 0.
> intent: reviewing the parser
```

No flags passed by hand. Before: `EPERM … locks/writer.lock`.

## Verification

- 877 tests passing, 0 failing · `syntax ok in 185 file(s)`
- recorded: `sha256 5a5f6b8b…76bf0` built from `f86a5c5`

Four mutations, all caught — the fourth only after I closed the gap it exposed:

| Mutation | Caught by |
|---|---|
| the writable root is never declared | `the state directory is declared writable, or agents here cannot record` |
| it overwrites a sandbox the user declared | `a config that sets its own sandbox is not written over` |
| it declares an empty root when there is none | `without a state directory nothing is declared` |
| **the state directory never reaches the adapters** | `the install tells an adapter where ACC keeps its state` — added after this survived, since the adapter tests pass it in themselves |
