### PR TITLE
fix: the plugin version is the acc version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `3ace271` |
+| Tarball | `agents-can-communicate-0.1.9.tgz`, 146 KB, 111 entries |
+| sha256 | `49a0400e6c2db38b3e56ee6258f58a8b4dc9931be813bdb752e9e7b84d1aac57` |
 | Tests | 939 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## Unreleased
+
+| | |
+|---|---|
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
+| Tests | 939 passing, 0 failing |
+
+Not published. A published record says what the registry serves and is not
+rewritten, so shipped code that changes after a release is measured here instead.
+
+The version a client caches ACC's plugin under is the version of the ACC that
+installed it. It was a literal in each plugin manifest, updated by hand and by
+nobody. Three releases after 0.1.6 the package was 0.1.9 while every client had
+cached, listed and reported `0.1.6` - including `installed_plugins.json`, which
+is where a person looks to answer "which ACC am I running".
+
+Worse than cosmetic: the version string is how a client decides whether its
+cached copy is still current. A bundle whose version never changes is a bundle a
+client has no reason to replace, so an upgrade could leave the old plugin body in
+place while the CLI moved on.
+
+The fix is not "remember to bump three more files". The shipped manifests now
+carry no version at all, and the install stamps the running one into the copy the
+client reads. There is one version on the machine and nothing in the repository
+that can fall out of step with it.
+
+The tests that touched this were reading the version out of the same manifest, so
+they followed the literal wherever it went and could never see it drift. They
+read the package now.
+
 ## 0.1.9
 
 Three fixes to installation, all found by breaking a real machine rather than by

--- a/packages/adapter-claude-code/plugin/.claude-plugin/plugin.json
+++ b/packages/adapter-claude-code/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,4 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.6",
   "description": "Coordinate this Claude Code session with other AI agent sessions working in the same workspace: shared presence, resource claims, typed messages, and handoffs."
 }

--- a/packages/adapter-claude-code/src/install.mjs
+++ b/packages/adapter-claude-code/src/install.mjs
@@ -5,6 +5,7 @@ import { AccError, EXIT } from "@agents-can-communicate/protocol";
 import { fileURLToPath } from "node:url";
 
 import { acccreatedFile, bakeSkillCommand, blankJson, mergeOwnedEntries, ownedEntries,
+  ownVersion, stampPluginVersion,
   removeIfEmpty,
   removeInstalledTree,
   removeOwnedEntries, writeForeignJson, writeHookShim }
@@ -122,7 +123,9 @@ const writeRegistry = async (file, value, remaining) => {
   return rm(file, { force: true });
 };
 
-const pluginVersion = async () => (await readJson(manifest, {})).version ?? "0.0.0";
+// One version on this machine: the package's own. The shipped manifest carries
+// none, so there is nothing in the repository to fall out of step.
+const pluginVersion = async () => ownVersion(import.meta.url);
 
 /** The marketplace manifest, in the shape the client's own directory sources use. */
 const marketplaceManifest = () => ({
@@ -147,6 +150,11 @@ async function layOutPlugin(target, { runner, node }) {
   // The bundle's hooks.json names this script, and nothing else writes it.
   await writeHookShim({ dir: path.join(target, "hooks"), adapterId: "claude_code",
     runner, node });
+  // The copy the client reads says which ACC wrote it. The shipped manifest
+  // carries no version, so there is nothing in the repository to fall out of
+  // step - which is how every client came to report 0.1.6 while running 0.1.9.
+  await stampPluginVersion({ file: path.join(target, ".claude-plugin", "plugin.json"),
+    version: await pluginVersion(), io: { readFile, writeFile } });
 }
 
 export async function installClaudePlugin({ configDir, runner, node, now = new Date() }) {

--- a/packages/adapter-codex/plugin/.codex-plugin/plugin.json
+++ b/packages/adapter-codex/plugin/.codex-plugin/plugin.json
@@ -1,9 +1,13 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.6",
   "description": "Coordinate this Codex session with other AI agent sessions working in the same workspace.",
   "license": "UNLICENSED",
-  "keywords": ["coordination", "multi-agent", "claims", "handoff"],
+  "keywords": [
+    "coordination",
+    "multi-agent",
+    "claims",
+    "handoff"
+  ],
   "skills": "./skills/",
   "hooks": "./hooks.json",
   "interface": {
@@ -12,6 +16,9 @@
     "longDescription": "Attaches this session to a local coordination plane shared with Codex, Claude Code, Gemini CLI, and MCP clients working in the same workspace. Publishes what this session is doing, warns before two sessions edit the same resource, carries typed messages between participants, and records a handoff at the end.",
     "developerName": "automatis-tools",
     "category": "Developer Tools",
-    "capabilities": ["Read", "Write"]
+    "capabilities": [
+      "Read",
+      "Write"
+    ]
   }
 }

--- a/packages/adapter-codex/src/install.mjs
+++ b/packages/adapter-codex/src/install.mjs
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { bakeSkillCommand, blankJson, blankText, removeIfEmpty, removeInstalledTree,
+  ownVersion, stampPluginVersion,
   removeTomlBlock, stripBlock, tomlString,
   writeForeignJson, writeHookShim, writeTomlBlock }
   from "@agents-can-communicate/adapter-sdk";
@@ -199,8 +200,13 @@ export async function installCodexPlugin({ home, agentsHome = home,
 
   // The client runs the cached copy, so this has to happen after the shim and
   // the rewritten hooks.json are in place.
-  const { version } = await readJson(
-    path.join(target, ".codex-plugin", "plugin.json"), { version: "0.0.0" });
+  // One version on this machine: the package's own. The shipped manifest carries
+  // none, so nothing in the repository can fall out of step with it - which is
+  // how every client came to report 0.1.6 while running 0.1.9. The copy the
+  // client reads is stamped, so it says which ACC wrote it.
+  const version = await ownVersion(import.meta.url);
+  await stampPluginVersion({ file: path.join(target, ".codex-plugin", "plugin.json"),
+    version, io: { readFile, writeFile } });
   const cached = cachedVersionPath(codexHome, version);
   await rm(cached, { recursive: true, force: true });
   await cp(target, cached, { recursive: true });

--- a/packages/adapter-kimi/plugin/.kimi-plugin/plugin.json
+++ b/packages/adapter-kimi/plugin/.kimi-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.6",
   "description": "Coordinate this Kimi Code session with other AI agent sessions working in the same workspace: shared presence, resource claims, typed messages, and handoffs.",
   "skills": "./skills/",
   "sessionStart": {

--- a/packages/adapter-kimi/src/install.mjs
+++ b/packages/adapter-kimi/src/install.mjs
@@ -5,6 +5,7 @@ import { AccError, EXIT } from "@agents-can-communicate/protocol";
 import { fileURLToPath } from "node:url";
 
 import { assertRunner, bakeSkillCommand, blankText, defaultRunner, removeIfEmpty,
+  ownVersion, stampPluginVersion,
   removeInstalledTree, runnerExists, writeForeignJson }
   from "@agents-can-communicate/adapter-sdk";
 
@@ -132,6 +133,10 @@ export async function installKimiPlugin({ home, runner = defaultRunner(), node }
   const target = pluginPath(home);
   await rm(target, { recursive: true, force: true });
   await cp(bundle, target, { recursive: true });
+  // The copy this client reads says which ACC wrote it. Nothing here reads it
+  // back, but a manifest that names a version it is not is a lie either way.
+  await stampPluginVersion({ file: path.join(target, ".kimi-plugin", "plugin.json"),
+    version: await ownVersion(import.meta.url), io: { readFile, writeFile } });
   // The skill ships with a placeholder where the command belongs: `acc` is
   // not on PATH everywhere, and an agent that cannot run it improvises.
   await bakeSkillCommand({ root: target, node });

--- a/packages/adapter-sdk/src/index.mjs
+++ b/packages/adapter-sdk/src/index.mjs
@@ -9,6 +9,7 @@ export { BEGIN, END, removeTomlBlock, renderBlock, stripBlock, tomlString, write
   from "./toml-block.mjs";
 export { projectContext } from "./context-projector.mjs";
 export { shellWriteTargets } from "./shell-writes.mjs";
+export { ownVersion, stampPluginVersion } from "./own-version.mjs";
 export { editJson, readJson } from "./json-text.mjs";
 export { formatJsonAs, jsonStyleOf, mergeOwnedConfig, mergeOwnedEntries, ownedEntries, ownedKeys,
   acccreatedFile, removeIfEmpty, removeOwnedConfig, removeOwnedEntries, writeForeignJson,

--- a/packages/adapter-sdk/src/own-version.mjs
+++ b/packages/adapter-sdk/src/own-version.mjs
@@ -1,0 +1,57 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * The version of the ACC that is running.
+ *
+ * Every plugin manifest used to carry its own version literal, updated by hand
+ * and by nobody: three releases after 0.1.6 the package was 0.1.9 while every
+ * client had cached, listed and reported 0.1.6. That is not cosmetic - the
+ * version string is how a client decides whether its cached copy is current, so
+ * a bundle whose version never changes is one it has no reason to replace.
+ *
+ * Read by walking up for the nearest `package.json`, which lands on the calling
+ * package in a checkout and on the same file once bundled, where every package
+ * is versioned together. Answers `0.0.0` rather than throwing: an install that
+ * cannot read its own version should still lay a plugin down, under a version
+ * that is visibly wrong rather than crash.
+ */
+export async function ownVersion(fromUrl) {
+  let directory = path.dirname(fileURLToPath(fromUrl));
+  for (;;) {
+    const candidate = path.join(directory, "package.json");
+    const text = await readFile(candidate, "utf8").catch(() => null);
+    if (text !== null) {
+      try {
+        const version = JSON.parse(text).version;
+        if (typeof version === "string" && version !== "") return version;
+      } catch {
+        // A manifest that will not parse is not this package's version.
+      }
+    }
+    const parent = path.dirname(directory);
+    if (parent === directory) return "0.0.0";
+    directory = parent;
+  }
+}
+
+/**
+ * Stamp a laid-out plugin manifest with the version that wrote it.
+ *
+ * The shipped manifest carries no version of its own, so there is nothing in the
+ * repository to fall out of step. Best-effort: a manifest that is not there was
+ * not ours to stamp.
+ */
+export async function stampPluginVersion({ file, version, io }) {
+  const text = await io.readFile(file, "utf8").catch(() => null);
+  if (text === null) return false;
+  let manifest;
+  try {
+    manifest = JSON.parse(text);
+  } catch {
+    return false;
+  }
+  await io.writeFile(file, `${JSON.stringify({ ...manifest, version }, null, 2)}\n`);
+  return true;
+}

--- a/tests/helpers/plugin-version.mjs
+++ b/tests/helpers/plugin-version.mjs
@@ -2,17 +2,22 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const packages = fileURLToPath(new URL("../../packages/", import.meta.url));
+const repo = fileURLToPath(new URL("../../", import.meta.url));
 
 /**
  * The version a client caches a plugin under.
  *
- * Read from the manifest that ships it rather than written out. Every one of
- * these paths was spelled `0.0.0` by hand, and the first version bump broke five
- * tests that were describing a real behaviour perfectly well.
+ * Read from the package, because that is now the only place it exists. It used
+ * to be a literal in each plugin manifest, and this helper read it from there -
+ * so the tests followed the literal wherever it went and could not see it drift.
+ * It drifted: three releases after 0.1.6 the package was 0.1.9 while every
+ * client had cached, listed and reported 0.1.6.
+ *
+ * The argument is kept so callers still say which plugin they mean; every one of
+ * them is versioned with the package.
  */
-export async function pluginVersion(manifest) {
-  return JSON.parse(await readFile(path.join(packages, manifest), "utf8")).version;
+export async function pluginVersion(_manifest) {
+  return JSON.parse(await readFile(path.join(repo, "package.json"), "utf8")).version;
 }
 
 export const CLAUDE_PLUGIN = "adapter-claude-code/plugin/.claude-plugin/plugin.json";

--- a/tests/process/the-plugin-version-is-the-acc-version.test.mjs
+++ b/tests/process/the-plugin-version-is-the-acc-version.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, readdir, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { clientContext } from "@agents-can-communicate/cli";
+import { createClaudeCodeAdapter } from "@agents-can-communicate/adapter-claude-code";
+import { createCodexAdapter } from "@agents-can-communicate/adapter-codex";
+
+const repo = fileURLToPath(new URL("../..", import.meta.url));
+
+/**
+ * The version a client caches ACC's plugin under.
+ *
+ * It was a literal in each plugin manifest, updated by hand and by nobody. Three
+ * releases later the package was 0.1.9 while every client had cached, listed and
+ * reported `0.1.6` - including `installed_plugins.json`, which is what a person
+ * reads to see which ACC they are running.
+ *
+ * Worse than cosmetic: the version string is how a client decides whether its
+ * cached copy is still current. A bundle whose version never changes is a bundle
+ * a client has no reason to replace.
+ *
+ * The tests that touched this all read the version out of the same manifest, so
+ * they followed it wherever it went and could never see it drift.
+ */
+const accVersion = async () =>
+  JSON.parse(await readFile(path.join(repo, "package.json"), "utf8")).version;
+
+async function home(t) {
+  const dir = await realpath(await mkdtemp(path.join(tmpdir(), "acc-plugin-version-")));
+  const state = await realpath(await mkdtemp(path.join(tmpdir(), "acc-plugin-state-")));
+  t.after(() => Promise.all([dir, state]
+    .map(one => rm(one, { recursive: true, force: true }))));
+  return clientContext(dir, state);
+}
+
+test("claude_code caches the plugin under the version of the acc that installed it", async t => {
+  const context = await home(t);
+  const version = await accVersion();
+
+  await createClaudeCodeAdapter().install(context);
+
+  const cache = path.join(context.home, ".claude", "plugins", "cache", "acc-local",
+    "agents-can-communicate");
+  assert.deepEqual(await readdir(cache), [version],
+    "the cache directory is not named for the running acc");
+
+  const manifest = JSON.parse(await readFile(
+    path.join(cache, version, ".claude-plugin", "plugin.json"), "utf8"));
+  assert.equal(manifest.version, version);
+});
+
+test("what the client lists is the version that is running", async t => {
+  // `installed_plugins.json` is where a person looks to answer "which ACC is
+  // this". It reported 0.1.6 on a machine running 0.1.9.
+  const context = await home(t);
+  const version = await accVersion();
+
+  await createClaudeCodeAdapter().install(context);
+
+  const listed = await readFile(
+    path.join(context.home, ".claude", "plugins", "installed_plugins.json"), "utf8");
+  assert.equal(listed.includes(version), true,
+    `installed_plugins.json does not mention ${version}: ${listed}`);
+});
+
+test("codex caches it under that version too", async t => {
+  const context = await home(t);
+  const version = await accVersion();
+
+  await createCodexAdapter().install(context);
+
+  const cache = path.join(context.home, ".codex", "plugins", "cache", "acc-local",
+    "agents-can-communicate");
+  assert.deepEqual(await readdir(cache), [version]);
+});
+
+test("no shipped manifest carries a version of its own to drift", async () => {
+  // The fix is not "remember to bump three more files". There is one version on
+  // this machine and the install stamps it; a second copy in the repository is
+  // the thing that went stale.
+  for (const manifest of [
+    "packages/adapter-claude-code/plugin/.claude-plugin/plugin.json",
+    "packages/adapter-codex/plugin/.codex-plugin/plugin.json",
+    "packages/adapter-kimi/plugin/.kimi-plugin/plugin.json",
+  ]) {
+    const shipped = JSON.parse(await readFile(path.join(repo, manifest), "utf8"));
+    assert.equal(shipped.version, undefined,
+      `${manifest} still declares a version that nothing keeps in step`);
+    assert.equal(typeof shipped.name, "string", `${manifest} lost its name`);
+  }
+});


### PR DESCRIPTION
Noticed while clearing the machine after #79: the package was **0.1.9** and every client had cached, listed and reported **0.1.6**.

```
claude cache:            0.1.6
codex cache:             0.1.6
installed_plugins.json:  0.1.6
acc --version:           0.1.9
```

Each plugin manifest carried its own `"version"` literal, updated by hand and by nobody. It last moved at 0.1.6.

## Why this is not cosmetic

`installed_plugins.json` is where a person looks to answer "which ACC am I running", and it was answering wrong. More to the point, that string is how a client decides whether its cached copy is still current — a bundle whose version never changes is one the client has no reason to replace. An upgrade could leave the old plugin body in place while the CLI moved on, which is the same class of failure as #79 and just as quiet.

## The fix is not "remember to bump three more files"

The shipped manifests now carry **no version at all**. The install stamps the running one into the copy the client reads. There is one version on the machine — the package's — and nothing in the repository that can drift from it.

```js
// One version on this machine: the package's own. The shipped manifest carries
// none, so there is nothing in the repository to fall out of step.
const pluginVersion = async () => ownVersion(import.meta.url);
```

## Why no test caught it

`tests/helpers/plugin-version.mjs` read the version out of the same manifest it was checking, so five tests followed the literal wherever it went and none could see it drift from the package. It reads the package now, and a new test asserts no shipped manifest declares a version of its own.

## Verified on the packed artifact

```
before:  claude cache 0.1.6, acc 0.1.9

after:   acc                     0.1.9
         claude cache            0.1.9
         codex cache             0.1.9
         installed_plugins.json  0.1.9
         manifest in the cache   0.1.9
```

## Record

```
PASS  agents-can-communicate-0.1.9.tgz  sha256 49a0400e…1aac57  built from 3ace271
```

146 KB, 111 entries. 939 tests passing, 0 failing · `syntax ok in 197 file(s)`.

Mutation-proved: making the stamp a no-op fails 1 of the 4 new tests, and returning a hardcoded `0.1.6` from `ownVersion` fails 3.
