### PR TITLE
fix: doctor names the ACC each client will actually run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Changelog
 
+## Unreleased
+
+| | |
+|---|---|
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
+| Tests | 935 passing, 0 failing |
+
+Not published. A published record says what the registry serves and is not
+rewritten, so shipped code that changes after a release is measured here instead.
+
+`acc doctor` names the ACC each client will actually run. Found by breaking a
+machine: extending PATH to expose one client resolved `acc` to an 0.1.1 sitting
+under a different Node version. That install rewired all four clients to itself,
+and the only symptom was a guard behaving like the version it came from - a shell
+write walked through a claim that 0.1.7 had learned to stop.
+
+Nothing reported it. `staleInstall` compares the version recorded at install
+against the one running now, and the 0.1.1 had rewritten that record with
+`accVersion: null` - it predates the field. So the old ACC did not only replace
+the wiring, it erased the evidence, and the check that existed for exactly this
+went quiet at exactly the wrong moment.
+
+The record is written by whoever writes last. The shim is not: it carries the
+absolute path of the runner the client executes, and an old ACC writes it
+honestly, pointing at itself. `acc doctor` now reads that path, resolves its
+manifest, and says what it found:
+
+```
+acc install --adapter kimi  # wired to acc 0.1.1, this is 0.1.8
+```
+
+`acc install` refuses to wire an older ACC over a newer one, and `--downgrade`
+asks for it deliberately. This is the weaker half and worth saying plainly: an
+older release cannot enforce a check it does not contain, so it will not stop the
+0.1.1 case that prompted this. It stops the same mistake between this release and
+every one after it. The diagnosis above is what covers the rest.
+
+Versions are compared per segment as numbers. A string comparison puts 0.1.10
+before 0.1.9, which is the release where this would start refusing every
+legitimate install.
+
+`acc install --adapter <client>` installs that client even when the version probe
+cannot find it. Presence was decided by running the client's `--version`, which
+answers "can ACC run this client" - not the question that matters, since ACC
+never runs it: the client runs ACC's hook. A CLI installed under a different Node
+version sat there with its own configuration directory while every install said
+"not installed on this machine". Naming the client is an answer to what the probe
+was guessing at, and the skip now names that way past itself.
+
+Presence is not inferred from the configuration directory existing. That was
+tried first and is unsound: ACC creates those directories itself, and the attempt
+read a client's own test fixture as proof the client was there.
+
 ## 0.1.8
 
 Two fixes to what an agent reads and what it can answer with. Both came out of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `39f9862` |
+| Tarball | `agents-can-communicate-0.1.8.tgz`, 145 KB, 110 entries |
+| sha256 | `cd2ef8723516f5c8473506705e178d1e931e47132ad292b316235e930b227d54` |
 | Tests | 935 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not

--- a/packages/cli/src/args.mjs
+++ b/packages/cli/src/args.mjs
@@ -63,7 +63,10 @@ export const COMMANDS = Object.freeze({
   // No `--yes`: neither of these ever asked, so the flag agreed to nothing. It
   // was accepted and read by nobody, which is a promise that a confirmation
   // exists to be skipped.
-  install: { required: [], optional: ["adapter", "home"], flags: ["dry-run"] },
+  // `--downgrade` because an older acc first on PATH will otherwise rewire every
+  // client to itself, and the only symptom is a guard behaving like the version
+  // it came from.
+  install: { required: [], optional: ["adapter", "home"], flags: ["dry-run", "downgrade"] },
   // `--dry-run` on both, because the preview was computed for either action and
   // only `install` could ask for it. Removal is the side that reaches into a
   // client's configuration - including a client that has left the machine.

--- a/packages/cli/src/doctor-command.mjs
+++ b/packages/cli/src/doctor-command.mjs
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 
@@ -30,9 +30,75 @@ import { diagnoseFilesystemStore, repairFilesystemStore }
  * Unknown when the install predates the record carrying it, and then nothing is
  * said: "your plugin might be old" on every run is not a diagnosis.
  */
+/**
+ * The ACC version a client will actually run, read out of its own shim.
+ *
+ * `staleInstall` compares the version recorded at install time against the one
+ * running now. That holds until the thing that rewrote the wiring is an ACC old
+ * enough not to know the field: an 0.1.1 first on PATH for one install rewired
+ * four clients to itself and rewrote the record with `accVersion: null`, erasing
+ * the evidence along with the wiring. The record is written by whoever writes
+ * last; the shim carries the absolute path of the runner the client executes,
+ * and an old ACC writes it honestly, pointing at itself.
+ *
+ * Null for anything unreadable. "Might be old" on every run is not a diagnosis.
+ */
+export async function wiredVersion(shimPath) {
+  if (typeof shimPath !== "string" || shimPath === "") return null;
+  const text = await readFile(shimPath, "utf8").catch(() => null);
+  if (text === null) return null;
+  const runner = /["']?(\/[^"'\s]*\/agents-can-communicate)\/bin\/acc-hook\.mjs["']?/.exec(text);
+  if (runner === null) return null;
+  const manifest = await readFile(path.join(runner[1], "package.json"), "utf8")
+    .catch(() => null);
+  if (manifest === null) return null;
+  try {
+    const version = JSON.parse(manifest).version;
+    return typeof version === "string" ? version : null;
+  } catch {
+    return null;
+  }
+}
+
 export function staleInstall({ recorded, running }) {
   if (typeof recorded !== "string" || typeof running !== "string") return null;
   return recorded === running ? null : { recorded, running };
+}
+
+/**
+ * The runner version behind whatever ACC wrote for one client.
+ *
+ * Two shapes, because the four clients differ: a config file ACC merged its hook
+ * commands into, and a tree ACC created with a shim inside it. The first
+ * readable answer wins, and every read is best-effort - a doctor that throws on
+ * a missing file diagnoses nothing.
+ */
+async function wiredVersionFor(artifacts) {
+  for (const artifact of artifacts ?? []) {
+    if (artifact.kind === "tree") {
+      for (const shim of await findShims(artifact.path, 4)) {
+        const version = await wiredVersion(shim);
+        if (version !== null) return version;
+      }
+      continue;
+    }
+    const version = await wiredVersion(artifact.path);
+    if (version !== null) return version;
+  }
+  return null;
+}
+
+/** Shim files under a tree ACC created, to a bounded depth. */
+async function findShims(root, depth) {
+  if (depth < 0) return [];
+  const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
+  const found = [];
+  for (const entry of entries) {
+    const target = path.join(root, entry.name);
+    if (entry.isDirectory()) found.push(...await findShims(target, depth - 1));
+    else if (entry.name.endsWith(".sh")) found.push(target);
+  }
+  return found;
 }
 
 async function diagnoseAdapters({ options, runtime }) {
@@ -64,16 +130,24 @@ async function diagnoseAdapters({ options, runtime }) {
     if (owned.missing.length > 0) {
       remediation.push(`acc install --adapter ${entry.adapterId}  # files are missing`);
     }
-    const stale = staleInstall({
-      recorded: record.installs.find(install => install.adapterId === entry.adapterId)
-        ?.accVersion ?? null,
-      running });
+    const installed = record.installs.find(one => one.adapterId === entry.adapterId);
+    const stale = staleInstall({ recorded: installed?.accVersion ?? null, running });
     if (stale !== null) {
       remediation.push(`acc install --adapter ${entry.adapterId}`
         + `  # plugin is ${stale.recorded}, acc is ${stale.running}`);
     }
-    return { ...entry, stale, owned: { modified: owned.modified, missing: owned.missing,
-      intact: owned.intact.length }, remediation };
+    // Read from the wiring rather than from the record. An ACC old enough not to
+    // know the record's version field still rewrites that record - blank - while
+    // pointing every client at itself, so the record goes quiet exactly when it
+    // matters. The shim names the runner the client will execute.
+    const wired = await wiredVersionFor(installed?.artifacts);
+    if (stale === null && typeof wired === "string" && typeof running === "string"
+      && wired !== running) {
+      remediation.push(`acc install --adapter ${entry.adapterId}`
+        + `  # wired to acc ${wired}, this is ${running}`);
+    }
+    return { ...entry, stale, wired, owned: { modified: owned.modified,
+      missing: owned.missing, intact: owned.intact.length }, remediation };
   }));
 }
 

--- a/packages/cli/src/install-command.mjs
+++ b/packages/cli/src/install-command.mjs
@@ -168,10 +168,11 @@ export async function runInstallCommand({ options, runtime, action = "install" }
   // An uninstall is planned from what ACC recorded writing, not only from what
   // is on the machine now. A client can be removed after ACC installed into it,
   // and its configuration directory - with ACC's files in it - stays behind.
-  const recorded = action === "uninstall"
-    ? (await loadOwnership({ dataHome })).installs
-    : [];
-  const plan = planInstallation({ adapters, detected, context, action, recorded });
+  // Read on both actions now. An uninstall plans from it because a client can
+  // leave the machine after ACC wrote to it; an install reads it to see which
+  // ACC is already wired, so an older copy cannot replace a newer one in
+  // silence.
+  const recorded = (await loadOwnership({ dataHome })).installs;
 
   const dryRun = options.dryRun === true;
   // Recorded with the install, so a later run can tell that the bundle sitting
@@ -180,6 +181,14 @@ export async function runInstallCommand({ options, runtime, action = "install" }
   const accVersion = typeof runtime.version === "function"
     ? await runtime.version().catch(() => null)
     : null;
+  // Naming a client is an answer to the question the version probe was guessing
+  // at. `acc install --adapter gemini_cli` says the client is here, whatever
+  // PATH this process happens to carry.
+  const requested = options.adapter === undefined
+    ? []
+    : (Array.isArray(options.adapter) ? options.adapter : [options.adapter]);
+  const plan = planInstallation({ adapters, detected, context, action, recorded,
+    accVersion, allowDowngrade: options.downgrade === true, requested });
   const result = await applyPlan({ plan, adapters, context, dataHome, dryRun, accVersion });
 
   const acted = actedOn(result);

--- a/packages/cli/test/doctor-names-the-wired-version.test.mjs
+++ b/packages/cli/test/doctor-names-the-wired-version.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { recordInstall } from "@agents-can-communicate/installer";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const binary = path.join(repoRoot, "bin", "acc.mjs");
+
+/**
+ * Doctor, run against a machine whose wiring came from a different ACC.
+ *
+ * The unit test beside this one covers reading a version out of a shim. This one
+ * covers the path the doctor actually walks to find that shim - a recorded tree
+ * artifact - which is the half that was missing when the helper shipped without
+ * its `readdir` import: every test passed, and the real `acc doctor` died with
+ * `readdir is not defined` on the first machine that had a tree recorded.
+ */
+async function machine(t, wiredVersion) {
+  const home = await realpath(await mkdtemp(path.join(tmpdir(), "acc-wired-home-")));
+  const dataHome = await realpath(await mkdtemp(path.join(tmpdir(), "acc-wired-data-")));
+  t.after(() => Promise.all([home, dataHome]
+    .map(dir => rm(dir, { recursive: true, force: true }))));
+
+  // A package that is not this one, with its own version, exactly as a second
+  // global install under another Node version would be.
+  const other = path.join(home, "other-node", "lib", "node_modules", "agents-can-communicate");
+  await mkdir(path.join(other, "bin"), { recursive: true });
+  await writeFile(path.join(other, "package.json"),
+    JSON.stringify({ name: "agents-can-communicate", version: wiredVersion }));
+  await writeFile(path.join(other, "bin", "acc-hook.mjs"), "// runner\n");
+
+  // The tree ACC records for this client, with the shim nested inside it the way
+  // a real plugin cache nests one.
+  const tree = path.join(home, ".claude", "plugins", "cache", "acc-local",
+    "agents-can-communicate", "0.1.6");
+  await mkdir(path.join(tree, "hooks"), { recursive: true });
+  await writeFile(path.join(tree, "hooks", "acc-hook.sh"),
+    `#!/bin/sh\nexec "/usr/bin/node" "${path.join(other, "bin", "acc-hook.mjs")}" claude_code "$@"\n`);
+
+  await recordInstall({ dataHome, adapterId: "claude_code", version: "2.1.0",
+    accVersion: null, artifacts: [{ path: tree, kind: "tree" }] });
+  return { home, dataHome };
+}
+
+const doctor = async ({ home, dataHome }) => {
+  const { stdout } = await execFileAsync(process.execPath, [binary, "doctor", "--json"],
+    { cwd: home, env: { ...process.env, HOME: home, ACC_DATA_HOME: dataHome } })
+    .catch(error => ({ stdout: error.stdout ?? "null" }));
+  return JSON.parse(stdout);
+};
+
+test("doctor names the ACC each client will actually run", async t => {
+  const place = await machine(t, "0.1.1");
+
+  const body = await doctor(place);
+
+  assert.equal(body.ok, true, JSON.stringify(body).slice(0, 300));
+  const entry = body.data.adapters.find(one => one.adapterId === "claude_code");
+  assert.equal(entry.wired, "0.1.1");
+  assert.equal(entry.remediation.some(line => /wired to acc 0\.1\.1/.test(line)), true,
+    `no remediation naming the wired version: ${JSON.stringify(entry.remediation)}`);
+});
+
+test("the record being blank does not stop the diagnosis", async t => {
+  // This is the whole point. An ACC old enough not to know `accVersion` rewrites
+  // the record with null while pointing every client at itself, so the
+  // record-based check goes quiet exactly when something has gone wrong.
+  const place = await machine(t, "0.1.1");
+
+  const body = await doctor(place);
+  const entry = body.data.adapters.find(one => one.adapterId === "claude_code");
+
+  assert.equal(entry.stale, null, "the record had nothing to say, as expected");
+  assert.equal(entry.wired, "0.1.1", "the wiring still answered");
+});
+
+test("wiring that matches the running acc says nothing", async t => {
+  const running = JSON.parse(
+    await (await import("node:fs/promises")).readFile(
+      path.join(repoRoot, "package.json"), "utf8")).version;
+  const place = await machine(t, running);
+
+  const body = await doctor(place);
+  const entry = body.data.adapters.find(one => one.adapterId === "claude_code");
+
+  assert.equal(entry.wired, running);
+  assert.equal(entry.remediation.some(line => /wired to acc/.test(line)), false,
+    "a healthy machine was told to reinstall");
+});

--- a/packages/cli/test/which-acc-will-actually-run.test.mjs
+++ b/packages/cli/test/which-acc-will-actually-run.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { wiredVersion } from "../src/doctor-command.mjs";
+
+/**
+ * Which ACC a client will actually run.
+ *
+ * `staleInstall` compared the version recorded at install time against the one
+ * running now, which works until the thing that rewrote the wiring is an ACC old
+ * enough not to know the field. Observed: an 0.1.1 sitting under a different
+ * Node version was first on PATH for one `acc install`. It rewired all four
+ * clients to itself **and** rewrote `installs.json` with `accVersion: null`,
+ * erasing the only evidence that anything had changed. Both the record-based
+ * check and a version guard in the planner went quiet, and the sole symptom was
+ * a guard behaving like the version it came from.
+ *
+ * The record can be overwritten by whoever writes last. The shim cannot lie in
+ * the same way: it carries the absolute path of the runner the client will
+ * execute, and an old ACC writes it honestly, pointing at itself.
+ */
+async function shim(t, runnerPackageVersion, { withPackage = true } = {}) {
+  const root = await realpath(await mkdtemp(path.join(tmpdir(), "acc-wired-")));
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const pkg = path.join(root, "lib", "node_modules", "agents-can-communicate");
+  await mkdir(path.join(pkg, "bin"), { recursive: true });
+  if (withPackage) {
+    await writeFile(path.join(pkg, "package.json"),
+      JSON.stringify({ name: "agents-can-communicate", version: runnerPackageVersion }));
+  }
+  const runner = path.join(pkg, "bin", "acc-hook.mjs");
+  await writeFile(runner, "// runner\n");
+
+  const file = path.join(root, "acc-hook.sh");
+  await writeFile(file, "#!/bin/sh\n"
+    + `exec "${path.join(root, "bin", "node")}" "${runner}" claude_code "$@"\n`);
+  return { file, runner };
+}
+
+test("the version a client will run is read out of its own shim", async t => {
+  const { file } = await shim(t, "0.1.1");
+
+  assert.equal(await wiredVersion(file), "0.1.1");
+});
+
+test("a shim pointing at a runner with no manifest answers null, not a guess", async t => {
+  const { file } = await shim(t, "0.1.1", { withPackage: false });
+
+  assert.equal(await wiredVersion(file), null);
+});
+
+test("a file that is not a shim is not read as one", async t => {
+  const root = await realpath(await mkdtemp(path.join(tmpdir(), "acc-wired-")));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const file = path.join(root, "settings.json");
+  await writeFile(file, '{"theme":"dark"}\n');
+
+  assert.equal(await wiredVersion(file), null);
+});
+
+test("a path that is not there answers null rather than throwing", async () => {
+  assert.equal(await wiredVersion("/nowhere/acc-hook.sh"), null);
+  assert.equal(await wiredVersion(undefined), null);
+});
+
+test("this is what the record could not tell you", async t => {
+  // The point of reading the shim: it still answers after an old ACC has blanked
+  // the record. `staleInstall(null, running)` says nothing; the shim says 0.1.1.
+  const { staleInstall } = await import("../src/doctor-command.mjs");
+  const { file } = await shim(t, "0.1.1");
+
+  assert.equal(staleInstall({ recorded: null, running: "0.1.8" }), null);
+  assert.equal(await wiredVersion(file), "0.1.1");
+});

--- a/packages/installer/src/plan.mjs
+++ b/packages/installer/src/plan.mjs
@@ -8,7 +8,7 @@ import { AccError, EXIT } from "@agents-can-communicate/protocol";
  * it previews is a decoration, and the operator would find out only afterwards.
  */
 export function planInstallation({ adapters, detected, context, action = "install",
-  recorded = [] }) {
+  recorded = [], accVersion = null, allowDowngrade = false, requested = [] }) {
   if (!["install", "uninstall"].includes(action)) {
     throw new AccError(EXIT.USAGE, `unknown installation action: ${action}`, { action });
   }
@@ -17,6 +17,15 @@ export function planInstallation({ adapters, detected, context, action = "instal
   // authority rather than detection: the record is the only account of what was
   // written, and a client's configuration directory outlives the client.
   const recordedById = new Map(recorded.map(install => [install.adapterId, install]));
+  // Presence is decided by running the client's `--version`, which answers "can
+  // ACC run this client" - not the question that matters, since ACC never runs
+  // it: the client runs ACC's hook. A client installed under a different Node
+  // version sat there with its own configuration directory while every install
+  // reported it missing. Its existence cannot be inferred from that directory,
+  // because ACC creates one itself - an earlier attempt at this read a client's
+  // own test fixture as proof the client was there. A person naming the client
+  // can be.
+  const askedFor = new Set(requested ?? []);
   const operations = [];
   const skipped = [];
 
@@ -38,11 +47,30 @@ export function planInstallation({ adapters, detected, context, action = "instal
       ? recordedById.get(entry.adapterId)
       : undefined;
 
-    if (!entry.present && record === undefined) {
+    if (!entry.present && record === undefined && !askedFor.has(entry.adapterId)) {
       // Named rather than dropped: "nothing happened" and "that client is not
-      // installed on this machine" look the same in an empty list.
+      // installed on this machine" look the same in an empty list. And the
+      // message names the way past itself, because the verdict is on PATH
+      // rather than on the machine.
       skipped.push({ adapterId: entry.adapterId,
-        reason: `${entry.displayName ?? entry.adapterId} is not installed on this machine` });
+        reason: `${entry.displayName ?? entry.adapterId} is not installed on this machine; `
+          + `if it is, wire it with --adapter ${entry.adapterId}` });
+      continue;
+    }
+    // The version doing the installing is whichever `acc` came first on PATH,
+    // and the shim it writes pins that copy's node and runner. So a second ACC
+    // on the machine quietly replaces every client's wiring with its own, older
+    // code, and the only symptom is a guard behaving like the version it came
+    // from. `recordInstall` has always written `accVersion` for exactly this
+    // comparison; nothing read it in this direction until now.
+    //
+    // Never on an uninstall: the older ACC is often the only thing that knows
+    // what it wrote, and refusing it would strand the wiring this undoes.
+    const wired = recordedById.get(entry.adapterId)?.accVersion;
+    if (action === "install" && !allowDowngrade && isOlder(accVersion, wired)) {
+      skipped.push({ adapterId: entry.adapterId,
+        reason: `${wired} is already wired here and this is ${accVersion}; `
+          + "run the newer acc, or pass --downgrade to wire this one deliberately" });
       continue;
     }
     if (record === undefined && typeof adapter.planInstall !== "function") {
@@ -82,4 +110,30 @@ export function planInstallation({ adapters, detected, context, action = "instal
     });
   }
   return { schemaVersion: 1, action, operations, skipped };
+}
+
+/**
+ * Is `candidate` an earlier release than `installed`?
+ *
+ * Numeric per segment, because the first comparison that matters in practice is
+ * 0.1.9 against 0.1.10, where a string comparison reverses the answer and starts
+ * refusing every legitimate install. Anything unreadable answers false: a
+ * corrupt record must not make the machine unrepairable by the command that
+ * exists to repair it.
+ */
+function isOlder(candidate, installed) {
+  const parse = value => {
+    if (typeof value !== "string") return null;
+    const parts = value.trim().split(".");
+    if (parts.length !== 3) return null;
+    const numbers = parts.map(part => (/^\d+$/.test(part) ? Number(part) : null));
+    return numbers.includes(null) ? null : numbers;
+  };
+  const left = parse(candidate);
+  const right = parse(installed);
+  if (left === null || right === null) return false;
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] !== right[index]) return left[index] < right[index];
+  }
+  return false;
 }

--- a/packages/installer/test/naming-a-client-is-an-answer.test.mjs
+++ b/packages/installer/test/naming-a-client-is-an-answer.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { planInstallation } from "../src/plan.mjs";
+
+/**
+ * Asking for a client by name, when the probe cannot find it.
+ *
+ * Presence is decided by running the client's `--version`, which answers "can
+ * ACC run this client" - not the question that matters. ACC never runs it. The
+ * client runs ACC's hook, and all ACC needs is a directory to write into.
+ *
+ * Observed: the Gemini CLI installed under one Node version while ACC ran under
+ * another. `~/.gemini` sat there with the user's own settings in it, and every
+ * `acc install` answered "Gemini CLI is not installed on this machine".
+ *
+ * Presence cannot be inferred from that directory existing, because ACC creates
+ * it itself when it installs - a first attempt at this read a client's own
+ * fixture as proof the client was there. What is unambiguous is a person naming
+ * the client: `acc install --adapter gemini_cli` is an answer to the question
+ * the probe was guessing at, and it is honoured.
+ */
+const adapter = (id, overrides = {}) => ({
+  id,
+  displayName: id,
+  client: { command: id, versionArgs: ["--version"] },
+  capabilities: {},
+  planInstall: () => [{ path: `/tmp/${id}`, kind: "file" }],
+  ...overrides,
+});
+
+const absent = id => ({ adapterId: id, displayName: id, present: false, version: null,
+  versionOutput: null, installed: false, diagnostics: [], capabilities: {}, error: null });
+
+const plan = extra => planInstallation({
+  adapters: [adapter("gemini_cli")],
+  detected: [absent("gemini_cli")],
+  context: { home: "/home/x", stateRoot: "/state" },
+  action: "install",
+  ...extra,
+});
+
+test("a client nobody asked for, that nothing can find, is still skipped", () => {
+  const result = plan({});
+
+  assert.deepEqual(result.operations, []);
+  assert.match(result.skipped[0].reason, /not installed on this machine/);
+});
+
+test("a client asked for by name is installed even when the probe missed it", () => {
+  const result = plan({ requested: ["gemini_cli"] });
+
+  assert.equal(result.operations.length, 1);
+  assert.deepEqual(result.skipped, []);
+});
+
+test("naming one client does not carry the others in with it", () => {
+  const result = planInstallation({
+    adapters: [adapter("gemini_cli"), adapter("kimi")],
+    detected: [absent("gemini_cli"), absent("kimi")],
+    context: { home: "/home/x", stateRoot: "/state" },
+    action: "install",
+    requested: ["gemini_cli"],
+  });
+
+  assert.deepEqual(result.operations.map(one => one.adapterId), ["gemini_cli"]);
+  assert.deepEqual(result.skipped.map(one => one.adapterId), ["kimi"]);
+});
+
+test("the skip says how to answer it", () => {
+  // The whole failure was a message that read as a verdict on the machine when
+  // it was a verdict on PATH. It has to name the way past itself.
+  const [skipped] = plan({}).skipped;
+
+  assert.match(skipped.reason, /--adapter gemini_cli/,
+    `the skip does not name the remedy: ${skipped.reason}`);
+});
+
+test("an explicit request does not override a downgrade", () => {
+  // Two different questions. "Is this client here" is answered by naming it;
+  // "should an older ACC replace a newer one" is not.
+  const result = plan({ requested: ["gemini_cli"], accVersion: "0.1.1",
+    recorded: [{ adapterId: "gemini_cli", accVersion: "0.1.8", artifacts: [] }] });
+
+  assert.deepEqual(result.operations, []);
+  assert.match(result.skipped[0].reason, /--downgrade/);
+});

--- a/packages/installer/test/no-silent-downgrade.test.mjs
+++ b/packages/installer/test/no-silent-downgrade.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { planInstallation } from "../src/plan.mjs";
+
+/**
+ * An install that would wire an older ACC than the one already wired.
+ *
+ * The version doing the installing is whichever `acc` came first on PATH, and
+ * the shim it writes pins that copy's node and runner. So a second ACC on the
+ * machine - a different Node version's global install, a stale one - silently
+ * replaces the wiring of every client with its own, older code.
+ *
+ * Observed: extending PATH to expose one client resolved `acc` to an 0.1.1
+ * sitting under another Node version. It rewired three clients to itself, and
+ * the only visible symptom was a guard behaving like the version it came from:
+ * a shell write walked through a claim that 0.1.7 had learned to stop.
+ *
+ * The record needed to catch this already existed. `recordInstall` writes
+ * `accVersion` per client, with a comment saying it is there "so a later run can
+ * tell that the bundle sitting in a client is older than the code now running".
+ * Nothing read it in the other direction.
+ */
+const adapter = (id, overrides = {}) => ({
+  id,
+  displayName: id,
+  client: { command: id, versionArgs: ["--version"] },
+  capabilities: {},
+  planInstall: () => [{ path: `/tmp/${id}`, kind: "file" }],
+  ...overrides,
+});
+
+const detectedEntry = (id, overrides = {}) => ({
+  adapterId: id, displayName: id, present: true, version: "1.0.0",
+  versionOutput: "1.0.0", installed: false, diagnostics: [], capabilities: {},
+  error: null, ...overrides,
+});
+
+const plan = ({ accVersion, recorded }) => planInstallation({
+  adapters: [adapter("claude_code")],
+  detected: [detectedEntry("claude_code")],
+  context: { home: "/home/x", stateRoot: "/state" },
+  action: "install",
+  recorded,
+  accVersion,
+});
+
+test("installing an older ACC over a newer one is refused, not done quietly", () => {
+  const result = plan({ accVersion: "0.1.1",
+    recorded: [{ adapterId: "claude_code", accVersion: "0.1.8", artifacts: [] }] });
+
+  assert.deepEqual(result.operations, []);
+  const [skipped] = result.skipped;
+  assert.equal(skipped?.adapterId, "claude_code");
+  // The message has to name both versions: the whole failure was that nobody
+  // could see which ACC was doing the writing.
+  assert.match(skipped.reason, /0\.1\.8/);
+  assert.match(skipped.reason, /0\.1\.1/);
+});
+
+test("the same version reinstalls, because that is how a repair is done", () => {
+  const result = plan({ accVersion: "0.1.8",
+    recorded: [{ adapterId: "claude_code", accVersion: "0.1.8", artifacts: [] }] });
+
+  assert.equal(result.operations.length, 1);
+  assert.deepEqual(result.skipped, []);
+});
+
+test("a newer ACC installs over an older one without ceremony", () => {
+  const result = plan({ accVersion: "0.1.9",
+    recorded: [{ adapterId: "claude_code", accVersion: "0.1.8", artifacts: [] }] });
+
+  assert.equal(result.operations.length, 1);
+  assert.deepEqual(result.skipped, []);
+});
+
+test("versions are compared as numbers, not as strings", () => {
+  // "0.1.10" < "0.1.9" alphabetically, which is exactly the release where a
+  // string comparison would start refusing every legitimate install.
+  const older = plan({ accVersion: "0.1.9",
+    recorded: [{ adapterId: "claude_code", accVersion: "0.1.10", artifacts: [] }] });
+  assert.equal(older.operations.length, 0, "0.1.9 over 0.1.10 is a downgrade");
+
+  const newer = plan({ accVersion: "0.1.10",
+    recorded: [{ adapterId: "claude_code", accVersion: "0.1.9", artifacts: [] }] });
+  assert.equal(newer.operations.length, 1, "0.1.10 over 0.1.9 is an upgrade");
+});
+
+test("a first install has nothing to compare against and proceeds", () => {
+  assert.equal(plan({ accVersion: "0.1.8", recorded: [] }).operations.length, 1);
+  assert.equal(plan({ accVersion: "0.1.8",
+    recorded: [{ adapterId: "claude_code", accVersion: null, artifacts: [] }] })
+    .operations.length, 1);
+});
+
+test("a version this cannot read is not treated as a downgrade", () => {
+  // Refusing on an unparseable record would make a corrupt file unrecoverable
+  // by the command that exists to repair the machine.
+  for (const recordedVersion of ["", "next", "0.1.x", undefined]) {
+    const result = plan({ accVersion: "0.1.8",
+      recorded: [{ adapterId: "claude_code", accVersion: recordedVersion, artifacts: [] }] });
+    assert.equal(result.operations.length, 1, `refused on ${JSON.stringify(recordedVersion)}`);
+  }
+});
+
+test("a deliberate downgrade is possible, and has to be asked for", () => {
+  const result = planInstallation({
+    adapters: [adapter("claude_code")],
+    detected: [detectedEntry("claude_code")],
+    context: { home: "/home/x", stateRoot: "/state" },
+    action: "install",
+    recorded: [{ adapterId: "claude_code", accVersion: "0.1.8", artifacts: [] }],
+    accVersion: "0.1.1",
+    allowDowngrade: true,
+  });
+
+  assert.equal(result.operations.length, 1);
+  assert.deepEqual(result.skipped, []);
+});
+
+test("an uninstall is never refused for being older", () => {
+  // The older ACC is often the only thing that knows what it wrote. Refusing
+  // its uninstall would strand exactly the wiring this check exists to undo.
+  const result = planInstallation({
+    adapters: [adapter("claude_code")],
+    detected: [detectedEntry("claude_code")],
+    context: { home: "/home/x", stateRoot: "/state" },
+    action: "uninstall",
+    recorded: [{ adapterId: "claude_code", accVersion: "0.1.8",
+      artifacts: [{ path: "/tmp/claude_code", kind: "file" }] }],
+    accVersion: "0.1.1",
+  });
+
+  assert.equal(result.operations.length, 1);
+});


### PR DESCRIPTION
Found by breaking a machine. Extending PATH to expose one client resolved `acc` to an **0.1.1** sitting under a different Node version. That install rewired all four clients to itself, and the only symptom was a guard behaving like the version it came from — a shell write walked through a `guarded` claim that 0.1.7 had learned to stop.

## Nothing reported it, and the check that should have was disarmed

`staleInstall` compares the version recorded at install against the one running now. The 0.1.1 rewrote that record with `accVersion: null` — it predates the field. So the old ACC did not only replace the wiring; it erased the evidence, and the check built for exactly this went quiet at exactly the wrong moment:

```
claude_code  accVersion=None
codex        accVersion=None
gemini_cli   accVersion=None
kimi         accVersion=None
```

The record is written by whoever writes last. **The shim is not** — it carries the absolute path of the runner the client executes, and an old ACC writes it honestly, pointing at itself. Doctor now reads that path, resolves its manifest, and says what it found:

```
store healthy; 0 live; protection none; 4 of 4 adapter(s) installed
  acc install --adapter claude_code  # wired to acc 0.1.1, this is 0.1.8
  acc install --adapter codex        # wired to acc 0.1.1, this is 0.1.8
  acc install --adapter gemini_cli   # wired to acc 0.1.1, this is 0.1.8
  acc install --adapter kimi         # wired to acc 0.1.1, this is 0.1.8
```

That output is from the real broken machine, before repair.

## The weaker half, said plainly

`acc install` refuses to wire an older ACC over a newer one; `--downgrade` asks for it deliberately. **This does not stop the 0.1.1 case that prompted it** — an older release cannot enforce a check it does not contain. It stops the same mistake between this release and every one after it. The diagnosis above is what covers the rest, and it is the part that actually works today.

Versions compare per segment as numbers. A string comparison puts `0.1.10` before `0.1.9` — the release where this would start refusing every legitimate install.

## A client the probe cannot find

Presence was decided by running the client's `--version`, which answers "can ACC run this client". That is not the question: ACC never runs it — the client runs ACC's hook, and all ACC needs is a directory to write into. A CLI installed under a different Node version sat there with its own configuration directory while every install answered:

```
skip gemini_cli: Gemini CLI is not installed on this machine
```

`--adapter <client>` is now an answer to what the probe was guessing at, and the skip names that way past itself:

```
skip gemini_cli: Gemini CLI is not installed on this machine; if it is, wire it with --adapter gemini_cli
```

**Presence is not inferred from the configuration directory existing.** That was the first attempt and it is unsound: ACC creates those directories itself, and the attempt read a client's own test fixture as proof the client was there. The suite caught it as a silently self-skipping test — 914 → 927 tests with one skipped, where clean main had none.

## Record

```
PASS  agents-can-communicate-0.1.8.tgz  sha256 cd2ef872…227d54  built from 39f9862
```

145 KB, 110 entries. 935 tests passing, 0 failing · `syntax ok in 195 file(s)`.

Mutation-proved: dropping the `readdir` import fails all 3 doctor tests, reading the version from the record instead of the wiring fails all 3, removing the labels' guard fails the planner tests, and comparing versions as strings fails the 0.1.9-vs-0.1.10 case.

One test exists because of a gap this work exposed: the helper shipped without its `readdir` import, every test passed, and the real `acc doctor` died with `readdir is not defined` on the first machine that had a tree recorded. Nothing covered the path from a recorded tree artifact to the shim inside it. Now something does.
