### PR TITLE
release: 0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ through it.
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `22ee9c9` |
+| Tarball | `agents-can-communicate-0.1.7.tgz`, 142 KB, 110 entries |
+| sha256 | `16bbddfe242df6da5bf48aeec30a6f0c70cd7491cfbb71320fa4d60ef408c642` |
 | Tests | 906 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,21 @@
 # Changelog
 
-## Unreleased
+## 0.1.7
+
+One fix that matters and two that tidy after it. The one that matters: until
+now a `guarded` claim stopped a file edit and nothing else, so the shell - the
+way agents in these harnesses are told to change files - walked straight
+through it.
 
 | | |
 |---|---|
-| Built from | `8b049fe` |
-| Tarball | `agents-can-communicate-0.1.6.tgz`, 142 KB, 110 entries |
-| sha256 | `f2cc7c8e4b68e869c230cbe05c9b41d6c539986411b15e1413e60b7a5f697853` |
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
 | Tests | 906 passing, 0 failing |
-
-Not published. A published record says what the registry serves and is not
-rewritten, so shipped code that changes after a release is measured here instead.
+| Node | 24 (current production LTS) |
+| Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
+| Not supported | Windows — untested rather than known-broken |
 
 A claim now holds against the shell. Found by asking a live Codex session to
 append a line to a file another agent held guarded, and watching it succeed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -102,51 +102,51 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.1.6"
+      "version": "0.1.7"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.1.6"
+      "version": "0.1.7"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.1.6"
+      "version": "0.1.7"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.1.6"
+      "version": "0.1.7"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.1.6"
+      "version": "0.1.7"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.1.6"
+      "version": "0.1.7"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.1.6"
+      "version": "0.1.7"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.1.6"
+      "version": "0.1.7"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.1.6"
+      "version": "0.1.7"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.1.6"
+      "version": "0.1.7"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.1.6"
+      "version": "0.1.7"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.1.6"
+      "version": "0.1.7"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "module",
   "description": "Local-first coordination for independently opened AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.mjs" },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Until now a `guarded` claim stopped a file edit and nothing else. The shell — the way agents in these harnesses are told to change files — walked straight through it. That is what this release is for.

| | |
|---|---|
| **#75** | **A claim holds against the shell.** `printf ... >> file`, `sed -i`, `mv`, `rm` and `git restore` all went through a `guarded` claim, on all four clients, in a workspace ACC reported as protected. The command is now read for the positions where a write is unambiguous — and for nothing else, so a read is never mistaken for one |
| #75 | `acc release --resource`, so a claim is given back the way it was taken instead of via a round trip through `acc status --json` for an id the caller never chose |
| #75 | `acc uninstall` clears the trust record Codex keeps about ACC's own hooks — five tables left behind per install, naming a plugin that no longer existed |

The reversed design decision is recorded under the row it reverses, with what changed: not the reasoning (a *guessed* path is still wrong), but the evidence — agents are instructed to prefer the shell, so the uncovered path was the default one.

## Verified on the packed artifact, against the real client

```
acc --version → 0.1.7      store healthy; 3 of 4 adapter(s) installed

1. claimed, live Codex, shell write:
     Command blocked by PreToolUse hook: file:src/parser.mjs is claimed by alice
     Command: printf 'y' >> src/parser.mjs
     on disk: 0 changes

2. claimed, live Codex, reads through the shell:
     cat / grep -c parse → exit 0, not blocked

3. acc release --resource file:src/parser.mjs
     released claim_vIY4d5fs_jjaKx7DYcYw0w
     0 claim(s); protection none

4. the identical shell command, now:
     file changed — the guard lifts, it does not merely refuse

5. acc uninstall:
     hooks.state entries for ACC: 5 → 0
```

Step 2 is not a formality: a guard that blocked reading would be a worse regression than the hole it closes. Step 4 separates a guard from a breakage — a hook that denied everything would pass step 1 alone.

## Record

```
PASS  agents-can-communicate-0.1.7.tgz  sha256 16bbddfe…08c642  built from 22ee9c9
```

142 KB, 110 entries. 906 tests passing, 0 failing · `syntax ok in 189 file(s)`.

The bump broke nothing — eighth release in a row. `scripts/verify-package.mjs` caught a real one on the way: after regenerating the lockfile the workspaces were not linked, and it refused the tarball rather than shipping a package whose internal imports fail on install.
