### PR TITLE
fix: an upgrade leaves one copy of the plugin, not one per release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@
 
 | | |
 |---|---|
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
+| Tests | 943 passing, 0 failing |
+
+Not published. A published record says what the registry serves and is not
+rewritten, so shipped code that changes after a release is measured here instead.
+
+An upgrade leaves one copy of the plugin, not one per release. These clients
+cache a plugin under its version, and until the previous release that version
+never moved: every install landed in `0.1.6` and overwrote itself, so nothing
+accumulated and nobody looked. Once the version started tracking the package,
+the first upgrade left this behind:
+
+```
+~/.claude/plugins/cache/acc-local/agents-can-communicate/0.1.6
+~/.claude/plugins/cache/acc-local/agents-can-communicate/0.1.9
+~/.claude/plugins/cache/acc-local/agents-can-communicate/0.1.10
+```
+
+Three copies of ACC in a home that should hold one, and a fresh one every time
+you upgrade. `acc uninstall` still cleared all of them, so this was litter rather
+than breakage - but litter ACC put there and told nobody about, which is the
+thing this tool promises not to do to other people's machines.
+
+The tidy is scoped to the plugin's own directory. The marketplace cache root
+above it holds every plugin installed from that marketplace, and removing that
+root once took a plugin the user had installed themselves.
+
+## Unreleased
+
+| | |
+|---|---|
 | Built from | `3ace271` |
 | Tarball | `agents-can-communicate-0.1.9.tgz`, 146 KB, 111 entries |
 | sha256 | `49a0400e6c2db38b3e56ee6258f58a8b4dc9931be813bdb752e9e7b84d1aac57` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `4cd8921` |
+| Tarball | `agents-can-communicate-0.1.9.tgz`, 146 KB, 111 entries |
+| sha256 | `e536270e4150a6a7cdb312c9ecc3cbcd019a206ed9b60c254e085c764cd20b82` |
 | Tests | 943 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not

--- a/packages/adapter-claude-code/src/install.mjs
+++ b/packages/adapter-claude-code/src/install.mjs
@@ -1,11 +1,11 @@
-import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { cp, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { AccError, EXIT } from "@agents-can-communicate/protocol";
 import { fileURLToPath } from "node:url";
 
 import { acccreatedFile, bakeSkillCommand, blankJson, mergeOwnedEntries, ownedEntries,
-  ownVersion, stampPluginVersion,
+  keepOnlyVersion, ownVersion, stampPluginVersion,
   removeIfEmpty,
   removeInstalledTree,
   removeOwnedEntries, writeForeignJson, writeHookShim }
@@ -180,6 +180,11 @@ export async function installClaudePlugin({ configDir, runner, node, now = new D
   // run `claude plugin install`, exactly as the Codex adapter does, because the
   // command's only effect is this copy plus the two registry entries below.
   await layOutPlugin(cached, { runner, node });
+  // One copy, the one just written. A client caches a plugin under its version,
+  // so every upgrade would otherwise leave the previous release's tree beside
+  // this one - invisible while the version never moved, three deep once it did.
+  await keepOnlyVersion({ root: path.dirname(cached), version,
+    io: { readdir, rm } });
 
   await writeClientJson(knownMarketplacesPath(configDir), {
     ...known,

--- a/packages/adapter-codex/src/install.mjs
+++ b/packages/adapter-codex/src/install.mjs
@@ -1,9 +1,9 @@
-import { cp, mkdir, readFile, rm, rmdir, stat, writeFile } from "node:fs/promises";
+import { cp, mkdir, readdir, readFile, rm, rmdir, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { bakeSkillCommand, blankJson, blankText, removeIfEmpty, removeInstalledTree,
-  ownVersion, stampPluginVersion,
+  keepOnlyVersion, ownVersion, stampPluginVersion,
   removeTomlBlock, stripBlock, tomlString,
   writeForeignJson, writeHookShim, writeTomlBlock }
   from "@agents-can-communicate/adapter-sdk";
@@ -210,6 +210,9 @@ export async function installCodexPlugin({ home, agentsHome = home,
   const cached = cachedVersionPath(codexHome, version);
   await rm(cached, { recursive: true, force: true });
   await cp(target, cached, { recursive: true });
+  // One copy, the one just written - and only inside this plugin's own
+  // directory. The marketplace cache root above it holds other people's plugins.
+  await keepOnlyVersion({ root: path.dirname(cached), version, io: { readdir, rm } });
 
   // The plugin's own directory in the cache. Not the versioned one inside it,
   // which goes stale the moment the version changes - and not the marketplace

--- a/packages/adapter-sdk/src/index.mjs
+++ b/packages/adapter-sdk/src/index.mjs
@@ -9,7 +9,7 @@ export { BEGIN, END, removeTomlBlock, renderBlock, stripBlock, tomlString, write
   from "./toml-block.mjs";
 export { projectContext } from "./context-projector.mjs";
 export { shellWriteTargets } from "./shell-writes.mjs";
-export { ownVersion, stampPluginVersion } from "./own-version.mjs";
+export { keepOnlyVersion, ownVersion, stampPluginVersion } from "./own-version.mjs";
 export { editJson, readJson } from "./json-text.mjs";
 export { formatJsonAs, jsonStyleOf, mergeOwnedConfig, mergeOwnedEntries, ownedEntries, ownedKeys,
   acccreatedFile, removeIfEmpty, removeOwnedConfig, removeOwnedEntries, writeForeignJson,

--- a/packages/adapter-sdk/src/own-version.mjs
+++ b/packages/adapter-sdk/src/own-version.mjs
@@ -55,3 +55,27 @@ export async function stampPluginVersion({ file, version, io }) {
   await io.writeFile(file, `${JSON.stringify({ ...manifest, version }, null, 2)}\n`);
   return true;
 }
+
+/**
+ * Leave one copy of a versioned plugin, the one just written.
+ *
+ * These clients cache a plugin under its version. Until the version tracked the
+ * package it never changed, every install landed in the same directory and
+ * overwrote itself, and nothing accumulated. Once it started moving, the first
+ * upgrade left three copies of ACC in a home that should hold one.
+ *
+ * Scoped to the plugin's own directory. The marketplace cache root above it
+ * holds every plugin installed from that marketplace, and removing that root
+ * once took a plugin the user had installed themselves - so a sibling here is
+ * an older ACC, and a sibling one level up is somebody else's.
+ */
+export async function keepOnlyVersion({ root, version, io }) {
+  const entries = await io.readdir(root, { withFileTypes: true }).catch(() => []);
+  const removed = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name === version) continue;
+    await io.rm(path.join(root, entry.name), { recursive: true, force: true });
+    removed.push(entry.name);
+  }
+  return removed;
+}

--- a/tests/process/an-upgrade-leaves-no-old-copy.test.mjs
+++ b/tests/process/an-upgrade-leaves-no-old-copy.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readdir, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { clientContext } from "@agents-can-communicate/cli";
+import { createClaudeCodeAdapter } from "@agents-can-communicate/adapter-claude-code";
+import { createCodexAdapter } from "@agents-can-communicate/adapter-codex";
+
+const repo = fileURLToPath(new URL("../..", import.meta.url));
+
+/**
+ * What an upgrade leaves behind in a client's plugin cache.
+ *
+ * These clients cache a plugin under its version, so ACC's tree lands in a
+ * directory named for the release that wrote it. Until 0.1.9 that name never
+ * changed - every install landed in `0.1.6` and overwrote itself - so nothing
+ * accumulated and nobody looked.
+ *
+ * Then the version started tracking the package, and the first upgrade after it
+ * left this:
+ *
+ *   ~/.claude/plugins/cache/acc-local/agents-can-communicate/0.1.6
+ *   ~/.claude/plugins/cache/acc-local/agents-can-communicate/0.1.9
+ *   ~/.claude/plugins/cache/acc-local/agents-can-communicate/0.1.10
+ *
+ * Three copies of ACC in a home that should hold one. `acc uninstall` still
+ * clears all of them - it removes the whole marketplace cache it created - so
+ * this is litter rather than breakage, but it is litter ACC put there and told
+ * nobody about.
+ */
+async function home(t) {
+  const dir = await realpath(await mkdtemp(path.join(tmpdir(), "acc-upgrade-")));
+  const state = await realpath(await mkdtemp(path.join(tmpdir(), "acc-upgrade-state-")));
+  t.after(() => Promise.all([dir, state]
+    .map(one => rm(one, { recursive: true, force: true }))));
+  return clientContext(dir, state);
+}
+
+const accVersion = async () => JSON.parse(
+  await (await import("node:fs/promises")).readFile(
+    path.join(repo, "package.json"), "utf8")).version;
+
+/** A copy left by an earlier release, exactly as an upgrade would find one. */
+async function olderCopy(root, version) {
+  const dir = path.join(root, version, "hooks");
+  await mkdir(dir, { recursive: true });
+  await writeFile(path.join(dir, "acc-hook.sh"), "#!/bin/sh\n# from an old release\n");
+  return path.join(root, version);
+}
+
+test("installing over an older copy leaves one copy, not two", async t => {
+  const context = await home(t);
+  const version = await accVersion();
+  const root = path.join(context.home, ".claude", "plugins", "cache", "acc-local",
+    "agents-can-communicate");
+  await olderCopy(root, "0.1.6");
+  await olderCopy(root, "0.1.9");
+
+  await createClaudeCodeAdapter().install(context);
+
+  assert.deepEqual(await readdir(root), [version],
+    "an upgrade left the copies the previous releases wrote");
+});
+
+test("codex is left with one copy too", async t => {
+  const context = await home(t);
+  const version = await accVersion();
+  const root = path.join(context.home, ".codex", "plugins", "cache", "acc-local",
+    "agents-can-communicate");
+  await olderCopy(root, "0.1.6");
+
+  await createCodexAdapter().install(context);
+
+  assert.deepEqual(await readdir(root), [version]);
+});
+
+test("only ACC's own plugin is tidied, never a neighbour's", async t => {
+  // The marketplace cache root holds every plugin installed from it. Removing
+  // that root once took a plugin the user had installed themselves - the reason
+  // uninstall is careful about it - and this must not reintroduce that.
+  const context = await home(t);
+  const marketplace = path.join(context.home, ".claude", "plugins", "cache", "acc-local");
+  const theirs = path.join(marketplace, "simplify", "2.0.0");
+  await mkdir(theirs, { recursive: true });
+  await writeFile(path.join(theirs, "plugin.json"), '{"name":"simplify"}\n');
+  await olderCopy(path.join(marketplace, "agents-can-communicate"), "0.1.6");
+
+  await createClaudeCodeAdapter().install(context);
+
+  assert.deepEqual(await readdir(path.join(marketplace, "simplify")), ["2.0.0"],
+    "a neighbour's cached plugin was removed");
+  assert.equal(
+    (await readdir(path.join(marketplace, "agents-can-communicate"))).length, 1);
+});
+
+test("a second install of the same version is still idempotent", async t => {
+  const context = await home(t);
+  const version = await accVersion();
+  const root = path.join(context.home, ".claude", "plugins", "cache", "acc-local",
+    "agents-can-communicate");
+
+  await createClaudeCodeAdapter().install(context);
+  await createClaudeCodeAdapter().install(context);
+
+  assert.deepEqual(await readdir(root), [version]);
+});


### PR DESCRIPTION
Found during the 0.1.10 acceptance run, and caused by the previous release.

These clients cache a plugin under its version. Until #81 that version never moved — every install landed in `0.1.6` and overwrote itself, so nothing accumulated and nobody looked. Once it started tracking the package, the first upgrade left this:

```
~/.claude/plugins/cache/acc-local/agents-can-communicate/0.1.6
~/.claude/plugins/cache/acc-local/agents-can-communicate/0.1.9
~/.claude/plugins/cache/acc-local/agents-can-communicate/0.1.10
```

Three copies of ACC in a home that should hold one, and a fresh one on every upgrade from here on.

`acc uninstall` still cleared all of them — it removes the whole marketplace cache it created — so this is litter rather than breakage. But it is litter ACC put there and told nobody about, which is the one thing this tool promises not to do to somebody else's machine.

## Scope

The tidy is confined to the plugin's own directory. The marketplace cache root above it holds **every** plugin installed from that marketplace, and removing that root once took a plugin the user had installed themselves — a test here plants a neighbour's `simplify/2.0.0` beside ACC's tree and asserts it survives.

## Verified on the packed artifact

```
before: 0.1.10  0.1.6  0.1.9
after:  0.1.9                       ← the version that installed, alone
neighbours in the marketplace cache: untouched
```

That live run also produced an unplanned proof of #79's guard. The first attempt did nothing:

```
skip claude_code: 0.1.10 is already wired here and this is 0.1.9;
                  run the newer acc, or pass --downgrade to wire this one deliberately
```

The fix branch is built from main at 0.1.9 while the machine was wired by the 0.1.10 release candidate — so ACC correctly refused to step backwards, and the check had to be asked for explicitly with `--downgrade`.

## Record

```
PASS  agents-can-communicate-0.1.9.tgz  sha256 e536270e…d20b82  built from 4cd8921
```

146 KB, 111 entries. 943 tests passing, 0 failing · `syntax ok in 198 file(s)`.

Mutation-proved: removing nothing fails 3 of the 4 new tests, and removing the current version along with the old ones fails all 4.
