### PR TITLE
fix: an install that wired nothing says what still works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `5b2e66f` |
+| Tarball | `agents-can-communicate-0.1.11.tgz`, 147 KB, 111 entries |
+| sha256 | `b3b35a86bfc62a48ba054b0fff780299454a94ff7d5a31ed8824630817c6b2e7` |
 | Tests | 949 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## Unreleased
+
+| | |
+|---|---|
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
+| Tests | 949 passing, 0 failing |
+
+Not published. A published record says what the registry serves and is not
+rewritten, so shipped code that changes after a release is measured here instead.
+
+An install that wired nothing says what still works. Every end-to-end run until
+now was done on a machine carrying all four clients, so the machine that carries
+one - or none - had never been looked at. On that machine `acc install` said:
+
+```
+installed 0 adapter(s)
+  skip claude_code: Claude Code is not installed on this machine; …
+  skip codex: Codex CLI is not installed on this machine; …
+  skip gemini_cli: …
+  skip kimi: …
+```
+
+Every line true, and together they read as "ACC has nothing for you". They are
+wrong about that: the MCP server needs no adapter at all. Measured on exactly
+such a machine - no client binary on PATH, a fresh home - `acc-mcp` answered
+`tools/list` with ten tools and `acc_work` wrote an intent into the store.
+
+Both `acc install` and `acc doctor` now name that path, and only when nothing was
+wired. The skips already carry their own remedy, `0 of 4 adapter(s) installed`
+would otherwise read as a broken machine on every run an MCP-only user makes, and
+a line printed every time is a line that stops being read. An uninstall that
+removed nothing stays quiet: same zero, opposite meaning.
+
 ## 0.1.11
 
 A repair, and it is worth publishing on its own. Since 0.1.9, any `acc uninstall`

--- a/packages/cli/src/doctor-command.mjs
+++ b/packages/cli/src/doctor-command.mjs
@@ -210,6 +210,13 @@ export async function runDoctor({ options, context, runtime }) {
   // the store was healthy and nothing else.
   const text = [`store healthy; ${describePresence(status.counts)}; `
     + `protection ${status.protection}; ${installed} of ${adapters.length} adapter(s) installed`,
-  ...data.remediation.map(line => `  ${line}`)].join("\n");
+  ...data.remediation.map(line => `  ${line}`),
+  // `0 of 4` is a true line that reads as a broken machine, and on an
+  // MCP-only one it would read that way on every run forever. The server needs
+  // no adapter: measured answering `tools/list` and writing an intent on a
+  // machine with no client binaries on PATH at all.
+  ...(installed === 0
+    ? ["  no client is wired; any MCP client can still take part through acc-mcp"]
+    : [])].join("\n");
   return { data, text };
 }

--- a/packages/cli/src/install-command.mjs
+++ b/packages/cli/src/install-command.mjs
@@ -125,6 +125,16 @@ export function describeOutcome({ action, acted, failed = [], skipped = [],
   // Said once, where it is needed: the reader has just been shown a list of
   // their own files with ACC's name in them.
   ...(action === "install" && acted > 0 ? ["", "undo with: acc uninstall"] : []),
+  // And said once where it is needed differently: an install that wired nothing
+  // has just told this reader four times that their machine is not supported.
+  // It is not - the MCP server needs no adapter, and was measured answering on a
+  // machine with no client binaries at all. Only when nothing was wired: the
+  // skips already carry their own remedy, and a line printed every time is a
+  // line that stops being read.
+  ...(action === "install" && acted === 0
+    ? ["", "no client was wired, but any MCP client can still take part: "
+      + "point it at the acc-mcp command"]
+    : []),
   ].join("\n");
 }
 

--- a/packages/cli/test/nothing-wired-is-not-nothing.test.mjs
+++ b/packages/cli/test/nothing-wired-is-not-nothing.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { describeOutcome } from "../src/install-command.mjs";
+
+/**
+ * A machine none of the four adapters fit.
+ *
+ * Every end-to-end run so far was done on a machine carrying all four clients,
+ * so this case was never seen. On a machine with only one - or none - `acc
+ * install` says:
+ *
+ *   installed 0 adapter(s)
+ *     skip claude_code: Claude Code is not installed on this machine; …
+ *     skip codex: Codex CLI is not installed on this machine; …
+ *     skip gemini_cli: …
+ *     skip kimi: …
+ *
+ * and exits 0. Every line of that is true, and together they read as "ACC has
+ * nothing for you". They are wrong about that: the MCP server needs no adapter
+ * at all. Measured on exactly such a machine - no client binaries on PATH, a
+ * fresh home - `acc-mcp` answered `tools/list` with ten tools and `acc_work`
+ * wrote an intent into the store.
+ *
+ * So the one time it is worth naming is when nothing was wired: a reader who has
+ * just been told four times that their machine is not supported.
+ */
+const skip = id => ({ adapterId: id, reason: `${id} is not installed on this machine` });
+
+test("when nothing was wired, the reader is told what still works", () => {
+  const text = describeOutcome({ action: "install", acted: 0,
+    skipped: ["claude_code", "codex", "gemini_cli", "kimi"].map(skip) });
+
+  assert.match(text, /installed 0 adapter\(s\)/);
+  assert.match(text, /acc-mcp/,
+    `nothing pointed at the path that needs no adapter:\n${text}`);
+});
+
+test("wiring even one client makes that advice noise", () => {
+  // The skips already name their own remedy. A reader who got an adapter
+  // installed is not stuck, and a line that appears every time is a line that
+  // stops being read.
+  const text = describeOutcome({ action: "install", acted: 1,
+    operations: [{ adapterId: "codex", applied: true, changes: [], removed: [] }],
+    skipped: ["claude_code", "gemini_cli", "kimi"].map(skip) });
+
+  assert.doesNotMatch(text, /acc-mcp/);
+});
+
+test("an uninstall that removed nothing is not an invitation", () => {
+  // Same zero, opposite meaning: this reader is leaving, not arriving.
+  const text = describeOutcome({ action: "uninstall", acted: 0,
+    skipped: ["claude_code", "codex"].map(skip) });
+
+  assert.doesNotMatch(text, /acc-mcp/);
+});
+
+test("the skips are still all there, and still say their own remedy", () => {
+  const text = describeOutcome({ action: "install", acted: 0,
+    skipped: ["claude_code", "codex", "gemini_cli", "kimi"].map(skip) });
+
+  for (const id of ["claude_code", "codex", "gemini_cli", "kimi"]) {
+    assert.match(text, new RegExp(`skip ${id}:`));
+  }
+});


### PR DESCRIPTION
Asked directly: *did you account for a machine that has only some of these — say only Codex, or none?*

No. Every end-to-end run so far was done on a machine carrying all four clients. So I built two isolated machines and looked.

## What a sparse machine gets

**Only Codex** — correct throughout. One adapter wired, three skipped with their own remedy, everything written into the given home, `1 of 4 adapter(s) installed`, uninstall leaves zero files. The trust line from 0.1.11 appears exactly where a first-time user needs it:

```
store healthy; 0 live; protection none; 1 of 4 adapter(s) installed
  start codex once and accept the hook trust prompt  # its hooks run nothing until then
```

**No clients at all** — this is the gap:

```
installed 0 adapter(s)
  skip claude_code: Claude Code is not installed on this machine; …
  skip codex: Codex CLI is not installed on this machine; …
  skip gemini_cli: …
  skip kimi: …
```

Every line is true, and together they read as *ACC has nothing for you*. They are wrong about that. The MCP server needs no adapter, and on that same machine — no client binary on PATH, a fresh home — it answered:

```
tools/list → 10 tools
acc_work   → {"schemaVersion":1,"sessionId":"session_G-2eg5T19042BFAeI5_mdA",…}
```

So a user whose editor speaks MCP and nothing else was being told, four times, that their machine is unsupported — while the path built for them worked.

## The fix, and where it stays quiet

```
installed 0 adapter(s)
  skip …  ×4

no client was wired, but any MCP client can still take part: point it at the acc-mcp command
```

```
store healthy; 0 live; protection none; 0 of 4 adapter(s) installed
  no client is wired; any MCP client can still take part through acc-mcp
```

Only when nothing was wired:

- **One client wired → nothing extra.** The skips already carry their own remedy; that reader is not stuck.
- **`acc uninstall` that removed nothing → nothing extra.** Same zero, opposite meaning: this reader is leaving, not arriving.
- **`0 of 4` in doctor** would otherwise read as a broken machine on every single run an MCP-only user ever makes.

A line printed every time is a line that stops being read.

## Record

```
PASS  agents-can-communicate-0.1.11.tgz  sha256 b3b35a86…c6b2e7  built from 5b2e66f
```

147 KB, 112 entries. 949 tests passing, 0 failing · `syntax ok in 200 file(s)`.

Verified live on both simulated machines — isolated `--home` and a PATH carrying only the clients each scenario is meant to have, so nothing on the real machine was touched.
