### PR TITLE
fix: the client's hook trust is not litter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `d462603` |
+| Tarball | `agents-can-communicate-0.1.10.tgz`, 147 KB, 111 entries |
+| sha256 | `968e273d1eb32dcf16014761753d05312273401754e102d99cf8a7ecf67a8417` |
 | Tests | 945 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,65 @@
 # Changelog
 
+## Unreleased
+
+| | |
+|---|---|
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
+| Tests | 945 passing, 0 failing |
+
+Not published. A published record says what the registry serves and is not
+rewritten, so shipped code that changes after a release is measured here instead.
+
+**0.1.9 silently switched off the write guard in Codex, and 0.1.9's own release
+notes state the opposite.** They say: *"Checked before touching them: a hook
+whose recorded hash no longer matches still runs, so this is tidiness rather than
+repair."* The check was real and the conclusion was wrong, because it perturbed
+the record instead of removing it. Absence was never tested, and absence is the
+whole mechanism.
+
+Codex keeps one `[hooks.state."<plugin>:…"]` table per hook, holding a hash it
+has trusted. With no table it runs no hook at all - and says nothing about it. It
+prints `hook: SessionStart Completed` and executes nothing. Proven by replacing
+ACC's hook with a two-line script that only appends its stdin to a file: an empty
+file, beside a `Completed` line.
+
+So after any `acc uninstall` followed by `acc install`, this was the state:
+
+```
+acc doctor         → 4 of 4 adapter(s) installed
+codex plugin list  → installed, enabled, 0.1.10
+the write guard    → off
+```
+
+A shell write walked straight through a `guarded` claim. Silently losing the
+write guard is the worst failure this tool has.
+
+Writing the same hashes back - captured before the deletion, from an ACC three
+releases older - revived the guard immediately. That is also how we know the
+record survives ACC upgrades and is granted once, by a person, for good. Nothing
+ACC writes can put it back, so it is never ACC's to remove. Uninstall leaves it
+alone now.
+
+`acc doctor` says when a client's hooks are not trusted, because every other
+indicator reads healthy while nothing runs:
+
+```
+store healthy; 0 live; protection none; 3 of 4 adapter(s) installed
+  start codex once and accept the hook trust prompt  # its hooks run nothing until then
+```
+
+That line is an *action*, not a diagnostic. The first version of this fix put it
+in `diagnostics`, which `acc doctor` renders only under `--json` - so on the very
+machine it was written for, the text output stayed silent and the guard stayed
+off. Adapters can now name something only a person can do, and it prints where a
+person reads.
+
+The reversal is recorded in [DESIGN_DECISIONS.md](docs/DESIGN_DECISIONS.md) with
+what it cost, along with the generalisation: to learn whether state is
+load-bearing, take it away - changing it tests something else.
+
 ## 0.1.10
 
 Two fixes about the same thing seen twice: the version a client caches ACC's

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -35,6 +35,27 @@ Why ACC is shaped the way it is, and what is deliberately still open.
 | Reporting queued messages as delivered | A delivery state that overstates itself is worse than no state. |
 | Guessing file paths out of shell commands | It would block work at random and still miss real writes. See [CAPABILITIES.md](CAPABILITIES.md). |
 
+**Reversed in 0.1.11: removing the client's hook-trust record on uninstall.** 0.1.9
+took Codex's `[hooks.state."<plugin>:…"]` tables out on uninstall, reasoning that they
+named a plugin that was gone, five per install, cleared by nobody. The check behind that
+reasoning perturbed the record instead of removing it: a hook whose recorded hash no
+longer *matched* was observed still running, and the record was declared inert. Absence
+was never tested.
+
+Absence is the whole mechanism. With no record this client runs no hook at all, prints
+`hook: SessionStart Completed` while executing nothing, and ACC's write guard is silently
+off - with `acc doctor` reporting the adapter installed and `codex plugin list` reporting
+it enabled. Measured on a real machine: a shell write walked through a guarded claim, and
+writing the exact same hashes back - captured before the deletion, from an ACC three
+releases older - revived the guard immediately.
+
+That last detail is the reason it is never ACC's to remove: the record is granted once by
+a person, survives ACC upgrades, and nothing ACC writes can put it back. Tidiness is not
+worth a permission that only a human can re-grant.
+
+**The generalisation, since this cost a release:** to learn whether state is load-bearing,
+take it away. Changing it tests something else.
+
 **Reversed in 0.1.7: reading write positions out of shell commands.** The row above still
 holds against *guessing*, and it is kept rather than deleted because the reasoning behind
 it is what shaped the replacement. What changed is the evidence: a live Codex session was

--- a/packages/adapter-codex/src/adapter.mjs
+++ b/packages/adapter-codex/src/adapter.mjs
@@ -68,8 +68,10 @@ export function createCodexAdapter() {
           "write guards cover apply_patch and the shell writes ACC can read; a model "
             + "without apply_patch edits through the shell, where a redirection or an "
             + "mv is matched and a runtime opening the file is not",
-          "Codex requires hooks to be trusted before they run; an untrusted plugin is "
-            + "installed but inert",
+          // Was a standing sentence here, true and useless: it said the same
+          // thing on a machine whose hooks were trusted, on one whose were not,
+          // and on one with nothing installed. Detection reads the client's own
+          // record now and speaks only when it has something to report.
         ],
       };
     },

--- a/packages/adapter-codex/src/install.mjs
+++ b/packages/adapter-codex/src/install.mjs
@@ -238,33 +238,6 @@ async function removeEmptyDirs(directories) {
   }
 }
 
-/**
- * Drop the client's trust record for hooks that are about to stop existing.
- *
- * Scoped to tables whose key begins with ACC's own `plugin@marketplace:` - a
- * table belonging to any other plugin is the client's business and stays. The
- * file is rewritten only when something was found, so an install that never ran
- * here leaves the config byte for byte as it was.
- */
-export async function removeHookTrust(file, prefix) {
-  const before = await readFile(file, "utf8").catch(() => null);
-  if (before === null || !before.includes(`hooks.state."${prefix}`)) return false;
-
-  const lines = before.split("\n");
-  const kept = [];
-  let dropping = false;
-  for (const line of lines) {
-    const header = /^\s*\[([^\]]*)\]\s*$/.exec(line);
-    if (header !== null) dropping = header[1].startsWith(`hooks.state."${prefix}`);
-    if (dropping) continue;
-    kept.push(line);
-  }
-  // A table's trailing blank line goes with it rather than piling up.
-  const text = kept.join("\n").replace(/\n{3,}/g, "\n\n");
-  if (text === before) return false;
-  await writeFile(file, text, "utf8");
-  return true;
-}
 
 export async function uninstallCodexPlugin({ home, agentsHome = home,
   codexHome = path.join(home, ".codex"), keep = [] }) {
@@ -277,15 +250,18 @@ export async function uninstallCodexPlugin({ home, agentsHome = home,
     await writeMarketplace(file, { ...existing, plugins: kept });
   }
   if (await removeTomlBlock(configPath(codexHome))) changes.push(configPath(codexHome));
-  // This client keeps its own record of which hook files it has trusted, one
-  // table per hook, keyed by the plugin that declared them. ACC never writes
-  // those - they are the client's bookkeeping about ACC - but once the plugin is
-  // gone they name a thing that does not exist, five of them per install, and
-  // nothing else will ever clear them. Verified inert first: a hook whose hash
-  // no longer matches still runs, so this is tidiness rather than repair.
-  if (await removeHookTrust(configPath(codexHome), `${PLUGIN_NAME}@${MARKETPLACE}:`)) {
-    if (!changes.includes(configPath(codexHome))) changes.push(configPath(codexHome));
-  }
+  // The client's `[hooks.state."<plugin>:…"]` tables stay. 0.1.9 removed them as
+  // litter naming a plugin that was gone; that was wrong, and wrong in a way
+  // worth writing down. The check behind it perturbed the record - a hook whose
+  // recorded hash no longer *matched* was seen still running - and concluded the
+  // record was inert. Absence was never tested, and absence is what matters:
+  // with the tables gone this client runs no hook at all, prints
+  // `hook: SessionStart Completed` while executing nothing, and ACC's write
+  // guard is silently off while `acc doctor` reports the adapter installed.
+  //
+  // The record is granted once, by a person, and survives ACC upgrades - hashes
+  // captured under 0.1.6 still admitted 0.1.10's hooks. Nothing ACC writes can
+  // put it back. So it is not ACC's to remove.
   // The marketplace directory is ACC's too, so it goes rather than being left
   // behind empty.
   // A blank TOML config and an absent one are the same to this client, and a
@@ -328,6 +304,13 @@ export async function detectCodex({ home, agentsHome = home,
   const enabled = config.includes(`[plugins."${QUALIFIED}"]`);
   const cached = await stat(cachePath(codexHome))
     .then(() => true).catch(() => false);
+  // The condition that decides whether ACC runs here at all, and the only one
+  // this client will not tell you about: with no trust record it runs no hook,
+  // prints `hook: SessionStart Completed`, and executes nothing. Everything else
+  // - published, registered, enabled, cached - can be true while the write guard
+  // is off. Only asked when something is wired: a warning about hooks that do
+  // not exist is how a real one gets ignored.
+  const untrusted = cached && !config.includes(`hooks.state."${QUALIFIED}:`);
   return { ok: true, changes: [], diagnostics: [
     published ? "acc plugin published in the marketplace" : "acc plugin not registered",
     registered && enabled
@@ -339,7 +322,25 @@ export async function detectCodex({ home, agentsHome = home,
     cached
       ? "plugin installed in the client's cache"
       : `plugin not installed yet; run: codex plugin add ${QUALIFIED}`,
-  ] };
+    // The condition that decides whether ACC runs here at all, and the only one
+    // this client will not tell you about: with no trust record it runs no hook,
+    // prints `hook: SessionStart Completed`, and executes nothing. Everything
+    // else - published, registered, enabled, cached - can be true while the
+    // write guard is off. Said only when there is something to trust, because a
+    // warning on a machine with nothing wired is how a real one gets ignored.
+    ...(untrusted
+      ? ["hooks are not trusted, so this client reports them completed and runs "
+        + "nothing"]
+      : []),
+  ],
+  // Said as an action rather than an observation, because a person has to do it
+  // and no acc command can: the client grants this once, from its own prompt.
+  // A diagnostic alone would have stayed in `--json`, which is where the first
+  // version of this fix put it and where nobody would have read it.
+  needsAction: untrusted
+    ? ["start codex once and accept the hook trust prompt  "
+      + "# its hooks run nothing until then"]
+    : [] };
 }
 
 /**

--- a/packages/adapter-codex/test/hook-trust.test.mjs
+++ b/packages/adapter-codex/test/hook-trust.test.mjs
@@ -4,94 +4,98 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { removeHookTrust } from "../src/install.mjs";
+import { createCodexAdapter } from "../src/adapter.mjs";
 
 /**
- * The record this client keeps about ACC's hooks.
+ * The trust record this client keeps about ACC's hooks.
  *
  * Codex stores one `[hooks.state."plugin@marketplace:file:event:i:j"]` table per
- * hook, holding the hash it trusted. ACC writes none of them - a search of the
- * shipped package finds no occurrence of `hooks.state` - so after `acc
- * uninstall` five tables were left naming a plugin that no longer exists, and
- * five more arrived on the next install.
+ * hook, holding a hash it has trusted. It will not run a hook it has no record
+ * for - and it says nothing about that. It prints `hook: SessionStart Completed`
+ * and executes nothing.
  *
- * Checked before writing this: a hook whose recorded hash no longer matches
- * still runs. Both a control run and a run against a modified file returned
- * normally. So this is tidiness, and it must not reach past ACC's own keys.
+ * 0.1.9 removed these tables on uninstall, calling them litter that named a
+ * plugin no longer there. The reasoning was checked the wrong way: a hook whose
+ * recorded hash no longer *matched* was observed still running, and that was
+ * taken to mean the record was inert. Absence was never tested. Absence is what
+ * matters.
+ *
+ * Measured afterwards, on a real machine: with the tables gone, ACC's write
+ * guard was silently off in Codex while `acc doctor` reported `4 of 4
+ * adapter(s) installed` and `codex plugin list` reported the plugin enabled. A
+ * shell write walked through a guarded claim. Writing the exact same hashes back
+ * - captured before the deletion, from an ACC three versions older - revived the
+ * guard immediately, which is also how we know the record survives ACC upgrades
+ * and is granted once, interactively, for good.
+ *
+ * So it is never ACC's to delete: it is the client's permission for ACC to run
+ * at all, and nothing ACC can write puts it back.
  */
-const PREFIX = "agents-can-communicate@acc-local:";
-
-async function config(t, text) {
-  const home = await mkdtemp(path.join(tmpdir(), "acc-hook-trust-"));
-  t.after(() => rm(home, { recursive: true, force: true }));
-  const file = path.join(home, "config.toml");
-  await writeFile(file, text, "utf8");
-  return file;
-}
-
-const ACC_TABLES = `[hooks.state."agents-can-communicate@acc-local:hooks.json:pre_tool_use:0:0"]
-trusted_hash = "sha256:8d4a13"
+const TRUST = `[hooks.state."agents-can-communicate@acc-local:hooks.json:pre_tool_use:0:0"]
+trusted_hash = "sha256:8d4a13568a8748e93b91e512b415eaf97817fbc138997bd91017bec936e6be14"
 
 [hooks.state."agents-can-communicate@acc-local:hooks.json:session_start:0:0"]
-trusted_hash = "sha256:a17bdb"
+trusted_hash = "sha256:a17bdb450ab476b3f0f03fbf8c0f61ec5d2714fe419b12c9599e8a62dc763571"
 `;
 
-test("the trust record for ACC's own hooks is taken back out", async t => {
-  const file = await config(t, ACC_TABLES);
+async function home(t) {
+  const dir = await mkdtemp(path.join(tmpdir(), "acc-hook-trust-"));
+  const state = await mkdtemp(path.join(tmpdir(), "acc-hook-trust-state-"));
+  t.after(() => Promise.all([dir, state]
+    .map(one => rm(one, { recursive: true, force: true }))));
+  return { home: dir, stateRoot: state };
+}
 
-  assert.equal(await removeHookTrust(file, PREFIX), true);
+const config = context => path.join(context.home, ".codex", "config.toml");
 
-  const after = await readFile(file, "utf8");
-  assert.equal(after.includes("agents-can-communicate"), false);
-  assert.equal(after.trim(), "");
+test("uninstall leaves the client's trust in ACC's hooks alone", async t => {
+  const context = await home(t);
+  const adapter = createCodexAdapter();
+  await adapter.install(context);
+
+  // As the client writes it once a person has accepted the hooks.
+  await writeFile(config(context), `${await readFile(config(context), "utf8")}\n${TRUST}`);
+
+  await adapter.uninstall(context);
+
+  const after = await readFile(config(context), "utf8");
+  assert.match(after, /pre_tool_use/,
+    "the guard's trust was removed; nothing ACC can write puts it back");
+  assert.match(after, /session_start/);
+  assert.match(after, /8d4a13568a8748e93b91e512b415eaf97817fbc138997bd91017bec936e6be14/,
+    "the hash was rewritten rather than left as the client wrote it");
 });
 
-test("another plugin's trust record is not ACC's to remove", async t => {
-  const theirs = `[hooks.state."simplify@local-marketplace:hooks.json:stop:0:0"]
-trusted_hash = "sha256:deadbeef"
-`;
-  const file = await config(t, `${ACC_TABLES}\n${theirs}`);
+test("a reinstall over surviving trust is what makes the guard work again", async t => {
+  // The whole point of leaving it: install, uninstall, install again, and the
+  // hooks still run - no interactive step, because the record never left.
+  const context = await home(t);
+  const adapter = createCodexAdapter();
+  await adapter.install(context);
+  await writeFile(config(context), `${await readFile(config(context), "utf8")}\n${TRUST}`);
 
-  assert.equal(await removeHookTrust(file, PREFIX), true);
+  await adapter.uninstall(context);
+  await adapter.install(context);
 
-  const after = await readFile(file, "utf8");
-  assert.equal(after.includes("agents-can-communicate"), false);
-  assert.match(after, /simplify@local-marketplace/);
-  assert.match(after, /sha256:deadbeef/);
+  const after = await readFile(config(context), "utf8");
+  assert.match(after, /hooks\.state\."agents-can-communicate@acc-local:/);
+  assert.match(after, /\[plugins\."agents-can-communicate@acc-local"\]/,
+    "the plugin registration did not come back");
 });
 
-test("the user's own configuration around it is untouched", async t => {
-  const mine = `model = "gpt-5"
+test("uninstall still removes everything that is ACC's own", async t => {
+  // Leaving the trust record must not turn into leaving the wiring: what ACC
+  // wrote still goes.
+  const context = await home(t);
+  const adapter = createCodexAdapter();
+  await adapter.install(context);
+  await writeFile(config(context), `${await readFile(config(context), "utf8")}\n${TRUST}`);
 
-[sandbox_workspace_write]
-writable_roots = ["/tmp"]
+  await adapter.uninstall(context);
 
-`;
-  const file = await config(t, `${mine}${ACC_TABLES}`);
-
-  await removeHookTrust(file, PREFIX);
-
-  const after = await readFile(file, "utf8");
-  assert.match(after, /model = "gpt-5"/);
-  assert.match(after, /\[sandbox_workspace_write\]/);
-  assert.match(after, /writable_roots = \["\/tmp"\]/);
-});
-
-test("a config with nothing of ACC's in it is not rewritten at all", async t => {
-  const theirs = `model = "gpt-5"
-
-[hooks.state."simplify@local-marketplace:hooks.json:stop:0:0"]
-trusted_hash = "sha256:deadbeef"
-`;
-  const file = await config(t, theirs);
-
-  assert.equal(await removeHookTrust(file, PREFIX), false);
-  assert.equal(await readFile(file, "utf8"), theirs);
-});
-
-test("a config that is not there is not an error", async t => {
-  const file = await config(t, "");
-  await rm(file);
-
-  assert.equal(await removeHookTrust(file, PREFIX), false);
+  const after = await readFile(config(context), "utf8");
+  assert.equal(after.includes('[plugins."agents-can-communicate@acc-local"]'), false,
+    "ACC's own plugin registration survived the uninstall");
+  assert.equal(after.includes("sandbox_workspace_write"), false,
+    "ACC's own sandbox table survived the uninstall");
 });

--- a/packages/adapter-codex/test/untrusted-is-inert.test.mjs
+++ b/packages/adapter-codex/test/untrusted-is-inert.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { createCodexAdapter } from "../src/adapter.mjs";
+
+/**
+ * Installed, enabled, and running nothing.
+ *
+ * This client will not run a hook it has no trust record for, and it does not
+ * say so. It prints `hook: SessionStart Completed` and executes nothing - proven
+ * by replacing ACC's hook with a two-line script that only appends its stdin to
+ * a file, and getting an empty file alongside a `Completed` line.
+ *
+ * Every other indicator says the opposite. On the machine where this was found:
+ *
+ *   acc doctor         → 4 of 4 adapter(s) installed
+ *   codex plugin list  → installed, enabled, 0.1.10
+ *   the write guard    → off
+ *
+ * Silently losing the write guard is the worst failure this tool has, so the one
+ * condition that decides whether ACC runs here at all is worth reading before
+ * reporting the client healthy.
+ */
+async function home(t) {
+  const dir = await mkdtemp(path.join(tmpdir(), "acc-inert-"));
+  const state = await mkdtemp(path.join(tmpdir(), "acc-inert-state-"));
+  t.after(() => Promise.all([dir, state]
+    .map(one => rm(one, { recursive: true, force: true }))));
+  return { home: dir, stateRoot: state };
+}
+
+const TRUSTED = `
+[hooks.state."agents-can-communicate@acc-local:hooks.json:pre_tool_use:0:0"]
+trusted_hash = "sha256:8d4a13568a8748e93b91e512b415eaf97817fbc138997bd91017bec936e6be14"
+`;
+
+const diagnosticsOf = async context =>
+  (await createCodexAdapter().doctor(context)).diagnostics;
+
+const actionsOf = async context =>
+  (await createCodexAdapter().detect(context)).needsAction ?? [];
+
+test("an installed plugin with no trust record is reported as inert", async t => {
+  const context = await home(t);
+  await createCodexAdapter().install(context);
+
+  const said = await diagnosticsOf(context);
+
+  assert.equal(said.some(line => /not trusted|inert/i.test(line)), true,
+    `nothing said the hooks will not run: ${JSON.stringify(said, null, 2)}`);
+  // The state is described here; what to do about it is an action, and the test
+  // below checks it separately - because only a person can carry it out.
+});
+
+test("once the client has trusted them, the warning goes away", async t => {
+  const context = await home(t);
+  await createCodexAdapter().install(context);
+  const file = path.join(context.home, ".codex", "config.toml");
+  await writeFile(file, (await readFile(file, "utf8")) + TRUSTED);
+
+  const said = await diagnosticsOf(context);
+
+  assert.equal(said.some(line => /not trusted|inert/i.test(line)), false,
+    `a healthy install was told its hooks will not run: ${JSON.stringify(said, null, 2)}`);
+});
+
+test("the thing a person must do is said where a person reads it", async t => {
+  // The first version of this fix put it in `diagnostics`, which `acc doctor`
+  // renders only under --json. On the machine it was written for, the text
+  // output stayed silent and the guard stayed off.
+  const context = await home(t);
+  await createCodexAdapter().install(context);
+
+  const actions = await actionsOf(context);
+
+  assert.equal(actions.length, 1, `no action was asked for: ${JSON.stringify(actions)}`);
+  assert.match(actions[0], /codex/);
+  assert.match(actions[0], /trust/i);
+});
+
+test("a client with no ACC installed at all is not nagged about trust", async t => {
+  // Nothing is wired, so there is nothing to trust. "Your hooks are untrusted"
+  // about hooks that do not exist is noise, and noise is how a real diagnosis
+  // gets ignored.
+  const context = await home(t);
+
+  const said = await diagnosticsOf(context);
+
+  assert.equal(said.some(line => /not trusted|inert/i.test(line)), false,
+    `an empty machine was warned about trust: ${JSON.stringify(said, null, 2)}`);
+});

--- a/packages/cli/src/doctor-command.mjs
+++ b/packages/cli/src/doctor-command.mjs
@@ -130,6 +130,9 @@ async function diagnoseAdapters({ options, runtime }) {
     if (owned.missing.length > 0) {
       remediation.push(`acc install --adapter ${entry.adapterId}  # files are missing`);
     }
+    // An adapter can name something only a person can do - the client's own
+    // trust prompt, most of all. It goes where a person reads, not into --json.
+    remediation.push(...(entry.needsAction ?? []));
     const installed = record.installs.find(one => one.adapterId === entry.adapterId);
     const stale = staleInstall({ recorded: installed?.accVersion ?? null, running });
     if (stale !== null) {

--- a/packages/installer/src/detect.mjs
+++ b/packages/installer/src/detect.mjs
@@ -44,7 +44,8 @@ export async function detectInstallation({ adapters, context, probe = spawnProbe
     .map(async adapter => {
       const entry = { adapterId: adapter.id, displayName: adapter.displayName,
         present: false, version: null, versionOutput: null, installed: false,
-        diagnostics: [], capabilities: adapter.capabilities ?? {}, error: null };
+        diagnostics: [], needsAction: [], capabilities: adapter.capabilities ?? {},
+        error: null };
 
       try {
         const output = await withTimeout(
@@ -65,6 +66,9 @@ export async function detectInstallation({ adapters, context, probe = spawnProbe
       try {
         const detected = await adapter.detect(context);
         entry.diagnostics = detected.diagnostics ?? [];
+        // What a person has to do, as opposed to what is true. Adapters that
+        // have nothing to ask for say nothing.
+        entry.needsAction = detected.needsAction ?? [];
         // "Installed" is the adapter's own answer, phrased in its own terms.
         // The installer does not second-guess it by looking at files it does
         // not understand.


### PR DESCRIPTION
**0.1.9 silently switched off the write guard in Codex, and 0.1.9's release notes claim the opposite.** They say:

> Checked before touching them: a hook whose recorded hash no longer matches still runs, so this is tidiness rather than repair.

The check was real. The conclusion was wrong, because it **perturbed** the record instead of **removing** it. Absence was never tested — and absence is the whole mechanism.

## What absence does

Codex keeps one `[hooks.state."<plugin>:…"]` table per hook, holding a hash it has trusted. With no table it runs no hook at all, and says nothing about it: it prints `hook: SessionStart Completed` and executes nothing.

Proven by replacing ACC's hook with a two-line script that only appends its stdin to a file — an empty file, beside a `Completed` line.

So after any `acc uninstall` → `acc install`:

```
acc doctor         → 4 of 4 adapter(s) installed
codex plugin list  → installed, enabled, 0.1.10
codex output       → hook: SessionStart Completed
the write guard    → off
```

A shell write walked straight through a `guarded` claim. Silently losing the write guard is the worst failure this tool has.

## How we know it is the sole cause

Three explanations were live: the client's own 0.147 → 0.150 upgrade, a hash bound to content ACC rewrites on every install, or the deletion. Writing back the **exact hashes captured before the deletion**, from an ACC three releases older, revived the guard immediately:

```
Command blocked by PreToolUse hook: file:src/parser.mjs is claimed by alice
файл змінено: 0
```

That kills both alternatives at once — the record is not version-bound and the client upgrade did not invalidate it — and it establishes the property that makes this a rule rather than a patch: **trust is granted once, by a person, survives ACC upgrades, and nothing ACC writes can put it back.** So it is never ACC's to remove.

## The other half: it has to be visible

`acc doctor` now says when hooks are untrusted, because every other indicator reads healthy while nothing runs:

```
store healthy; 0 live; protection none; 3 of 4 adapter(s) installed
  start codex once and accept the hook trust prompt  # its hooks run nothing until then
```

That line is an **action**, not a diagnostic. The first version of this fix put it in `diagnostics` — which `acc doctor` renders only under `--json` — so on the very machine it was written for, the text output stayed silent and the guard stayed off. Adapters can now return `needsAction`: things only a person can carry out, printed where a person reads.

It is said only when something is wired. A warning about hooks that do not exist is how a real one gets ignored.

## Verified live, on the machine this broke

```
uninstall → install:  trust records 5 → 5 → 5   (before this fix: 5 → 0)
then, no flags:       Command blocked by PreToolUse hook: … claimed by alice2
                      hook: PreToolUse Blocked      файл змінено: 0

trust removed:        doctor prints the action line
trust restored:       doctor goes quiet
```

## Record

```
PASS  agents-can-communicate-0.1.10.tgz  sha256 968e273d…7a8417  built from d462603
```

147 KB, 112 entries. 945 tests passing, 0 failing · `syntax ok in 199 file(s)`.

Mutation-proved: restoring the deletion fails all 3 uninstall tests; silencing the diagnosis fails 1; making it unconditional fails 2.

The reversal is recorded in [DESIGN_DECISIONS.md](docs/DESIGN_DECISIONS.md) beside the reasoning it overturns, with the generalisation this cost a release to learn: **to find out whether state is load-bearing, take it away — changing it tests something else.**
