### PR TITLE
release: 0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ that case had been disarmed by the same event.
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `4697a72` |
+| Tarball | `agents-can-communicate-0.1.9.tgz`, 145 KB, 110 entries |
+| sha256 | `f83415d679f300ac0d58c92b53a18a4739133c45846f0c386d7607f59fed40fc` |
 | Tests | 935 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,21 @@
 # Changelog
 
-## Unreleased
+## 0.1.9
+
+Three fixes to installation, all found by breaking a real machine rather than by
+reading the code. The one that matters: when a second ACC on the machine took
+over every client's wiring, nothing said so - and the check built for exactly
+that case had been disarmed by the same event.
 
 | | |
 |---|---|
-| Built from | `39f9862` |
-| Tarball | `agents-can-communicate-0.1.8.tgz`, 145 KB, 110 entries |
-| sha256 | `cd2ef8723516f5c8473506705e178d1e931e47132ad292b316235e930b227d54` |
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
 | Tests | 935 passing, 0 failing |
-
-Not published. A published record says what the registry serves and is not
-rewritten, so shipped code that changes after a release is measured here instead.
+| Node | 24 (current production LTS) |
+| Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
+| Not supported | Windows — untested rather than known-broken |
 
 `acc doctor` names the ACC each client will actually run. Found by breaking a
 machine: extending PATH to expose one client resolved `acc` to an 0.1.1 sitting

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -102,51 +102,51 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.1.8"
+      "version": "0.1.9"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.1.8"
+      "version": "0.1.9"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.1.8"
+      "version": "0.1.9"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.1.8"
+      "version": "0.1.9"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.1.8"
+      "version": "0.1.9"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.1.8"
+      "version": "0.1.9"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.1.8"
+      "version": "0.1.9"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.1.8"
+      "version": "0.1.9"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.1.8"
+      "version": "0.1.9"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.1.8"
+      "version": "0.1.9"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.1.8"
+      "version": "0.1.9"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.1.8"
+      "version": "0.1.9"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "description": "Local-first coordination for independently opened AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.mjs" },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Three fixes to installation, all found by breaking a real machine rather than by reading the code.

| | |
|---|---|
| **#79** | **`acc doctor` names the ACC each client will actually run.** A second ACC on the machine took over every client's wiring and nothing said so — and the check built for that case had been disarmed by the same event, because the old version rewrote the ownership record with `accVersion: null` |
| #79 | `acc install` refuses to wire an older ACC over a newer one; `--downgrade` asks for it deliberately |
| #79 | `acc install --adapter <client>` installs a client the version probe cannot find, and the skip now names that way past itself |

## Verified on the packed artifact, by reproducing the breakage

```
1. healthy machine, 0.1.9 installed, bundles not yet rewired:
     acc install --adapter claude_code  # plugin is 0.1.8, acc is 0.1.9
     …the record-based check, working as it always did

2. an 0.1.1 under another Node version hijacks the wiring:
     installed 4 adapter(s)

3. what 0.1.9 says about that — the thing no earlier release could:
     acc install --adapter claude_code  # wired to acc 0.1.1, this is 0.1.9
     acc install --adapter codex        # wired to acc 0.1.1, this is 0.1.9
     acc install --adapter gemini_cli   # wired to acc 0.1.1, this is 0.1.9
     acc install --adapter kimi         # wired to acc 0.1.1, this is 0.1.9

4. after repair: store healthy, nothing to report

5. a client the probe cannot find, named explicitly:
     acc install --adapter gemini_cli
     created ~/.gemini/extensions/agents-can-communicate
```

Step 1 matters as much as step 3: it shows the older check still doing its own job rather than being replaced by the new one. Step 4 separates a diagnosis from an alarm — a doctor that always complains diagnoses nothing.

## Said plainly

The install-side refusal **cannot stop the 0.1.1 case that prompted it**: an older release cannot enforce a check it does not contain. It stops the same mistake between this release and every one after it. Step 3 is the part that works today.

## Record

```
PASS  agents-can-communicate-0.1.9.tgz  sha256 f83415d6…ed40fc  built from 4697a72
```

145 KB, 110 entries. 935 tests passing, 0 failing · `syntax ok in 195 file(s)`.

Tenth release in a row without a broken bump.
