### PR TITLE
fix: status says when the sessions it counts are not answering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,9 +51,9 @@ appeared as `kimi-5P8POZ`, then `kimi-qUW4ei`.
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `f0100c9` |
+| Tarball | `agents-can-communicate-0.1.5.tgz`, 135 KB, 109 entries |
+| sha256 | `24ce109ae1928fde21ab22bf89f42bff35b2b20add7e089b7eab6a283534a1c1` |
 | Tests | 880 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,29 @@ along; the document a reader acts from had not.
 Seen while running two real clients against one workspace: consecutive runs
 appeared as `kimi-5P8POZ`, then `kimi-qUW4ei`.
 
+## Unreleased
+
+| | |
+|---|---|
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
+| Tests | 880 passing, 0 failing |
+
+Not published. A published record says what the registry serves and is not
+rewritten, so shipped code that changes after a release is measured here instead.
+
+`acc status` says when the sessions it counts are not answering. `live` means
+present rather than online - a client that exits without closing its session
+leaves a record that goes stale rather than disappearing - so the line read
+`1 live` about a workspace whose only agent had left minutes before. The data
+was right the whole time: the same call reported `presence: stale` and
+`counts.stale: 1`. The sentence a person reads was the part that was not.
+
+Found by running a real client and watching what it left behind: a short run
+closes its session on the way out, and a longer one does not always get that
+far.
+
 ## 0.1.5
 
 One fix, and the most serious so far: every published version taught agents a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 | | |
 |---|---|
-| Built from | `5fb3cfd` |
+| Built from | `f0100c9` |
 | Tarball | `agents-can-communicate-0.1.5.tgz`, 135 KB, 109 entries |
-| sha256 | `98995091e8d17f8ec34f84246f4f993e663d036a6ebeb24e938db8946944d09d` |
-| Tests | 879 passing, 0 failing |
+| sha256 | `24ce109ae1928fde21ab22bf89f42bff35b2b20add7e089b7eab6a283534a1c1` |
+| Tests | 880 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not
 rewritten, so shipped code that changes after a release is measured here instead.
@@ -33,11 +33,6 @@ Measured with `codex exec`, which is how an agent actually runs: the same
 command that failed with EPERM now returns `intent: reviewing the parser` and
 exit 0, with no flags passed by hand.
 
-## Unreleased
-
-Not published. Documentation only; the packed tarball is unchanged, so the
-record below still describes it.
-
 `docs/CLI.md` names the condition on the promise it makes. It said an agent can
 close its terminal and the next session it opens is still told - true only when
 that agent has a name of its own. Without one, each run is a new participant and
@@ -46,18 +41,6 @@ along; the document a reader acts from had not.
 
 Seen while running two real clients against one workspace: consecutive runs
 appeared as `kimi-5P8POZ`, then `kimi-qUW4ei`.
-
-## Unreleased
-
-| | |
-|---|---|
-| Built from | `f0100c9` |
-| Tarball | `agents-can-communicate-0.1.5.tgz`, 135 KB, 109 entries |
-| sha256 | `24ce109ae1928fde21ab22bf89f42bff35b2b20add7e089b7eab6a283534a1c1` |
-| Tests | 880 passing, 0 failing |
-
-Not published. A published record says what the registry serves and is not
-rewritten, so shipped code that changes after a release is measured here instead.
 
 `acc status` says when the sessions it counts are not answering. `live` means
 present rather than online - a client that exits without closing its session

--- a/packages/cli/src/doctor-command.mjs
+++ b/packages/cli/src/doctor-command.mjs
@@ -7,6 +7,7 @@ import { detectInstallation, loadOwnership, verifyOwned }
 import { AccError, EXIT } from "@agents-can-communicate/protocol";
 
 import { ALL_ADAPTERS, clientContext, probeTimeout } from "./install-command.mjs";
+import { describePresence } from "./main.mjs";
 import { platformPaths } from "./platform-paths.mjs";
 import { noticeUpdate } from "./update-check.mjs";
 import { diagnoseFilesystemStore, repairFilesystemStore }
@@ -130,7 +131,7 @@ export async function runDoctor({ options, context, runtime }) {
   // command documented as saying "what to run next" said it only to `--json`.
   // A person running `acc doctor` on a client wired to an older plugin was told
   // the store was healthy and nothing else.
-  const text = [`store healthy; ${status.counts.live} live session(s); `
+  const text = [`store healthy; ${describePresence(status.counts)}; `
     + `protection ${status.protection}; ${installed} of ${adapters.length} adapter(s) installed`,
   ...data.remediation.map(line => `  ${line}`)].join("\n");
   return { data, text };

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -42,6 +42,14 @@ async function openContext(options, runtime) {
 
 const human = value => (typeof value === "string" ? value : JSON.stringify(value, null, 2));
 
+/** How many are here, and how many only look it. */
+export function describePresence({ live = 0, stale = 0 } = {}) {
+  if (live === 0) return "0 live";
+  if (stale === 0) return `${live} live`;
+  if (stale === live) return `${live} present, none answering`;
+  return `${live} live (${stale} not answering)`;
+}
+
 const HANDLERS = Object.freeze({
   attach: async ({ options, context }) => {
     const session = await context.service.openSession({
@@ -241,7 +249,12 @@ const HANDLERS = Object.freeze({
   status: async ({ options, context }) => {
     const status = await context.service.collectStatus({
       participantId: options.participant, all: options.all === true });
-    const text = `${status.counts.live} live; ${status.counts.claims} claim(s); `
+    // `live` counts everyone present, which includes sessions gone stale - a
+    // client that exited without its session being closed keeps a record that
+    // stops being answered but does not disappear. Printing the number alone
+    // said "1 live" about a workspace where the last agent had left minutes
+    // before, which is the one thing a person reads this line to find out.
+    const text = `${describePresence(status.counts)}; ${status.counts.claims} claim(s); `
       + `protection ${status.protection}`;
     return { data: status, text };
   },

--- a/packages/cli/test/install-command.test.mjs
+++ b/packages/cli/test/install-command.test.mjs
@@ -200,3 +200,18 @@ test("the install tells an adapter where ACC keeps its state", async t => {
   assert.match(config, /\[sandbox_workspace_write\]/);
   assert.match(config, new RegExp(`writable_roots = \\["${dataHome}/acc"\\]`));
 });
+
+test("the status line says when the sessions it counts are not answering", async () => {
+  const { describePresence } = await import("../src/main.mjs");
+
+  // `live` counts everyone present, and a session goes stale rather than
+  // vanishing when its client exits without closing it. The number alone said
+  // "1 live" about a workspace whose last agent had left minutes before -
+  // measured, by running a real client and watching what it left behind.
+  assert.equal(describePresence({ live: 0, stale: 0 }), "0 live");
+  assert.equal(describePresence({ live: 2, stale: 0 }), "2 live");
+  assert.equal(describePresence({ live: 1, stale: 1 }), "1 present, none answering");
+  assert.equal(describePresence({ live: 3, stale: 3 }), "3 present, none answering");
+  assert.equal(describePresence({ live: 3, stale: 1 }), "3 live (1 not answering)");
+  assert.equal(describePresence(), "0 live");
+});


### PR DESCRIPTION
Found by running a real Claude Code session and watching what it left behind.

```
$ acc status                      # minutes after the only agent exited
1 live; 0 claim(s); protection none

$ acc status --all --json
claude_code-hROkO7   presence=stale
counts: {"live": 1, "stale": 1, …}
```

**Nothing was miscounted.** `live` means *present* rather than *online*, and the same call already reported `presence: stale` and `counts.stale: 1`. The number and the sentence disagreed about what `live` means, and only the sentence was addressed to a person — who reads that line to find out whether anybody is there.

```
1 present, none answering; 0 claim(s); protection none
3 live (1 not answering); 2 claim(s); protection guarded
```

`acc doctor` uses the same phrase.

## Why a session outlives its client

A short `claude -p` run closes its session on the way out — `SessionEnd` fires, the record goes, the binding is cleared, and the participant stays, which is right:

```
short run,  after exit:  participants=1 sessions=0 bindings=0
```

A longer one did not get that far:

```
longer run, during:      sessions=1 bindings=1   status: 1 live
longer run, after exit:  sessions=1 bindings=1   status: 1 live
```

The staleness classifier is the designed answer to that, and it worked — the session was `stale` when I looked. This is the report catching up with it.

## Also: one Unreleased section, not three

I had been adding a new `## Unreleased` heading each time instead of writing into the one already there, so three had stacked up, two of them carrying their own measurement table. The gate reads the first record in the file, which is why it kept passing while the document said "Unreleased" three times. Merged, keeping every paragraph in the order it was written and the newest measurement.

## Verification

- 880 tests passing, 0 failing
- recorded: `sha256 24ce109a…34a1c1` built from `f0100c9`
- mutation: dropping the all-stale phrase fails `the status line says when the sessions it counts are not answering`

The wording is a pure function with its own test, so none/some/all are asserted without needing a stale session to exist.
