### PR TITLE
release: 0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ did not here.
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `1c994f7` |
+| Tarball | `agents-can-communicate-0.1.10.tgz`, 146 KB, 111 entries |
+| sha256 | `cbf695c209f9eaa109a1254e09d0095c41a7c51641be2f2fc3dbf6fe94c96b89` |
 | Tests | 943 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,25 @@
 # Changelog
 
-## Unreleased
+## 0.1.10
+
+Two fixes about the same thing seen twice: the version a client caches ACC's
+plugin under. It had been frozen at `0.1.6` for three releases, and unfreezing it
+turned out to leave a copy behind on every upgrade. The second fix was found by
+the first one's acceptance run.
+
+This is also the first two-digit patch, which is the comparison the version guard
+added in 0.1.9 was written for - `0.1.10` sorts before `0.1.9` as a string, and
+did not here.
 
 | | |
 |---|---|
-| Built from | `4cd8921` |
-| Tarball | `agents-can-communicate-0.1.9.tgz`, 146 KB, 111 entries |
-| sha256 | `e536270e4150a6a7cdb312c9ecc3cbcd019a206ed9b60c254e085c764cd20b82` |
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
 | Tests | 943 passing, 0 failing |
-
-Not published. A published record says what the registry serves and is not
-rewritten, so shipped code that changes after a release is measured here instead.
+| Node | 24 (current production LTS) |
+| Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
+| Not supported | Windows — untested rather than known-broken |
 
 An upgrade leaves one copy of the plugin, not one per release. These clients
 cache a plugin under its version, and until the previous release that version

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -102,51 +102,51 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.1.9"
+      "version": "0.1.10"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.1.9"
+      "version": "0.1.10"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.1.9"
+      "version": "0.1.10"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.1.9"
+      "version": "0.1.10"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.1.9"
+      "version": "0.1.10"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.1.9"
+      "version": "0.1.10"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.1.9"
+      "version": "0.1.10"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.1.9"
+      "version": "0.1.10"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.1.9"
+      "version": "0.1.10"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.1.9"
+      "version": "0.1.10"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.1.9"
+      "version": "0.1.10"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.1.9"
+      "version": "0.1.10"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "type": "module",
   "description": "Local-first coordination for independently opened AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.mjs" },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Two fixes about the same thing seen twice: the version a client caches ACC's plugin under. The second was found by the first one's acceptance run.

| | |
|---|---|
| **#81** | **The plugin version is the ACC version.** It was a literal in each manifest, last moved at 0.1.6 — so the package reached 0.1.9 while every client had cached, listed and reported `0.1.6`. That string is how a client decides whether its cached copy is current, so a version that never changes is a bundle it has no reason to replace |
| **#82** | **An upgrade leaves one copy, not one per release.** Unfreezing the version made every upgrade leave the previous release's tree behind — three copies of ACC in a home that should hold one |

## The first two-digit patch

`0.1.10` sorts *before* `0.1.9` as a string. That is the comparison the version guard in 0.1.9 was written for, and this is the first release where it is not hypothetical. On the live machine:

```
acc install --adapter claude_code        (from the 0.1.9 under another Node)
→ skip claude_code: 0.1.10 is already wired here and this is 0.1.9;
                    run the newer acc, or pass --downgrade to wire this one deliberately

  as strings : "0.1.10" < "0.1.9"  → 0.1.10 looks older
  as numbers : [0,1,10] < [0,1,9]  → false, 0.1.10 is newer
```

## Verified on the packed artifact

Starting from a real machine carrying registry 0.1.9 and an extra stale copy planted beside it:

```
before:  acc 0.1.9,  claude cache: 0.1.6  0.1.7

after:   acc                     0.1.10
         claude cache            0.1.10        ← one copy, not four
         codex cache             0.1.10
         installed_plugins.json  0.1.10
         manifest in the cache   0.1.10
         doctor                  store healthy, nothing to report
```

Both fixes in one line each: what the client reports is what is running, and what it keeps is one copy.

## Record

```
PASS  agents-can-communicate-0.1.10.tgz  sha256 cbf695c2…c96b89  built from 1c994f7
```

146 KB, 111 entries. 943 tests passing, 0 failing · `syntax ok in 198 file(s)`.

Eleventh release in a row without a broken bump.
