### PR TITLE
docs: the promise about addressing names its condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,20 @@ Measured with `codex exec`, which is how an agent actually runs: the same
 command that failed with EPERM now returns `intent: reviewing the parser` and
 exit 0, with no flags passed by hand.
 
+## Unreleased
+
+Not published. Documentation only; the packed tarball is unchanged, so the
+record below still describes it.
+
+`docs/CLI.md` names the condition on the promise it makes. It said an agent can
+close its terminal and the next session it opens is still told - true only when
+that agent has a name of its own. Without one, each run is a new participant and
+nothing addressed to the last one reaches it. `docs/PROTOCOL.md` had said so all
+along; the document a reader acts from had not.
+
+Seen while running two real clients against one workspace: consecutive runs
+appeared as `kimi-5P8POZ`, then `kimi-qUW4ei`.
+
 ## 0.1.5
 
 One fix, and the most serious so far: every published version taught agents a

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -168,7 +168,14 @@ appears as an attention item addressed to them, and the message explains why. A 
 no message is work nobody understands; a message with no task is a request nothing tracks.
 
 Work is addressed to a **participant**, not a session. The agent can close its terminal and
-the next session it opens is still told. Only that participant can take it:
+the next session it opens is still told — as long as that agent has a name of its own.
+Without one, each run is a new participant, so nothing addressed to the last one reaches it:
+
+```bash
+ACC_PARTICIPANT=backend-codex codex
+```
+
+Only that participant can take the work:
 
 ```bash
 acc task --task task_x --take     # exit 5 if it is not yours


### PR DESCRIPTION
Two documents, one promise, one condition — stated in the wrong one.

`docs/PROTOCOL.md`:

> `ACC_PARTICIPANT` pins a durable name, which is what lets work addressed to an agent survive it restarting.

`docs/CLI.md`:

> Work is addressed to a **participant**, not a session. The agent can close its terminal and the next session it opens is still told.

The second is false without the first. And `docs/CLI.md` is the document somebody reads **while running the commands**.

Seen rather than reasoned about: running two real clients against one workspace, consecutive runs appeared as separate participants —

```
kimi-5P8POZ  →  kimi-qUW4ei
claude_code-OCbU4H  →  claude_code-lqwoyg
```

so `acc request --to <the previous one>` would have addressed a participant that no longer runs anywhere.

The default is deliberate and the code says so: it distinguishes two sessions of the same client, and an agent meant to be addressable across restarts is named by whoever launches it. Nothing about that changes here — only the sentence that promised the result without the condition.

Documentation only. The tarball is unchanged, so the recorded digest still describes it, and 879 tests pass.
