### PR TITLE
release: 0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,21 @@
 # Changelog
 
-## Unreleased
+## 0.1.11
+
+A repair, and it is worth publishing on its own. Since 0.1.9, any `acc uninstall`
+followed by `acc install` left the write guard switched off in Codex while every
+indicator - `acc doctor`, `codex plugin list`, the client's own output - reported
+health. Anyone who ran that pair is unprotected there until they upgrade.
 
 | | |
 |---|---|
-| Built from | `d462603` |
-| Tarball | `agents-can-communicate-0.1.10.tgz`, 147 KB, 111 entries |
-| sha256 | `968e273d1eb32dcf16014761753d05312273401754e102d99cf8a7ecf67a8417` |
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
 | Tests | 945 passing, 0 failing |
-
-Not published. A published record says what the registry serves and is not
-rewritten, so shipped code that changes after a release is measured here instead.
+| Node | 24 (current production LTS) |
+| Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
+| Not supported | Windows — untested rather than known-broken |
 
 **0.1.9 silently switched off the write guard in Codex, and 0.1.9's own release
 notes state the opposite.** They say: *"Checked before touching them: a hook

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ health. Anyone who ran that pair is unprotected there until they upgrade.
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `bdd78a2` |
+| Tarball | `agents-can-communicate-0.1.11.tgz`, 147 KB, 111 entries |
+| sha256 | `0eec8874230233671aad83313b5f4030bc67a6b915ea0140d1e912ef4ac7d0ac` |
 | Tests | 945 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -102,51 +102,51 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.1.10"
+      "version": "0.1.11"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.1.10"
+      "version": "0.1.11"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.1.10"
+      "version": "0.1.11"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.1.10"
+      "version": "0.1.11"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.1.10"
+      "version": "0.1.11"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.1.10"
+      "version": "0.1.11"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.1.10"
+      "version": "0.1.11"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.1.10"
+      "version": "0.1.11"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.1.10"
+      "version": "0.1.11"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.1.10"
+      "version": "0.1.11"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.1.10"
+      "version": "0.1.11"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.1.10"
+      "version": "0.1.11"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "type": "module",
   "description": "Local-first coordination for independently opened AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.mjs" },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
A repair, and it is worth publishing on its own.

Since 0.1.9, any `acc uninstall` followed by `acc install` left the write guard **switched off in Codex** while every indicator reported health. Anyone who has run that pair is unprotected there until they upgrade.

| | |
|---|---|
| **#84** | **The client's hook trust is not litter.** 0.1.9 removed Codex's `[hooks.state."<plugin>:…"]` tables on uninstall. With no table the client runs no hook at all — it prints `hook: SessionStart Completed` and executes nothing |
| #84 | `acc doctor` says when hooks are untrusted, as an action a person can carry out, printed where a person reads |

## What 0.1.9 got wrong, exactly

Its release notes say:

> Checked before touching them: a hook whose recorded hash no longer matches still runs, so this is tidiness rather than repair.

The check was real; the conclusion was not. It **perturbed** the record instead of **removing** it. Absence was never tested, and absence is the whole mechanism.

Three explanations were live — the client's own 0.147 → 0.150 upgrade, a hash bound to content ACC rewrites on every install, or the deletion. Writing back the exact hashes captured *before* the deletion, from an ACC three releases older, revived the guard immediately. That kills both alternatives and establishes the property: trust is granted once by a person, survives ACC upgrades, and nothing ACC writes can put it back.

## Verified on the packed artifact, by reproducing the breaking cycle

```
1. uninstall → install (the pair that used to disarm it):
     trust records  5 → 5 → 5        (before: 5 → 0)

2. a live Codex session, no flags, guarded claim held by a peer:
     Command blocked by PreToolUse hook: file:src/parser.mjs is claimed by alice2
     hook: PreToolUse Blocked
     файл змінено: 0

3. trust removed by hand — what a person now sees:
     start codex once and accept the hook trust prompt  # its hooks run nothing until then

4. trust restored: doctor says nothing about it
```

Step 3 and 4 together are the point: it speaks when something is wrong and is quiet when it is not. A warning that is always on is how a real one gets ignored.

## Also in this record

The reversal is written into [DESIGN_DECISIONS.md](docs/DESIGN_DECISIONS.md) beside the reasoning it overturns, and the changelog quotes 0.1.9's false claim rather than quietly replacing it — with the generalisation this cost a release to learn:

> To find out whether state is load-bearing, take it away. Changing it tests something else.

## Record

```
PASS  agents-can-communicate-0.1.11.tgz  sha256 0eec8874…c7d0ac  built from bdd78a2
```

147 KB, 111 entries. 945 tests passing, 0 failing · `syntax ok in 199 file(s)`.

Twelfth release in a row without a broken bump.
