### PR TITLE
release: 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,20 @@
 # Changelog
 
-## Unreleased
+## 0.1.6
+
+Five fixes, and the one that matters most is that an agent in Codex can act at
+all. Everything here came out of driving the real clients with live models
+rather than with hand-written payloads.
 
 | | |
 |---|---|
-| Built from | `f0100c9` |
-| Tarball | `agents-can-communicate-0.1.5.tgz`, 135 KB, 109 entries |
-| sha256 | `24ce109ae1928fde21ab22bf89f42bff35b2b20add7e089b7eab6a283534a1c1` |
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
 | Tests | 880 passing, 0 failing |
-
-Not published. A published record says what the registry serves and is not
-rewritten, so shipped code that changes after a release is measured here instead.
+| Node | 24 (current production LTS) |
+| Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
+| Not supported | Windows — untested rather than known-broken |
 
 Every binary the manifest declares is executable in the repository.
 `bin/acc-hook.mjs` was not, while its two siblings were. npm sets the bit when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ rather than with hand-written payloads.
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `b047ec5` |
+| Tarball | `agents-can-communicate-0.1.6.tgz`, 136 KB, 109 entries |
+| sha256 | `66c50759dbfb5cec31f6fa128e454542eb4f89fdb5fcdcd2ca9c9421f14d04fa` |
 | Tests | 880 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -102,51 +102,51 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.1.5"
+      "version": "0.1.6"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.1.5"
+      "version": "0.1.6"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.1.5"
+      "version": "0.1.6"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.1.5"
+      "version": "0.1.6"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.1.5"
+      "version": "0.1.6"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.1.5"
+      "version": "0.1.6"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.1.5"
+      "version": "0.1.6"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.1.5"
+      "version": "0.1.6"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.1.5"
+      "version": "0.1.6"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.1.5"
+      "version": "0.1.6"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.1.5"
+      "version": "0.1.6"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.1.5"
+      "version": "0.1.6"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "description": "Local-first coordination for independently opened AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-claude-code/plugin/.claude-plugin/plugin.json
+++ b/packages/adapter-claude-code/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Coordinate this Claude Code session with other AI agent sessions working in the same workspace: shared presence, resource claims, typed messages, and handoffs."
 }

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/plugin/.codex-plugin/plugin.json
+++ b/packages/adapter-codex/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Coordinate this Codex session with other AI agent sessions working in the same workspace.",
   "license": "UNLICENSED",
   "keywords": ["coordination", "multi-agent", "claims", "handoff"],

--- a/packages/adapter-gemini-cli/extension/gemini-extension.json
+++ b/packages/adapter-gemini-cli/extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Coordinate this Gemini CLI session with other AI agent sessions working in the same workspace.",
   "contextFileName": "skills/acc/SKILL.md"
 }

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/plugin/.kimi-plugin/plugin.json
+++ b/packages/adapter-kimi/plugin/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Coordinate this Kimi Code session with other AI agent sessions working in the same workspace: shared presence, resource claims, typed messages, and handoffs.",
   "skills": "./skills/",
   "sessionStart": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.mjs" },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Five fixes. All of them came out of driving the real clients with live models rather than with hand-written payloads, and the first one is why this should not wait.

| | |
|---|---|
| **#70** | **An agent in Codex can act at all.** That client sandboxes what a model runs to the workspace; ACC keeps its state outside every workspace on purpose. So `acc claim`, `acc work`, `acc message` each failed with `EPERM … locks/writer.lock`. On the registry today, a Codex agent reads the roster and records nothing |
| #73 | `acc status` said `1 live` about a workspace whose only agent had left minutes before |
| #71 | `bin/acc-hook.mjs` was not executable in the repository, while its two siblings were |
| #72 | `docs/CLI.md` promised work survives a restart without naming the condition that makes it true |
| — | one `## Unreleased` section in the changelog instead of three |

## Verified on the artifact, against the real client

```
1. acc --version → 0.1.6
2. the table the Codex fix writes:
     [sandbox_workspace_write]
     writable_roots = ["~/Library/Application Support/acc"]

3. a real codex agent, default sandbox, no flags:
     Succeeded (exit code 0).
     > intent: reviewing the parser

4. and the guard still refuses a claimed file:
     Command blocked by PreToolUse hook: file:src/parser.mjs is claimed by alice (session …)
     file untouched: 0 changes
```

Step 3 is the fix. Step 4 is the thing that already worked, checked again because the fix touches the same config block.

## Record

```
PASS  agents-can-communicate-0.1.6.tgz  sha256 66c50759…4d04fa  built from b047ec5
```

136 KB, 109 entries. 880 tests passing, 0 failing · `syntax ok in 185 file(s)`.

The bump broke nothing — seventh release in a row.
