### PR TITLE
fix: a claim holds against the shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,71 @@
 # Changelog
 
+## Unreleased
+
+| | |
+|---|---|
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
+| Tests | 906 passing, 0 failing |
+
+Not published. A published record says what the registry serves and is not
+rewritten, so shipped code that changes after a release is measured here instead.
+
+A claim now holds against the shell. Found by asking a live Codex session to
+append a line to a file another agent held guarded, and watching it succeed.
+
+`printf '%s\n' '// via shell' >> src/parser.mjs` went through untouched, on a
+`guarded` claim, in a workspace ACC reported as protected. So did `sed -i`, `mv`,
+`rm` and every other shell write - on all four clients. The guard only ever read
+the path out of an editing tool's arguments, and a shell call declares no path.
+
+That was a deliberate decision, and its reasoning was sound: a command can write
+anywhere, and a path *guessed* out of one blocks work at random while still
+missing real writes. What it did not account for is that agents in these harness
+are told to prefer the shell for file edits - this session's own instructions say
+exactly that - so the uncovered path is not the exotic one. It is the default
+one.
+
+The answer is not to guess. The command is read for the positions where a write
+is unambiguous, and for nothing else:
+
+- a redirection - `> file`, `>> file`, `2> file` - but never `< file`, and never
+  `/dev/null`
+- the operands of commands whose whole job is to put bytes somewhere: `tee`,
+  `touch`, `truncate`, `dd of=`, `rm`, `mv`, `cp`, `ln`, `install`
+- in-place editors, only when the in-place flag is present: `sed -i`, `perl -i`
+- `git restore` and `git checkout --`, which overwrite whatever a peer was
+  holding
+
+A read is never reported. `cat file`, `grep file`, `sed` without `-i` and
+`git diff file` all name a path and write nothing, and blocking a session for
+looking would be a worse failure than the one being fixed. Quoted text is text,
+a heredoc body is content, and every command in a `&&` chain or a pipeline is
+read rather than only the first.
+
+Coverage is partial on purpose and the injected context now says so, where an
+agent reads it: `file edits and recognised shell writes are blocked; a runtime
+can still get past`. It used to promise the opposite - `edits made through a
+shell are not` - which was honest about the gap and, read by an agent under
+instructions to use the shell, amounted to directions around the guard. A
+language runtime opening the file itself is still unseen. An agent that knows
+where a guard ends behaves better than one that believes it absolute.
+
+A claim is given back the way it was taken. `acc claim` takes `--resource` and
+`acc release` took `--claim`, so handing one back meant a round trip through
+`acc status --json` to find an id the caller never chose. Watched costing a live
+agent a step mid-task. `--resource` now works on `release`; the id still works,
+and stays the precise answer when an authority releases someone else's claim.
+
+`acc uninstall` clears the trust record Codex keeps about ACC's hooks. That
+client writes one table per hook, keyed by the plugin that declared them; ACC
+writes none of them, so five were left behind naming a plugin that no longer
+existed, and five more arrived on the next install. Checked before touching
+them: a hook whose recorded hash no longer matches still runs, so this is
+tidiness rather than repair. Only keys carrying ACC's own
+`plugin@marketplace` prefix are removed.
+
 ## 0.1.6
 
 Five fixes, and the one that matters most is that an agent in Codex can act at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `8b049fe` |
+| Tarball | `agents-can-communicate-0.1.6.tgz`, 142 KB, 110 entries |
+| sha256 | `f2cc7c8e4b68e869c230cbe05c9b41d6c539986411b15e1413e60b7a5f697853` |
 | Tests | 906 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not

--- a/docs/ADAPTER_AUTHORING.md
+++ b/docs/ADAPTER_AUTHORING.md
@@ -75,7 +75,8 @@ tool output; none of it may survive.
 ```js
 return normalizedEvent({
   kind, sessionId, cwd, model, parentSessionId, tool,
-  targets,   // paths this call would WRITE. [] for shell — a command names no resource.
+  targets,   // paths this call would WRITE. For a shell call, pass the command to
+             // shellWriteTargets() — it reads write positions only, never reads.
 });
 ```
 

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -60,10 +60,17 @@ toolset contained no `apply_patch`.
 `plan` modes the client declares no write tool to the model at all. `write_file` and
 `replace` appear under `auto_edit`; `run_shell_command` under `yolo`.
 
-**`guards.beforeShell` is never resource-aware.** A shell command can write anywhere, and
-ACC does not parse commands. The guard fires and is allowed through, because guessing a
-path out of a command would block work at random and still miss real writes. Shell calls
-therefore declare no targets on every adapter.
+**`guards.beforeShell` is resource-aware where the write is unambiguous.** ACC reads the
+command for its write positions only - a redirection, an operand of a command whose whole
+job is to put bytes somewhere - and declares those paths as targets. Reading positions are
+left alone: `cat file` and `grep file` name a path and write nothing, and treating them as
+writes would have sessions blocking each other for looking.
+
+What it does not see is a language runtime opening the file itself (`python3 -c
+"open(...)"`), a command assembled at runtime, or an `eval`. A shell can still evade the
+guard. Until 0.1.7 every shell write did, which is why partial sight is the improvement it
+is: a session told to prefer the shell for file changes walked through every claim in the
+workspace.
 
 Where the guard cannot help, the turn context does: it names the claims other sessions
 hold and says which way this session stands with them. Two facts decide the wording -
@@ -71,7 +78,7 @@ what the claim's owner asked for, and whether ACC can stop this session at all:
 
 | Claim | This session | Note |
 |---|---|---|
-| guarded | can be guarded | `file edits are blocked; edits made through a shell are not` |
+| guarded | can be guarded | `file edits and recognised shell writes are blocked; a runtime can still get past` |
 | guarded | cannot be guarded | `not enforced for this session; do not edit it` |
 | advisory | either | `advisory; nothing will stop you, the owner is asking` |
 
@@ -154,5 +161,9 @@ harness name. Both default to the weaker reading, so a generic MCP client or a h
 the CLI reads as advisory and manual.
 
 A workspace reports `protection: guarded` only when every live session can be stopped. One
-MCP client, one Kimi session, or one Codex session on a shell-editing model, and a guarded
-claim is advice - so the workspace says `advisory`, whatever its claims were declared as.
+MCP client and a guarded claim is advice - so the workspace says `advisory`, whatever its
+claims were declared as.
+
+"Stoppable" is not "unevadable". Even in a guarded workspace, a session that writes through
+a language runtime rather than a recognised shell form gets past. The claim still says who
+is working where; enforcement is the floor, not the ceiling.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -60,7 +60,7 @@ graph LR
 | `acc sync` | New events since a cursor; silent when alone |
 | `acc work` | Publish what this session is doing. `--clear` when it has stopped |
 | `acc claim` | Reserve a resource. Exit `5` on conflict |
-| `acc release` | Give it back |
+| `acc release` | Give it back. `--resource` for what you claimed, `--claim` for its id |
 | `acc ack` | Answer a message that asked for one, so it stops asking |
 | `acc message` | Send a typed message to participants |
 | `acc request` | Ask another agent to do something. One call: the work plus why |

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -140,7 +140,10 @@ asked what the whole system is doing.
 
 ## Protection is a property of the room
 
-A claim is `guarded` only while every live session can actually be stopped. One MCP client,
-one shell-editing model, and the workspace reports `advisory` — because that is the truth.
+A claim is `guarded` only while every live session can actually be stopped. One MCP client
+and the workspace reports `advisory` — because that is the truth.
+
+Being stoppable is not the same as being unevadable. A guarded claim stops file edits and
+the shell writes ACC can read; a language runtime opening the file gets past either way.
 
 See [CAPABILITIES.md](CAPABILITIES.md) for what each client was measured doing.

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -35,6 +35,20 @@ Why ACC is shaped the way it is, and what is deliberately still open.
 | Reporting queued messages as delivered | A delivery state that overstates itself is worse than no state. |
 | Guessing file paths out of shell commands | It would block work at random and still miss real writes. See [CAPABILITIES.md](CAPABILITIES.md). |
 
+**Reversed in 0.1.7: reading write positions out of shell commands.** The row above still
+holds against *guessing*, and it is kept rather than deleted because the reasoning behind
+it is what shaped the replacement. What changed is the evidence: a live Codex session was
+asked to append a line to a file another agent held guarded, and `printf ... >> file` went
+through untouched. Meanwhile agents in this harness are told to prefer the shell for file
+edits, so the gap was not an edge case but the common path.
+
+The answer is not to guess. Write positions are read - a redirection, the operand of a
+command whose job is to put bytes somewhere - and nothing else is. A read is never
+reported, so the "blocks work at random" failure the original row feared cannot occur: the
+only paths declared are ones the command would write. Coverage is deliberately partial and
+[CAPABILITIES.md](CAPABILITIES.md) says where it ends, because an agent that knows where a
+guard stops behaves better than one that believes it absolute.
+
 ## Still open
 
 1. **Storage backend.** The hardened filesystem store ships first. A transactional backend

--- a/packages/adapter-claude-code/src/hooks.mjs
+++ b/packages/adapter-claude-code/src/hooks.mjs
@@ -1,4 +1,4 @@
-import { normalizedEvent } from "@agents-can-communicate/adapter-sdk";
+import { normalizedEvent, shellWriteTargets } from "@agents-can-communicate/adapter-sdk";
 import { AccError, EXIT } from "@agents-can-communicate/protocol";
 
 // Confirmed by capture on 2.1.233, and matching the published documentation
@@ -66,10 +66,15 @@ export const CLAUDE_EDIT_TOOLS = Object.freeze(["Write", "Edit", "MultiEdit",
  * Only the path is taken. `content`, `old_string` and `new_string` are the
  * file's contents, which ACC has no use for and must not carry.
  *
- * `Bash` declares nothing: a command can write anywhere, and a path guessed out
- * of one gives a guard that is wrong in both directions.
+ * `Bash` declares no path, but its command names the ones it would write. Those
+ * are read out of the write positions only - a redirection, an operand of a
+ * command whose job is to put bytes somewhere - because a session told to prefer
+ * the shell would otherwise walk through every claim in the workspace. The
+ * command string itself is conversation content and stays out; only paths leave
+ * this function.
  */
 function writeTargets(tool, input) {
+  if (tool === "Bash") return shellWriteTargets(input?.command);
   if (!CLAUDE_EDIT_TOOLS.includes(tool)) return [];
   const target = input?.file_path ?? input?.notebook_path;
   return typeof target === "string" && target !== "" ? [target] : [];

--- a/packages/adapter-claude-code/test/adapter.test.mjs
+++ b/packages/adapter-claude-code/test/adapter.test.mjs
@@ -157,7 +157,7 @@ test("the guard sees this client's real tool names", async () => {
   assert.doesNotMatch(matcher, /apply_patch/);
 });
 
-test("an edit declares the path it would write, a shell call declares none", async () => {
+test("an edit declares the path it would write, and so does a shell write", async () => {
   // Captured from 2.1.233: Write takes file_path/content, Edit takes file_path
   // with old_string/new_string. Without the path a guard has nothing to compare
   // against a claim.
@@ -165,8 +165,16 @@ test("an edit declares the path it would write, a shell call declares none", asy
   assert.equal(edit.tool, "Edit");
   assert.deepEqual([...edit.targets], ["/tmp/example-workspace/notes.txt"]);
 
-  // The surviving PreToolUse fixture is the Bash one.
+  // The surviving PreToolUse fixture is the Bash one, and `echo probe` writes
+  // nothing. A command that does write is a different matter: this session is
+  // itself told to prefer the shell for file changes, which is precisely why
+  // the command is read rather than waved through.
   assert.deepEqual([...normalizeClaudeHook(await captured("PreToolUse")).targets], []);
+
+  const shell = normalizeClaudeHook({ hook_event_name: "PreToolUse", session_id: "s",
+    cwd: "/tmp", tool_name: "Bash",
+    tool_input: { command: "printf '// x' >> /tmp/example-workspace/notes.txt" } });
+  assert.deepEqual([...shell.targets], ["/tmp/example-workspace/notes.txt"]);
 });
 
 test("reading a file is not a write", () => {

--- a/packages/adapter-codex/COMPATIBILITY.md
+++ b/packages/adapter-codex/COMPATIBILITY.md
@@ -228,7 +228,7 @@ write, so it says so before the turn instead:
 
 ```text
 2 session(s); cursor 0000000000000004
-- [claim] file:src/** held by models - file edits are blocked; edits made through a shell are not
+- [claim] file:src/** held by models - file edits and recognised shell writes are blocked; a runtime can still get past
 - session_9Xo… (cli, online)
 - session_BlU… (codex, online)
 ```
@@ -241,7 +241,7 @@ asked for, and whether ACC can stop this particular session:
 
 | Claim | This session | Note |
 |---|---|---|
-| guarded | can be guarded | `file edits are blocked; edits made through a shell are not` |
+| guarded | can be guarded | `file edits and recognised shell writes are blocked; a runtime can still get past` |
 | guarded | cannot be guarded | `not enforced for this session; do not edit it` |
 | advisory | either | `advisory; nothing will stop you, the owner is asking` |
 

--- a/packages/adapter-codex/src/adapter.mjs
+++ b/packages/adapter-codex/src/adapter.mjs
@@ -62,10 +62,12 @@ export function createCodexAdapter() {
           // property of the model's metadata (apply_patch_tool_type), not a user
           // setting. With a model that does not have it, edits go through
           // exec_command, which reaches hooks as tool_name \"Bash\" carrying a
-          // command string - and a command names no resource, so a write guard
-          // has nothing to match. Verified on 0.147.0.
-          "write guards apply only to models that offer apply_patch; with the rest, "
-            + "edits run through the shell and cannot be matched to a claim",
+          // command string. Since 0.1.7 that command is read for its write
+          // positions, so those edits are matched too - as far as the reading
+          // goes. Verified on 0.147.0.
+          "write guards cover apply_patch and the shell writes ACC can read; a model "
+            + "without apply_patch edits through the shell, where a redirection or an "
+            + "mv is matched and a runtime opening the file is not",
           "Codex requires hooks to be trusted before they run; an untrusted plugin is "
             + "installed but inert",
         ],

--- a/packages/adapter-codex/src/hooks.mjs
+++ b/packages/adapter-codex/src/hooks.mjs
@@ -1,4 +1,4 @@
-import { normalizedEvent } from "@agents-can-communicate/adapter-sdk";
+import { normalizedEvent, shellWriteTargets } from "@agents-can-communicate/adapter-sdk";
 import { AccError, EXIT } from "@agents-can-communicate/protocol";
 
 // The event names are settled: they are an enum in the installed 0.147.0 binary,
@@ -68,7 +68,7 @@ export function normalizeCodexHook(payload) {
     model: pick(payload, FIELD_CANDIDATES.model),
     parentSessionId: pick(payload, FIELD_CANDIDATES.parentSessionId),
     tool,
-    targets: patchTargets(tool, payload?.tool_input),
+    targets: writeTargets(tool, payload?.tool_input),
   });
 }
 
@@ -76,6 +76,7 @@ export function normalizeCodexHook(payload) {
 // patch body, one per operation, so a single call can touch several files.
 // Reading `tool_input.path` here - the shape every other harness uses - would
 // find nothing and leave every edit unguarded.
+const PATCH_ENVELOPE = "*** Begin Patch";
 const PATCH_OPERATION = /^\*\*\* (?:Add|Update|Delete) File: (.+)$/;
 const PATCH_MOVE = /^\*\*\* Move to: (.+)$/;
 
@@ -86,15 +87,33 @@ const PATCH_MOVE = /^\*\*\* Move to: (.+)$/;
  * are never read: they are the file's contents, which ACC has no use for.
  */
 export function patchTargets(tool, input) {
-  if (tool !== "apply_patch") return [];
   const body = input?.command ?? input?.patch ?? input?.input;
   if (typeof body !== "string") return [];
+  if (tool !== "apply_patch" && !body.trimStart().startsWith(PATCH_ENVELOPE)) return [];
   const targets = [];
   for (const line of body.split("\n")) {
     const operation = PATCH_OPERATION.exec(line) ?? PATCH_MOVE.exec(line);
     if (operation !== null) targets.push(operation[1].trim());
   }
   return targets;
+}
+
+/**
+ * The paths a tool call would write.
+ *
+ * The guard is wired to three tool names here, and which one a shell command
+ * arrives under is a property of the model's metadata rather than of this
+ * config. So the shape decides instead of the name: a patch envelope is read as
+ * a patch, and any other command string is read as a shell command. Reading
+ * positions in that command are left alone.
+ */
+export function writeTargets(tool, input) {
+  const patched = patchTargets(tool, input);
+  if (patched.length > 0) return patched;
+  const command = input?.command ?? input?.input;
+  if (typeof command !== "string") return [];
+  if (command.trimStart().startsWith(PATCH_ENVELOPE)) return [];
+  return shellWriteTargets(command);
 }
 
 /**

--- a/packages/adapter-codex/src/install.mjs
+++ b/packages/adapter-codex/src/install.mjs
@@ -229,6 +229,34 @@ async function removeEmptyDirs(directories) {
   }
 }
 
+/**
+ * Drop the client's trust record for hooks that are about to stop existing.
+ *
+ * Scoped to tables whose key begins with ACC's own `plugin@marketplace:` - a
+ * table belonging to any other plugin is the client's business and stays. The
+ * file is rewritten only when something was found, so an install that never ran
+ * here leaves the config byte for byte as it was.
+ */
+export async function removeHookTrust(file, prefix) {
+  const before = await readFile(file, "utf8").catch(() => null);
+  if (before === null || !before.includes(`hooks.state."${prefix}`)) return false;
+
+  const lines = before.split("\n");
+  const kept = [];
+  let dropping = false;
+  for (const line of lines) {
+    const header = /^\s*\[([^\]]*)\]\s*$/.exec(line);
+    if (header !== null) dropping = header[1].startsWith(`hooks.state."${prefix}`);
+    if (dropping) continue;
+    kept.push(line);
+  }
+  // A table's trailing blank line goes with it rather than piling up.
+  const text = kept.join("\n").replace(/\n{3,}/g, "\n\n");
+  if (text === before) return false;
+  await writeFile(file, text, "utf8");
+  return true;
+}
+
 export async function uninstallCodexPlugin({ home, agentsHome = home,
   codexHome = path.join(home, ".codex"), keep = [] }) {
   const file = marketplacePath(agentsHome);
@@ -240,6 +268,15 @@ export async function uninstallCodexPlugin({ home, agentsHome = home,
     await writeMarketplace(file, { ...existing, plugins: kept });
   }
   if (await removeTomlBlock(configPath(codexHome))) changes.push(configPath(codexHome));
+  // This client keeps its own record of which hook files it has trusted, one
+  // table per hook, keyed by the plugin that declared them. ACC never writes
+  // those - they are the client's bookkeeping about ACC - but once the plugin is
+  // gone they name a thing that does not exist, five of them per install, and
+  // nothing else will ever clear them. Verified inert first: a hook whose hash
+  // no longer matches still runs, so this is tidiness rather than repair.
+  if (await removeHookTrust(configPath(codexHome), `${PLUGIN_NAME}@${MARKETPLACE}:`)) {
+    if (!changes.includes(configPath(codexHome))) changes.push(configPath(codexHome));
+  }
   // The marketplace directory is ACC's too, so it goes rather than being left
   // behind empty.
   // A blank TOML config and an absent one are the same to this client, and a

--- a/packages/adapter-codex/test/hook-trust.test.mjs
+++ b/packages/adapter-codex/test/hook-trust.test.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { removeHookTrust } from "../src/install.mjs";
+
+/**
+ * The record this client keeps about ACC's hooks.
+ *
+ * Codex stores one `[hooks.state."plugin@marketplace:file:event:i:j"]` table per
+ * hook, holding the hash it trusted. ACC writes none of them - a search of the
+ * shipped package finds no occurrence of `hooks.state` - so after `acc
+ * uninstall` five tables were left naming a plugin that no longer exists, and
+ * five more arrived on the next install.
+ *
+ * Checked before writing this: a hook whose recorded hash no longer matches
+ * still runs. Both a control run and a run against a modified file returned
+ * normally. So this is tidiness, and it must not reach past ACC's own keys.
+ */
+const PREFIX = "agents-can-communicate@acc-local:";
+
+async function config(t, text) {
+  const home = await mkdtemp(path.join(tmpdir(), "acc-hook-trust-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const file = path.join(home, "config.toml");
+  await writeFile(file, text, "utf8");
+  return file;
+}
+
+const ACC_TABLES = `[hooks.state."agents-can-communicate@acc-local:hooks.json:pre_tool_use:0:0"]
+trusted_hash = "sha256:8d4a13"
+
+[hooks.state."agents-can-communicate@acc-local:hooks.json:session_start:0:0"]
+trusted_hash = "sha256:a17bdb"
+`;
+
+test("the trust record for ACC's own hooks is taken back out", async t => {
+  const file = await config(t, ACC_TABLES);
+
+  assert.equal(await removeHookTrust(file, PREFIX), true);
+
+  const after = await readFile(file, "utf8");
+  assert.equal(after.includes("agents-can-communicate"), false);
+  assert.equal(after.trim(), "");
+});
+
+test("another plugin's trust record is not ACC's to remove", async t => {
+  const theirs = `[hooks.state."simplify@local-marketplace:hooks.json:stop:0:0"]
+trusted_hash = "sha256:deadbeef"
+`;
+  const file = await config(t, `${ACC_TABLES}\n${theirs}`);
+
+  assert.equal(await removeHookTrust(file, PREFIX), true);
+
+  const after = await readFile(file, "utf8");
+  assert.equal(after.includes("agents-can-communicate"), false);
+  assert.match(after, /simplify@local-marketplace/);
+  assert.match(after, /sha256:deadbeef/);
+});
+
+test("the user's own configuration around it is untouched", async t => {
+  const mine = `model = "gpt-5"
+
+[sandbox_workspace_write]
+writable_roots = ["/tmp"]
+
+`;
+  const file = await config(t, `${mine}${ACC_TABLES}`);
+
+  await removeHookTrust(file, PREFIX);
+
+  const after = await readFile(file, "utf8");
+  assert.match(after, /model = "gpt-5"/);
+  assert.match(after, /\[sandbox_workspace_write\]/);
+  assert.match(after, /writable_roots = \["\/tmp"\]/);
+});
+
+test("a config with nothing of ACC's in it is not rewritten at all", async t => {
+  const theirs = `model = "gpt-5"
+
+[hooks.state."simplify@local-marketplace:hooks.json:stop:0:0"]
+trusted_hash = "sha256:deadbeef"
+`;
+  const file = await config(t, theirs);
+
+  assert.equal(await removeHookTrust(file, PREFIX), false);
+  assert.equal(await readFile(file, "utf8"), theirs);
+});
+
+test("a config that is not there is not an error", async t => {
+  const file = await config(t, "");
+  await rm(file);
+
+  assert.equal(await removeHookTrust(file, PREFIX), false);
+});

--- a/packages/adapter-codex/test/install.test.mjs
+++ b/packages/adapter-codex/test/install.test.mjs
@@ -239,12 +239,35 @@ test("the patch's content lines are never read as paths", () => {
   assert.deepEqual([...normalised.targets], ["real.txt"]);
 });
 
-test("a shell call declares no target rather than a guessed one", () => {
+test("a shell call declares the paths it would write", () => {
+  // Until 0.1.6 this declared nothing, and a session told to prefer the shell
+  // walked through every claim in the workspace. Proven against a live session:
+  // `printf ... >> src/parser.mjs` modified a file another agent held.
+  const shell = command => normalizeCodexHook({ hook_event_name: "PreToolUse",
+    session_id: "s", cwd: "/tmp", tool_name: "shell",
+    tool_input: { command } });
+
+  assert.deepEqual([...shell("rm -rf src/").targets], ["src/"]);
+  assert.deepEqual([...shell("printf 'x' >> src/parser.mjs").targets], ["src/parser.mjs"]);
+});
+
+test("a shell call that only reads still declares nothing", () => {
   const normalised = normalizeCodexHook({ hook_event_name: "PreToolUse",
     session_id: "s", cwd: "/tmp", tool_name: "shell",
-    tool_input: { command: "rm -rf src/" } });
+    tool_input: { command: "cat src/parser.mjs && npm test" } });
 
   assert.deepEqual([...normalised.targets], []);
+});
+
+test("a patch envelope is read as a patch whichever tool name carries it", () => {
+  // Which name a call arrives under is a property of the model's metadata, not
+  // of this config, so the shape decides. Reading this envelope as a shell
+  // command would find `***` and no paths at all.
+  const body = "*** Begin Patch\n*** Update File: real.txt\n+one\n*** End Patch";
+  const normalised = normalizeCodexHook({ hook_event_name: "PreToolUse",
+    session_id: "s", cwd: "/tmp", tool_name: "shell", tool_input: { command: body } });
+
+  assert.deepEqual([...normalised.targets], ["real.txt"]);
 });
 
 const realFixture = fixture;

--- a/packages/adapter-gemini-cli/src/hooks.mjs
+++ b/packages/adapter-gemini-cli/src/hooks.mjs
@@ -1,4 +1,4 @@
-import { normalizedEvent } from "@agents-can-communicate/adapter-sdk";
+import { normalizedEvent, shellWriteTargets } from "@agents-can-communicate/adapter-sdk";
 import { AccError, EXIT } from "@agents-can-communicate/protocol";
 
 // All eight observed in a live 0.37.0 configuration; the six that ACC uses were
@@ -59,10 +59,11 @@ export function normalizeGeminiHook(payload) {
  * Both editing tools take `file_path`, confirmed from a capture. The file's
  * contents are not read: they are conversation content.
  *
- * `run_shell_command` declares nothing. A command can write anywhere, and a path
- * guessed out of one gives a guard that is wrong in both directions.
+ * `run_shell_command` declares no path, so its command is read for the positions
+ * where a write is unambiguous, and for nothing else.
  */
 function writeTargets(tool, input) {
+  if (tool === "run_shell_command") return shellWriteTargets(input?.command);
   if (!GEMINI_EDIT_TOOLS.includes(tool)) return [];
   const target = input?.file_path;
   return typeof target === "string" && target !== "" ? [target] : [];

--- a/packages/adapter-gemini-cli/test/adapter.test.mjs
+++ b/packages/adapter-gemini-cli/test/adapter.test.mjs
@@ -149,14 +149,20 @@ test("injection uses the envelope, which is the opposite of the deny contract", 
   assert.deepEqual(injectResponse(""), {}, "solo injected an empty banner");
 });
 
-test("an edit declares the path it would write, a shell call declares none", async () => {
+test("an edit declares the path it would write, and so does a shell write", async () => {
   const edit = normalizeGeminiHook(await captured("BeforeTool"));
   assert.equal(edit.tool, "write_file");
   assert.deepEqual([...edit.targets], ["/tmp/example-workspace/notes.txt"]);
 
+  // The captured command is redacted content, and writes nothing.
   const shell = normalizeGeminiHook(await captured("BeforeTool-shell"));
   assert.equal(shell.tool, "run_shell_command");
   assert.deepEqual([...shell.targets], []);
+
+  const writing = normalizeGeminiHook({ hook_event_name: "BeforeTool", session_id: "s",
+    cwd: "/tmp", tool_name: "run_shell_command",
+    tool_input: { command: "printf x > notes.txt" } });
+  assert.deepEqual([...writing.targets], ["notes.txt"]);
 });
 
 test("captured payloads normalise and drop conversation content", async () => {

--- a/packages/adapter-kimi/src/hooks.mjs
+++ b/packages/adapter-kimi/src/hooks.mjs
@@ -1,4 +1,4 @@
-import { normalizedEvent } from "@agents-can-communicate/adapter-sdk";
+import { normalizedEvent, shellWriteTargets } from "@agents-can-communicate/adapter-sdk";
 import { AccError, EXIT } from "@agents-can-communicate/protocol";
 
 // Not read from documentation and not guessed: this client validates its config
@@ -73,11 +73,12 @@ export function normalizeKimiHook(payload) {
  * `old_string` and `new_string`. Nothing else is read: the contents and the
  * replacement strings are conversation content and stay out.
  *
- * `Bash` declares nothing. A command can write anywhere, and a path guessed out
- * of one would give a guard that blocks work it holds no claim over while
- * missing writes it does.
+ * `Bash` declares no path of its own, so the command is read for the positions
+ * where a write is unambiguous. Reading positions are left alone: naming a file
+ * is not touching it.
  */
 function writeTargets(tool, input) {
+  if (tool === "Bash") return shellWriteTargets(input?.command);
   if (!KIMI_EDIT_TOOLS.includes(tool)) return [];
   const path = input?.path;
   return typeof path === "string" && path !== "" ? [path] : [];

--- a/packages/adapter-kimi/test/adapter.test.mjs
+++ b/packages/adapter-kimi/test/adapter.test.mjs
@@ -194,15 +194,19 @@ test("the guard sees the real tool name on both a write and a shell call", async
   assert.equal(normalizeKimiHook(await captured("PreToolUse-Bash")).tool, "Bash");
 });
 
-test("a write declares the path it would touch, a shell call declares none", async () => {
+test("a write declares the path it would touch, and so does a shell write", async () => {
   // Both editing tools take `path`, confirmed from their declared schemas.
   // Without this the guard has nothing to compare against a claim.
   assert.deepEqual(normalizeKimiHook(await captured("PreToolUse-Write")).targets,
     ["/workspace/project/notes.txt"]);
 
-  // A command can write anywhere; a path guessed from one would be wrong in
-  // both directions.
+  // The captured Bash payload carries no write, so it declares nothing - but a
+  // command that does write names the file it would touch.
   assert.deepEqual(normalizeKimiHook(await captured("PreToolUse-Bash")).targets, []);
+  assert.deepEqual(normalizeKimiHook({ hook_event_name: "PreToolUse", session_id: "s",
+    cwd: "/tmp", tool_name: "Bash",
+    tool_input: { command: "sed -i '' 's/a/b/' src/parser.mjs" } }).targets,
+  ["src/parser.mjs"]);
 
   assert.deepEqual(normalizeKimiHook(await captured("SessionStart")).targets, []);
 });

--- a/packages/adapter-sdk/src/context-projector.mjs
+++ b/packages/adapter-sdk/src/context-projector.mjs
@@ -85,11 +85,12 @@ function claimNote(claim) {
   if (claim.enforceable === false) {
     return " - not enforced for this session; do not edit it";
   }
-  // Guarded, and this session can be stopped - but only on a file edit. No
-  // harness intercepts a shell command, so an edit made through one goes
-  // through whatever the claim says, and a session told merely "this is
-  // claimed" would reasonably assume otherwise.
-  return " - file edits are blocked; edits made through a shell are not";
+  // Guarded, and this session can be stopped - on a file edit, and on the shell
+  // writes the guard can read: a redirection, an operand of a command whose job
+  // is to put bytes somewhere. A language runtime opening the file itself still
+  // gets past, and a session told merely "this is claimed" would reasonably
+  // assume either more or less than is true.
+  return " - file edits and recognised shell writes are blocked; a runtime can still get past";
 }
 
 function claimLines(claims) {

--- a/packages/adapter-sdk/src/index.mjs
+++ b/packages/adapter-sdk/src/index.mjs
@@ -8,6 +8,7 @@ export { assertRunner, bakeSkillCommand, defaultCli, defaultRunner, removeInstal
 export { BEGIN, END, removeTomlBlock, renderBlock, stripBlock, tomlString, writeTomlBlock }
   from "./toml-block.mjs";
 export { projectContext } from "./context-projector.mjs";
+export { shellWriteTargets } from "./shell-writes.mjs";
 export { editJson, readJson } from "./json-text.mjs";
 export { formatJsonAs, jsonStyleOf, mergeOwnedConfig, mergeOwnedEntries, ownedEntries, ownedKeys,
   acccreatedFile, removeIfEmpty, removeOwnedConfig, removeOwnedEntries, writeForeignJson,

--- a/packages/adapter-sdk/src/shell-writes.mjs
+++ b/packages/adapter-sdk/src/shell-writes.mjs
@@ -1,0 +1,319 @@
+/**
+ * What a shell command would write.
+ *
+ * The guard used to declare no targets for a shell call at all, on the reasoning
+ * that a command can write anywhere and a guessed path is wrong in both
+ * directions. That reasoning held until agents started being told to prefer the
+ * shell for file edits: a claim that any `printf >> file` walks through is not a
+ * claim. The answer is not to guess. It is to read the positions where a write
+ * is unambiguous - a redirection, the operand of a command whose whole job is to
+ * put bytes somewhere - and to stay silent everywhere else.
+ *
+ * Two properties matter more than coverage:
+ *
+ *   - A read is never reported. `cat file` and `grep file` name a path in an
+ *     argument position that writes nothing; treating those as writes would have
+ *     sessions blocking each other for looking.
+ *   - It never throws. This runs on the hook path inside a budget that fails
+ *     open, so an unparseable command yields no targets rather than an error.
+ *
+ * What it does not see is stated where a person reads it (`context-projector`):
+ * a language runtime opening a file, an `eval`, a command built at runtime. A
+ * shell can still evade this. Partial sight is not the same as none - today
+ * every one of these walks through - and an agent told where the guard ends
+ * behaves better than one who believes it absolute.
+ */
+
+const SEPARATORS = new Set([";", "&&", "||", "|", "|&", "&", "\n"]);
+
+// Redirections that write. `<` and `<<` read; `>&`/`<&` duplicate a descriptor
+// and name no file.
+const WRITE_REDIRECTION = /^(?:[0-9]*|&)(?:>>|>\|?)$/;
+
+// Sinks that discard. Naming one is not touching a file anybody claims.
+const NOT_A_FILE = new Set(["/dev/null", "/dev/stdout", "/dev/stderr", "/dev/tty"]);
+
+/**
+ * How each command spends its operands.
+ *
+ * `pick` decides which operands are written: every one, only the last (a
+ * destination), or every one but the first (a script that is not a file).
+ * `valueFlags` are the flags whose following token is a value rather than a
+ * path - without them, `truncate -s 0 file` would report a file named `0`.
+ */
+const WRITERS = new Map(Object.entries({
+  tee: { pick: "all" },
+  touch: { pick: "all", valueFlags: new Set(["-d", "-r", "-t", "--date", "--reference"]) },
+  truncate: { pick: "all", valueFlags: new Set(["-s", "--size", "-r", "--reference"]) },
+  rm: { pick: "all" },
+  unlink: { pick: "all" },
+  shred: { pick: "all", valueFlags: new Set(["-n", "--iterations", "-s", "--size"]) },
+  mkdir: { pick: "all", valueFlags: new Set(["-m", "--mode"]) },
+  rmdir: { pick: "all" },
+  cp: { pick: "last", valueFlags: new Set(["-t", "--target-directory", "-S", "--suffix"]) },
+  install: { pick: "last", valueFlags: new Set(["-t", "--target-directory", "-m", "-o", "-g"]) },
+  rsync: { pick: "last", valueFlags: new Set(["-e", "--rsh", "--exclude"]) },
+  ln: { pick: "last", valueFlags: new Set(["-t", "--target-directory", "-S", "--suffix"]) },
+  // A move writes the destination and empties the source. Both are the peer's
+  // business, so both are reported.
+  mv: { pick: "all", valueFlags: new Set(["-t", "--target-directory", "-S", "--suffix"]) },
+}));
+
+// In-place editors: a write only when the in-place flag is present, and their
+// script operand is never a file.
+const IN_PLACE = new Map(Object.entries({
+  sed: { valueFlags: new Set(["-e", "--expression", "-f", "--file", "-l", "-E"]) },
+  perl: { valueFlags: new Set(["-e", "-E", "-M", "-m"]) },
+  ruby: { valueFlags: new Set(["-e", "-r"]) },
+}));
+
+/**
+ * Split a command line into tokens, keeping quoted text out of the grammar.
+ *
+ * Returns null on anything it cannot read - an unterminated quote, most often -
+ * which the caller turns into "no targets" rather than a guess.
+ */
+function tokenize(command) {
+  const tokens = [];
+  let text = "";
+  let started = false;
+  let quoted = false;
+
+  const flush = () => {
+    if (started) tokens.push({ text, quoted });
+    text = "";
+    started = false;
+    quoted = false;
+  };
+
+  for (let index = 0; index < command.length; index += 1) {
+    const character = command[index];
+
+    if (character === "\\") {
+      const next = command[index + 1];
+      if (next === undefined) return null;
+      text += next;
+      started = true;
+      quoted = true;
+      index += 1;
+      continue;
+    }
+
+    if (character === "'" || character === '"') {
+      const close = command.indexOf(character, index + 1);
+      if (close === -1) return null;
+      text += command.slice(index + 1, close);
+      started = true;
+      quoted = true;
+      index = close;
+      continue;
+    }
+
+    if (character === " " || character === "\t") {
+      flush();
+      continue;
+    }
+
+    if (character === "\n") {
+      flush();
+      tokens.push({ operator: "\n" });
+      continue;
+    }
+
+    if (character === ";" || character === "&" || character === "|" || character === ">"
+      || character === "<") {
+      // A redirection may carry its descriptor on the front (`2>`), which is
+      // already sitting in `text` unquoted.
+      const prefix = !quoted && /^[0-9]+$/.test(text) ? text : null;
+      if (prefix === null) flush();
+      else { text = ""; started = false; }
+
+      let operator = character;
+      while (index + 1 < command.length && "&|<>".includes(command[index + 1])) {
+        operator += command[index + 1];
+        index += 1;
+      }
+      tokens.push({ operator: prefix === null ? operator : prefix + operator });
+      continue;
+    }
+
+    text += character;
+    started = true;
+  }
+  flush();
+  return tokens;
+}
+
+/** Break a token list at the separators, so every simple command is read. */
+function simpleCommands(tokens) {
+  const commands = [[]];
+  for (const token of tokens) {
+    if (token.operator !== undefined && SEPARATORS.has(token.operator)) commands.push([]);
+    else commands.at(-1).push(token);
+  }
+  return commands.filter(command => command.length > 0);
+}
+
+/**
+ * Drop heredoc bodies.
+ *
+ * The body is content the shell never parses, and it is exactly where a `>` or
+ * an `rm` is most likely to appear innocently. Reading it would invent targets
+ * out of a file's own text.
+ */
+function stripHeredocs(command) {
+  const pattern = /<<-?\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\1/g;
+  let result = command;
+  for (;;) {
+    pattern.lastIndex = 0;
+    const opener = pattern.exec(result);
+    if (opener === null) return result;
+    const lineEnd = result.indexOf("\n", opener.index);
+    if (lineEnd === -1) return result.slice(0, opener.index) + result.slice(opener.index).replace(pattern, "");
+    const terminator = new RegExp(`^\\s*${opener[2]}\\s*$`, "m");
+    const rest = result.slice(lineEnd + 1);
+    const end = terminator.exec(rest);
+    const body = end === null ? rest.length : end.index + end[0].length;
+    result = result.slice(0, opener.index) + result.slice(opener.index, lineEnd).replace(pattern, "")
+      + "\n" + rest.slice(body);
+  }
+}
+
+/** The word a redirection writes to, or null when it names no file. */
+function redirectionTarget(tokens, index) {
+  const next = tokens[index + 1];
+  if (next === undefined || next.operator !== undefined) return null;
+  if (next.text.startsWith("&")) return null;
+  return NOT_A_FILE.has(next.text) ? null : next.text;
+}
+
+/** Operands of a simple command, with flags and their values removed. */
+function operandsOf(words, valueFlags = new Set()) {
+  const operands = [];
+  for (let index = 1; index < words.length; index += 1) {
+    const word = words[index];
+    if (!word.quoted && word.text.startsWith("-") && word.text !== "-") {
+      if (valueFlags.has(word.text)) index += 1;
+      continue;
+    }
+    operands.push(word.text);
+  }
+  return operands;
+}
+
+/** Strip the leading environment assignments and wrappers off a command. */
+function commandWords(words) {
+  let start = 0;
+  while (start < words.length) {
+    const word = words[start];
+    if (word.operator !== undefined) return null;
+    if (!word.quoted && /^[A-Za-z_][A-Za-z0-9_]*=/.test(word.text)) { start += 1; continue; }
+    if (["sudo", "command", "nohup", "time", "nice"].includes(word.text)) { start += 1; continue; }
+    if (word.text === "env") { start += 1; continue; }
+    break;
+  }
+  return start >= words.length ? null : words.slice(start);
+}
+
+/** Targets a `dd` call writes, which it names as `of=`. */
+function ddTargets(words) {
+  return words.slice(1)
+    .filter(word => word.text.startsWith("of="))
+    .map(word => word.text.slice(3))
+    .filter(target => target !== "" && !NOT_A_FILE.has(target));
+}
+
+/**
+ * Targets a `git` call writes into the working tree.
+ *
+ * Only the two that overwrite a file a peer may be holding. `git log -- path`
+ * and `git diff path` name the same path and touch nothing, which is why the
+ * subcommand is read before the operands.
+ */
+function gitTargets(words) {
+  const subcommand = words[1]?.text;
+  if (subcommand === "restore") {
+    return operandsOf(words.slice(1), new Set(["--source", "-s"]));
+  }
+  if (subcommand === "checkout") {
+    const separator = words.findIndex(word => word.text === "--" && !word.quoted);
+    if (separator === -1) return [];
+    return words.slice(separator + 1).map(word => word.text);
+  }
+  return [];
+}
+
+/** Targets of an in-place editor, whose script operand is not a file. */
+function inPlaceTargets(words, spec) {
+  const flags = words.slice(1).filter(word => !word.quoted && word.text.startsWith("-"));
+  const inPlace = flags.some(word => word.text === "-i" || word.text.startsWith("-i")
+    || word.text === "--in-place" || word.text.startsWith("--in-place="));
+  if (!inPlace) return [];
+
+  const valueFlags = new Set(spec.valueFlags);
+  const operands = [];
+  for (let index = 1; index < words.length; index += 1) {
+    const word = words[index];
+    if (!word.quoted && word.text.startsWith("-") && word.text !== "-") {
+      // `-i ''` on BSD takes its suffix as a separate word; a cluster carrying
+      // `e` takes the script that follows it.
+      if (valueFlags.has(word.text)) index += 1;
+      else if (/^-[A-Za-z]*[eEf]$/.test(word.text)) index += 1;
+      else if (word.text === "-i" && words[index + 1]?.quoted
+        && (words[index + 1].text === "" || words[index + 1].text.startsWith("."))) index += 1;
+      continue;
+    }
+    operands.push(word.text);
+  }
+
+  const scriptGiven = flags.some(word => /^-[A-Za-z]*[eEf]$/.test(word.text)
+    || word.text.startsWith("--expression") || word.text.startsWith("--file"));
+  return scriptGiven ? operands : operands.slice(1);
+}
+
+/**
+ * Paths a shell command would write.
+ *
+ * Order is the order they appear; a path named twice is reported once. Anything
+ * unreadable yields an empty list.
+ */
+export function shellWriteTargets(command) {
+  if (typeof command !== "string" || command.trim() === "") return [];
+
+  let targets = [];
+  try {
+    const tokens = tokenize(stripHeredocs(command));
+    if (tokens === null) return [];
+
+    for (const simple of simpleCommands(tokens)) {
+      for (let index = 0; index < simple.length; index += 1) {
+        const token = simple[index];
+        if (token.operator === undefined || !WRITE_REDIRECTION.test(token.operator)) continue;
+        const target = redirectionTarget(simple, index);
+        if (target !== null) targets.push(target);
+      }
+
+      const words = commandWords(simple.filter(token => token.operator === undefined));
+      if (words === null || words.length === 0) continue;
+      const name = words[0].text.split("/").at(-1);
+
+      if (name === "dd") { targets.push(...ddTargets(words)); continue; }
+      if (name === "git") { targets.push(...gitTargets(words)); continue; }
+
+      const inPlace = IN_PLACE.get(name);
+      if (inPlace !== undefined) { targets.push(...inPlaceTargets(words, inPlace)); continue; }
+
+      const writer = WRITERS.get(name);
+      if (writer === undefined) continue;
+      const operands = operandsOf(words, writer.valueFlags);
+      if (operands.length === 0) continue;
+      targets.push(...(writer.pick === "last" ? operands.slice(-1) : operands));
+    }
+  } catch {
+    // The hook path fails open. A command this cannot read is a command it
+    // reports nothing about.
+    return [];
+  }
+
+  return [...new Set(targets.filter(target => target !== "" && !NOT_A_FILE.has(target)))];
+}

--- a/packages/adapter-sdk/test/context-projector.test.mjs
+++ b/packages/adapter-sdk/test/context-projector.test.mjs
@@ -170,7 +170,7 @@ test("a guarded session is told the limit of its own guard", () => {
   // Being guarded is not the same as being safe: no harness intercepts a shell
   // command, so an edit made through one is never stopped. A session told only
   // "this is claimed" would reasonably assume ACC has it covered.
-  assert.match(projected, /through a shell are not/);
+  assert.match(projected, /recognised shell writes are blocked/);
 });
 
 test("a claim its owner declared advisory is never described as blocking", () => {

--- a/packages/adapter-sdk/test/events.test.mjs
+++ b/packages/adapter-sdk/test/events.test.mjs
@@ -27,9 +27,9 @@ test("targets carry the paths a call would write, and nothing else", () => {
   assert.deepEqual(event.targets, ["src/a.mjs", "src/b.mjs"]);
 });
 
-test("a shell call declares no targets rather than a guessed one", () => {
-  // A command can write anywhere. Inventing a path from it would produce a
-  // guard that is wrong in both directions.
+test("an event carries the targets it was given and invents none", () => {
+  // Reading a command for its write positions is the adapter's job; this shape
+  // carries the result and adds nothing of its own.
   assert.deepEqual(normalizedEvent({ ...base, tool: "Bash" }).targets, []);
 });
 

--- a/packages/adapter-sdk/test/shell-writes.test.mjs
+++ b/packages/adapter-sdk/test/shell-writes.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shellWriteTargets } from "../src/shell-writes.mjs";
+
+/**
+ * A claim is only worth what the guard can see.
+ *
+ * Every case here was written against a command an agent actually reached for,
+ * or one a careless reader of the rules would reach for next. The list is
+ * deliberately not exhaustive - a shell can always evade it - so each test says
+ * which side of the line it is proving: a write that must be seen, or a read
+ * that must not be mistaken for one.
+ */
+
+test("a redirection names the file it would overwrite", () => {
+  assert.deepEqual(shellWriteTargets("printf '%s\\n' '// via shell' >> src/parser.mjs"),
+    ["src/parser.mjs"]);
+  assert.deepEqual(shellWriteTargets("echo x > notes.txt"), ["notes.txt"]);
+  assert.deepEqual(shellWriteTargets("node build.mjs 2> build.log"), ["build.log"]);
+});
+
+test("reading is not writing", () => {
+  // The whole point of scoping to write positions: a command may name a claimed
+  // file and still leave it alone.
+  assert.deepEqual(shellWriteTargets("cat src/parser.mjs"), []);
+  assert.deepEqual(shellWriteTargets("grep -n parse src/parser.mjs"), []);
+  assert.deepEqual(shellWriteTargets("node --test src/parser.test.mjs"), []);
+  assert.deepEqual(shellWriteTargets("sed 's/a/b/' src/parser.mjs"), []);
+});
+
+test("a redirection that reads is not a redirection that writes", () => {
+  // `<` feeds a file in. Counting it would block a session for reading a peer's
+  // file through a shell, which is exactly the over-reach this guard avoids.
+  assert.deepEqual(shellWriteTargets("node build.mjs < src/parser.mjs"), []);
+  assert.deepEqual(shellWriteTargets("wc -l < src/parser.mjs"), []);
+  assert.deepEqual(shellWriteTargets("node - <<< 'console.log(1)'"), []);
+});
+
+test("the sink that discards is not a file anyone claims", () => {
+  assert.deepEqual(shellWriteTargets("npm test > /dev/null"), []);
+  assert.deepEqual(shellWriteTargets("npm test 2>&1"), []);
+  assert.deepEqual(shellWriteTargets("npm test > /dev/null 2>&1"), []);
+});
+
+test("editing in place is a write, and the script is not a file", () => {
+  assert.deepEqual(shellWriteTargets("sed -i '' 's/a/b/' src/parser.mjs"),
+    ["src/parser.mjs"]);
+  assert.deepEqual(shellWriteTargets("sed -i.bak -e 's/a/b/' src/parser.mjs"),
+    ["src/parser.mjs"]);
+  assert.deepEqual(shellWriteTargets("perl -i -pe 's/a/b/' src/parser.mjs"),
+    ["src/parser.mjs"]);
+});
+
+test("the commands whose whole job is to put bytes somewhere", () => {
+  assert.deepEqual(shellWriteTargets("tee src/parser.mjs"), ["src/parser.mjs"]);
+  assert.deepEqual(shellWriteTargets("tee -a src/parser.mjs"), ["src/parser.mjs"]);
+  assert.deepEqual(shellWriteTargets("touch src/parser.mjs"), ["src/parser.mjs"]);
+  assert.deepEqual(shellWriteTargets("truncate -s 0 src/parser.mjs"), ["src/parser.mjs"]);
+  assert.deepEqual(shellWriteTargets("dd if=/dev/zero of=src/parser.mjs"), ["src/parser.mjs"]);
+});
+
+test("removing a file is the most complete write there is", () => {
+  assert.deepEqual(shellWriteTargets("rm src/parser.mjs"), ["src/parser.mjs"]);
+  assert.deepEqual(shellWriteTargets("rm -rf src/parser.mjs"), ["src/parser.mjs"]);
+});
+
+test("copying and moving write the destination, and moving empties the source", () => {
+  assert.deepEqual(shellWriteTargets("cp /tmp/new.mjs src/parser.mjs"), ["src/parser.mjs"]);
+  assert.deepEqual(shellWriteTargets("mv src/parser.mjs src/old.mjs").sort(),
+    ["src/old.mjs", "src/parser.mjs"]);
+  assert.deepEqual(shellWriteTargets("ln -sf /tmp/other src/parser.mjs"), ["src/parser.mjs"]);
+});
+
+test("restoring from git overwrites whatever a peer was holding", () => {
+  assert.deepEqual(shellWriteTargets("git restore src/parser.mjs"), ["src/parser.mjs"]);
+  assert.deepEqual(shellWriteTargets("git checkout -- src/parser.mjs"), ["src/parser.mjs"]);
+  // Reading history is not writing the tree.
+  assert.deepEqual(shellWriteTargets("git log -1 -- src/parser.mjs"), []);
+  assert.deepEqual(shellWriteTargets("git diff src/parser.mjs"), []);
+});
+
+test("every command in a chain is looked at, not just the first", () => {
+  assert.deepEqual(shellWriteTargets("npm test && printf x > src/parser.mjs"),
+    ["src/parser.mjs"]);
+  assert.deepEqual(shellWriteTargets("cd src; rm parser.mjs"), ["parser.mjs"]);
+  assert.deepEqual(shellWriteTargets("cat in.txt | tee src/parser.mjs"), ["src/parser.mjs"]);
+});
+
+test("a redirection inside quotes is text, not a redirection", () => {
+  assert.deepEqual(shellWriteTargets("echo 'a > b'"), []);
+  assert.deepEqual(shellWriteTargets('echo "write > nothing"'), []);
+  assert.deepEqual(shellWriteTargets("git commit -m 'move a > b'"), []);
+});
+
+test("a heredoc body is content, and the redirection before it is real", () => {
+  const command = "cat > src/parser.mjs <<'EOF'\n"
+    + "// this line > is not a redirection\n"
+    + "rm everything.mjs\n"
+    + "EOF";
+  assert.deepEqual(shellWriteTargets(command), ["src/parser.mjs"]);
+});
+
+test("a command it cannot read leaves the guard where it found it", () => {
+  // Fail open, never throw: an unparseable command must not take the hook down,
+  // and must not invent a target either.
+  for (const command of ["", "   ", "python3 -c \"open('src/parser.mjs','w')\"",
+    "eval \"$CMD\"", "((", "'unterminated"]) {
+    assert.deepEqual(shellWriteTargets(command), [],
+      `expected no targets from: ${command}`);
+  }
+  for (const bad of [null, undefined, 42, {}, []]) {
+    assert.deepEqual(shellWriteTargets(bad), [], `expected no targets from: ${bad}`);
+  }
+});
+
+test("the same file named twice is reported once", () => {
+  assert.deepEqual(shellWriteTargets("rm src/parser.mjs && touch src/parser.mjs"),
+    ["src/parser.mjs"]);
+});

--- a/packages/cli/src/args.mjs
+++ b/packages/cli/src/args.mjs
@@ -17,8 +17,12 @@ export const COMMANDS = Object.freeze({
     "state", "workstream"], repeated: ["hint"], flags: ["clear"] },
   claim: { required: ["resource"],
     optional: ["session", "generation", "mode", "enforcement", "reason", "lease"] },
-  release: { required: ["claim"],
-    optional: ["session", "generation", "authority", "reason"] },
+  // Neither is required on its own, because either one names the claim: an id
+  // is precise, and a resource is what the caller typed to take it in the first
+  // place. Requiring the id meant a round trip through `acc status --json` to
+  // look up something the caller never chose.
+  release: { required: [],
+    optional: ["claim", "resource", "session", "generation", "authority", "reason"] },
   message: { required: ["subject", "body"],
     optional: ["session", "generation", "type", "priority", "workstream"],
     repeated: ["to"], flags: ["requires-ack"] },

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -21,6 +21,39 @@ import { discoverWorkspace } from "./workspace-discovery.mjs";
 
 const DEFAULT_CADENCE_MS = 30_000;
 
+/**
+ * The claim a caller means when they name a resource instead of an id.
+ *
+ * `acc claim` takes `--resource`; `acc release` took `--claim`. The asymmetry
+ * cost every caller - a person and an agent alike - a round trip through
+ * `acc status --json` to find an id they never chose. The id is still accepted,
+ * and is still the precise answer when two sessions hold the same resource and
+ * an authority is releasing someone else's.
+ */
+async function claimOn(options, context) {
+  if (options.resource === undefined) {
+    throw new AccError(EXIT.USAGE,
+      "release needs the claim to give back: --resource is what you claimed, "
+      + "--claim is its id");
+  }
+  const resource = await canonicalClaim(options.resource, context.descriptor);
+  const { claims } = await context.service.collectStatus({});
+  // An authority releasing another session's claim is not looking for its own.
+  const mine = claims.filter(claim => claim.resource === resource
+    && (options.authority !== undefined || claim.ownerSessionId === options.session));
+
+  if (mine.length === 0) {
+    throw new AccError(EXIT.DATA, `no claim on ${resource} to release`,
+      { resource, held: claims.map(claim => claim.resource) });
+  }
+  if (mine.length > 1) {
+    throw new AccError(EXIT.DATA,
+      `${mine.length} claims on ${resource}; name the one you mean with --claim`,
+      { resource, claims: mine.map(claim => claim.claimId) });
+  }
+  return mine[0].claimId;
+}
+
 async function openContext(options, runtime) {
   const descriptor = await discoverWorkspace({
     cwd: options.cwd ?? runtime.cwd,
@@ -120,11 +153,12 @@ const HANDLERS = Object.freeze({
   },
 
   release: async ({ options, context }) => {
-    const request = { claimId: options.claim, sessionId: options.session,
+    const claimId = options.claim ?? await claimOn(options, context);
+    const request = { claimId, sessionId: options.session,
       generation: options.generation, authority: options.authority, reason: options.reason };
     if (options.authority === undefined) await context.service.releaseClaim(request);
     else await context.service.forceReleaseClaim(request);
-    return { data: { claimId: options.claim }, text: `released ${options.claim}` };
+    return { data: { claimId }, text: `released ${claimId}` };
   },
 
   message: async ({ options, context }) => {

--- a/packages/cli/test/release-by-resource.test.mjs
+++ b/packages/cli/test/release-by-resource.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { EXIT } from "@agents-can-communicate/protocol";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const binary = path.join(repoRoot, "bin", "acc.mjs");
+
+/**
+ * Giving a claim back the way it was taken.
+ *
+ * `acc claim --resource file:src/parser.mjs` and then `acc release --claim
+ * claim_LM69YGb8…`: the id is not something the caller ever chose, so releasing
+ * meant a round trip through `acc status --json` first. Observed costing a real
+ * agent a step mid-task. Both spellings work now, and the id stays the precise
+ * one where a resource is ambiguous.
+ */
+async function workspace(t) {
+  const root = await realpath(await mkdtemp(path.join(tmpdir(), "acc-release-")));
+  const dataHome = await realpath(await mkdtemp(path.join(tmpdir(), "acc-release-home-")));
+  t.after(() => Promise.all([rm(root, { recursive: true, force: true }),
+    rm(dataHome, { recursive: true, force: true })]));
+
+  const json = async argv => {
+    const argument = [...argv, "--json"];
+    try {
+      const { stdout } = await execFileAsync(process.execPath, [binary, ...argument],
+        { cwd: root, env: { ...process.env, ACC_DATA_HOME: dataHome, HOME: dataHome } });
+      return { code: 0, body: JSON.parse(stdout) };
+    } catch (error) {
+      return { code: error.code,
+        body: error.stdout?.trim() === "" ? null : JSON.parse(error.stdout ?? "null") };
+    }
+  };
+
+  const attach = async participant => {
+    const attached = await json(["attach", "--participant", participant, "--harness", "cli"]);
+    assert.equal(attached.code, 0, JSON.stringify(attached.body));
+    return attached.body.data;
+  };
+  return { json, attach };
+}
+
+test("a claim is given back by the resource it was taken on", async t => {
+  const place = await workspace(t);
+  const session = await place.attach("alice");
+
+  const claimed = await place.json(["claim", "--session", session.sessionId,
+    "--generation", session.generation,
+    "--resource", "file:src/parser.mjs", "--reason", "rewriting"]);
+  assert.equal(claimed.code, 0, JSON.stringify(claimed.body));
+
+  const released = await place.json(["release", "--session", session.sessionId,
+    "--generation", session.generation,
+    "--resource", "file:src/parser.mjs"]);
+
+  assert.equal(released.code, 0, JSON.stringify(released.body));
+  // The id still comes back, because that is what was released.
+  assert.equal(released.body.data.claimId, claimed.body.data.claimId);
+
+  const status = await place.json(["status"]);
+  assert.deepEqual(status.body.data.claims, []);
+});
+
+test("the id still works, and still names what it released", async t => {
+  const place = await workspace(t);
+  const session = await place.attach("alice");
+  const claimed = await place.json(["claim", "--session", session.sessionId,
+    "--generation", session.generation,
+    "--resource", "file:src/parser.mjs", "--reason", "rewriting"]);
+
+  const released = await place.json(["release", "--session", session.sessionId,
+    "--generation", session.generation,
+    "--claim", claimed.body.data.claimId]);
+
+  assert.equal(released.code, 0, JSON.stringify(released.body));
+  assert.equal(released.body.data.claimId, claimed.body.data.claimId);
+});
+
+test("naming neither says what the two spellings are", async t => {
+  const place = await workspace(t);
+  const session = await place.attach("alice");
+
+  const refused = await place.json(["release", "--session", session.sessionId,
+    "--generation", session.generation]);
+
+  assert.equal(refused.code, EXIT.USAGE);
+  assert.match(refused.body.error.message, /--resource/);
+  assert.match(refused.body.error.message, /--claim/);
+});
+
+test("releasing a resource nobody claimed says so, and lists what is held", async t => {
+  const place = await workspace(t);
+  const session = await place.attach("alice");
+  await place.json(["claim", "--session", session.sessionId,
+    "--generation", session.generation,
+    "--resource", "file:src/render.mjs", "--reason", "rendering"]);
+
+  const refused = await place.json(["release", "--session", session.sessionId,
+    "--generation", session.generation,
+    "--resource", "file:src/parser.mjs"]);
+
+  assert.equal(refused.code, EXIT.DATA);
+  assert.match(refused.body.error.message, /no claim on file:src\/parser\.mjs/);
+  assert.deepEqual(refused.body.error.details.held, ["file:src/render.mjs"]);
+});
+
+test("a peer's claim is not released by naming its resource", async t => {
+  // Without the owner check this would hand one session the power to release
+  // another's claim by spelling, which is what `--authority` exists to do
+  // deliberately and loudly.
+  const place = await workspace(t);
+  const owner = await place.attach("alice");
+  const other = await place.attach("bob");
+  await place.json(["claim", "--session", owner.sessionId,
+    "--generation", owner.generation,
+    "--resource", "file:src/parser.mjs", "--reason", "rewriting"]);
+
+  const refused = await place.json(["release", "--session", other.sessionId,
+    "--generation", other.generation,
+    "--resource", "file:src/parser.mjs"]);
+
+  assert.equal(refused.code, EXIT.DATA);
+  assert.match(refused.body.error.message, /no claim on file:src\/parser\.mjs/);
+
+  const status = await place.json(["status"]);
+  assert.equal(status.body.data.claims.length, 1);
+});

--- a/packages/hook-runner/test/runner.test.mjs
+++ b/packages/hook-runner/test/runner.test.mjs
@@ -139,7 +139,7 @@ test("an advisory claim does not block, it informs", async t => {
   assert.equal(allowed.decision, "allow");
 });
 
-test("a shell call declares no target, so there is nothing to match", async t => {
+test("a command the guard cannot read declares no target, so nothing matches", async t => {
   const place = await workspace(t);
   const peer = await run("kimi", event("sessionStart", { sessionId: "peer" }), place);
   await peer.service.acquireClaim({ sessionId: peer.accSessionId,
@@ -149,8 +149,9 @@ test("a shell call declares no target, so there is nothing to match", async t =>
 
   const allowed = await run("kimi", event("beforeTool", { tool: "Bash", targets: [] }), place);
 
-  // Honest rather than convenient: the runner cannot tell what a command
-  // touches, and pretending otherwise would block work at random.
+  // Honest rather than convenient: a command whose write positions the adapter
+  // could not read arrives with no targets, and the runner does not invent one.
+  // The commands it can read arrive with targets and are matched like any edit.
   assert.equal(allowed.decision, "allow");
   assert.equal(allowed.unguarded, true);
 });


### PR DESCRIPTION
Three fixes, all found by using 0.1.6 rather than by reading it.

## A claim held nothing against the shell

The guard read the path out of an editing tool's arguments. A shell call declares no path, so it declared no targets — on all four clients.

Asked a live Codex session to append a line to a file another agent held `guarded`:

```
printf '%s\n' '// via shell' >> src/parser.mjs
→ Appended. Verified the final line and Git diff.
```

The workspace reported `protection: guarded` throughout. `sed -i`, `mv`, `rm` and `git restore` went through the same way.

That was a deliberate decision — [DESIGN_DECISIONS.md](docs/DESIGN_DECISIONS.md) has the row — and its reasoning was sound: a path *guessed* out of a command blocks work at random and still misses real writes. What it did not account for is that agents in these harnesses are told to prefer the shell for file edits. **This session's own instructions say exactly that.** The uncovered path was not the exotic one; it was the default one.

So the row stays, and the reversal is recorded under it with what changed.

## The fix does not guess

`shellWriteTargets()` reads the positions where a write is unambiguous, and nothing else:

| seen | not seen |
|---|---|
| `> file`, `>> file`, `2> file` | `< file`, `2>&1`, `/dev/null` |
| `tee`, `touch`, `truncate`, `dd of=`, `rm`, `mv`, `cp`, `ln` | `cat`, `grep`, `wc`, `node --test` |
| `sed -i`, `perl -i` | `sed` without `-i` |
| `git restore`, `git checkout --` | `git diff`, `git log -- path` |

Quoted text is text, a heredoc body is content, every command in a `&&` chain or pipeline is read, and anything unparseable yields nothing rather than a guess. It never throws — the hook path fails open.

**A read is never reported.** That is what makes partial coverage safe: the only paths declared are ones the command would write, so the "blocks work at random" failure the original decision feared cannot occur.

Coverage is partial on purpose, and the injected context now says so where an agent reads it:

```diff
- file edits are blocked; edits made through a shell are not
+ file edits and recognised shell writes are blocked; a runtime can still get past
```

The old line was honest about the gap and, read by an agent under instructions to use the shell, amounted to directions around the guard.

## Verified on the packed artifact, with live agents

```
1. claimed, live Codex, shell write:
     Command blocked by PreToolUse hook: file:src/parser.mjs is claimed by alice
     Command: printf 'y' >> src/parser.mjs
     on disk: unchanged

2. claimed, live Codex, reads through the shell:
     cat  → export const parse = input => JSON.parse(input);
     wc -l → 1
     grep -c parse → 1
     each exited 0

3. after acc release, the identical command:
     file changed — the guard lifts, it does not merely refuse
```

Step 2 matters as much as step 1: a guard that blocks reading would be a worse regression than the hole it closes.

## Also

**`acc release --resource`.** `acc claim` takes a resource and `release` took an id, so handing a claim back meant a round trip through `acc status --json` for an id the caller never chose — watched costing a live agent a step mid-task. Both spellings work; the id stays precise when an authority releases someone else's claim. A peer cannot release your claim by naming its resource.

**`acc uninstall` clears the trust record Codex keeps about ACC's hooks.** That client writes one table per hook keyed by the declaring plugin; ACC writes none of them, so five were left behind naming a plugin that no longer existed, and five more arrived on the next install. Checked before touching them — a hook whose recorded hash no longer matches still runs, control and modified runs both returned normally — so this is tidiness, not repair. Only ACC's own `plugin@marketplace` prefix is removed; another plugin's record is left alone.

## Record

```
PASS  agents-can-communicate-0.1.6.tgz  sha256 f2cc7c8e…97853  built from 8b049fe
```

142 KB, 110 entries. 906 tests passing, 0 failing · `syntax ok in 189 file(s)`.

Every new assertion was mutation-proved: blanking the guard fails 9 tests, counting `<` as a write fails 1, dropping the `/dev/null` exception fails 1, parsing heredoc bodies fails 1, treating every `sed` as in-place fails 1. The `<` mutation initially failed to apply and passed — which exposed that the tests had no input-redirection case at all, so one was added before the mutation was retried.
