### PR TITLE
fix: doctor runs on the store it exists to diagnose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `491b41b` |
+| Tarball | `agents-can-communicate-0.1.11.tgz`, 148 KB, 111 entries |
+| sha256 | `178782d6553b7bb40d931a394c31f71581142ff7f443d1b19f1666c75a2d0cc6` |
 | Tests | 953 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,54 @@
 
 | | |
 |---|---|
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
+| Tests | 953 passing, 0 failing |
+
+Not published. A published record says what the registry serves and is not
+rewritten, so shipped code that changes after a release is measured here instead.
+
+`acc doctor` runs on the store it exists to diagnose. This was fixed once
+already, and the throw moved rather than went away. The first time, `collectStatus`
+read every record before the diagnosis and died on a truncated file, so the
+command answered `invalid JSON record` while the inspection had already found the
+file and put it in a list nobody saw. `runDoctor` was taught to check the report
+first.
+
+But every command outside a short list opens the store before its handler is
+called, and `doctor` was not on that list. So the diagnosis still died - one
+frame earlier, in the setup, before any of the code written to report it ran:
+
+```
+$ acc doctor --cwd <project>
+invalid JSON record: …/workspaces/workspace_662a…/protocol.json
+```
+
+One line, no framing, no list, no remedy. `--repair` did the same, instead of
+saying that repair is blocked - which is exactly what it is designed to say, and
+for a good reason it already carries: *completing a journal on top of state we
+cannot even read would turn an ambiguous store into a confidently wrong one.*
+
+Locating a workspace and opening it are separate now. `doctor` gets a context
+that knows where the store is and opens it on request, after the report has said
+that reading is safe:
+
+```
+store state is ambiguous; repair is blocked. 1 unreadable:
+  …/workspaces/workspace_02407733…/protocol.json
+```
+
+Splitting them exposed a case the old order had been hiding: opening the store
+created it, so the inspection never met a store that does not exist yet. Reading
+the report first, "no protocol.json" looked exactly like "unreadable
+protocol.json", and a person's first `acc doctor` in a new project would have
+been told their store was broken. Absent and unreadable are now different things.
+
+## Unreleased
+
+| | |
+|---|---|
 | Built from | `5b2e66f` |
 | Tarball | `agents-can-communicate-0.1.11.tgz`, 147 KB, 111 entries |
 | sha256 | `b3b35a86bfc62a48ba054b0fff780299454a94ff7d5a31ed8824630817c6b2e7` |

--- a/packages/cli/src/doctor-command.mjs
+++ b/packages/cli/src/doctor-command.mjs
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 
@@ -156,9 +156,21 @@ async function diagnoseAdapters({ options, runtime }) {
 
 export async function runDoctor({ options, context, runtime }) {
   const root = context.paths.root;
-  const report = options.repair === true
-    ? await repairFilesystemStore({ root, clock: context.service.clock })
-    : await diagnoseFilesystemStore({ root });
+  // The clock comes from the context rather than through the service, because
+  // the service is what may not open: this command runs before anything reads a
+  // record, which is the whole point of it.
+  const clock = context.clock ?? context.service?.clock;
+  // A store that is not there yet is not an ambiguous one. Opening the workspace
+  // used to happen first and created it, so the inspection never saw this case;
+  // now that the diagnosis runs first, "no protocol.json" would read as
+  // "unreadable protocol.json" and a person's first `acc doctor` in a new
+  // project would answer that their store is broken.
+  const started = await stat(path.join(root, "protocol.json")).then(() => true, () => false);
+  const report = !started
+    ? { healthy: true, blocked: [], corrupt: [], repaired: [] }
+    : options.repair === true
+      ? await repairFilesystemStore({ root, clock })
+      : await diagnoseFilesystemStore({ root });
   const adapters = await diagnoseAdapters({ options, runtime });
   const { data: dataHome } = platformPaths({ platform: runtime?.platform,
     env: runtime?.env ?? {} });
@@ -166,7 +178,7 @@ export async function runDoctor({ options, context, runtime }) {
     ? await runtime.version().catch(() => null)
     : null;
   const update = await noticeUpdate({ dataHome, running, env: runtime?.env ?? {},
-    now: Date.parse(context.service.clock.now()), get: runtime?.fetch,
+    now: Date.parse(clock.now()), get: runtime?.fetch,
     io: { readFile, writeFile, mkdir } });
 
   // Before the store is read for anything else. `collectStatus` reads every
@@ -185,7 +197,11 @@ export async function runDoctor({ options, context, runtime }) {
         remediation: ["inspect blocked and corrupt paths before repairing"] });
   }
 
-  const status = await context.service.collectStatus({});
+  // Only now, and only because the report said the records can be read. A
+  // context built for this command opens the store on request rather than up
+  // front.
+  const service = context.service ?? await context.openService();
+  const status = await service.collectStatus({});
 
   const data = {
     workspaceId: context.descriptor.id,

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -54,7 +54,14 @@ async function claimOn(options, context) {
   return mine[0].claimId;
 }
 
-async function openContext(options, runtime) {
+/**
+ * Where this workspace's state lives, without reading a byte of it.
+ *
+ * Split out because `doctor` is the command a person runs when the store cannot
+ * be read, and it has to know which store to look at before deciding whether
+ * looking is safe.
+ */
+async function locateContext(options, runtime) {
   const descriptor = await discoverWorkspace({
     cwd: options.cwd ?? runtime.cwd,
     env: runtime.env,
@@ -67,10 +74,35 @@ async function openContext(options, runtime) {
     workspaceId: descriptor.id,
     workspaceRoots: descriptor.roots,
   });
+  return { descriptor, paths };
+}
+
+async function withService({ descriptor, paths }, runtime) {
   const store = await openFilesystemStore({ root: paths.root, clock: runtime.clock,
     ids: runtime.ids, workspaceId: descriptor.id });
   return { descriptor, paths,
     service: createCoordinationService({ store, clock: runtime.clock, ids: runtime.ids }) };
+}
+
+async function openContext(options, runtime) {
+  return withService(await locateContext(options, runtime), runtime);
+}
+
+/**
+ * A context for the one command that has to survive an unopenable store.
+ *
+ * `runDoctor` already refused to read records before diagnosing them - fixed
+ * after a truncated file made it answer "invalid JSON record" while the
+ * inspection had already found the file and put it in a list nobody saw. The
+ * throw then moved earlier: opening the store happens before any handler runs,
+ * so one unreadable `protocol.json` killed the diagnosis a frame before the code
+ * written to report it. Here the store is opened on request, after the report
+ * has said that reading is safe.
+ */
+async function openDiagnosticContext(options, runtime) {
+  const located = await locateContext(options, runtime);
+  return { ...located, clock: runtime.clock,
+    openService: async () => (await withService(located, runtime)).service };
 }
 
 const human = value => (typeof value === "string" ? value : JSON.stringify(value, null, 2));
@@ -368,7 +400,9 @@ export async function main(argv, runtime) {
     // and `help` has to answer in a directory that is no workspace at all.
     const context = NO_WORKSPACE.includes(parsed.command)
       ? null
-      : await openContext(parsed.options, runtime);
+      : parsed.command === "doctor"
+        ? await openDiagnosticContext(parsed.options, runtime)
+        : await openContext(parsed.options, runtime);
     // Which session is calling is answered once, here, rather than by each
     // handler: every one of them needs the same pair, and a handler that forgot
     // to ask would be an operation an agent cannot reach.

--- a/packages/cli/test/doctor-runs-on-a-broken-store.test.mjs
+++ b/packages/cli/test/doctor-runs-on-a-broken-store.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readdir, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { EXIT } from "@agents-can-communicate/protocol";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const binary = path.join(repoRoot, "bin", "acc.mjs");
+
+/**
+ * The command you run when the store is broken has to run on a broken store.
+ *
+ * `runDoctor` already refuses to read records before it has diagnosed them -
+ * that was fixed once, after a truncated file made `acc doctor` answer "invalid
+ * JSON record" while `inspect` had already found it. But the throw moved rather
+ * than went away: every command outside a small list opens the store before its
+ * handler is called, and `doctor` was not on that list. So one unreadable
+ * `protocol.json` and the diagnosis died in the setup, one stack frame before
+ * the code written to report it.
+ *
+ * Measured: `acc doctor --cwd <broken>` exited 4 with a bare
+ * `invalid JSON record: <path>` and nothing else - no list, no framing, no
+ * remedy - and `--repair` did the same instead of reporting that repair is
+ * blocked, which is what it is designed to say.
+ */
+async function brokenStore(t) {
+  const home = await realpath(await mkdtemp(path.join(tmpdir(), "acc-broken-home-")));
+  const dataHome = await realpath(await mkdtemp(path.join(tmpdir(), "acc-broken-data-")));
+  const project = await realpath(await mkdtemp(path.join(tmpdir(), "acc-broken-proj-")));
+  t.after(() => Promise.all([home, dataHome, project]
+    .map(dir => rm(dir, { recursive: true, force: true }))));
+
+  const run = (...argv) => execFileAsync(process.execPath, [binary, ...argv],
+    { cwd: home, env: { ...process.env, HOME: home, ACC_DATA_HOME: dataHome } })
+    .then(({ stdout }) => ({ code: 0, stdout }),
+      error => ({ code: error.code, stdout: error.stdout ?? "", stderr: error.stderr ?? "" }));
+
+  // A workspace, made the way one is made: by asking about it.
+  await run("status", "--cwd", project);
+  const workspaces = path.join(dataHome, "acc", "workspaces");
+  const [id] = await readdir(workspaces);
+  const header = path.join(workspaces, id, "protocol.json");
+  await writeFile(header, "this is not json\n");
+  return { run, project, header };
+}
+
+test("doctor diagnoses a store it cannot open", async t => {
+  const { run, project, header } = await brokenStore(t);
+
+  const result = await run("doctor", "--cwd", project);
+
+  assert.equal(result.code, EXIT.DATA);
+  const said = `${result.stdout}${result.stderr ?? ""}`;
+  assert.match(said, new RegExp(header.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+    `the unreadable file was not named:\n${said}`);
+  // The framing is what makes it actionable: this is not "acc is broken", it is
+  // "your store cannot be read and repair will not guess".
+  assert.match(said, /ambiguous|unreadable/i,
+    `no framing beyond the raw parse error:\n${said}`);
+});
+
+test("--repair says it is blocked rather than failing the same way", async t => {
+  const { run, project } = await brokenStore(t);
+
+  const result = await run("doctor", "--repair", "--cwd", project);
+  const said = `${result.stdout}${result.stderr ?? ""}`;
+
+  assert.equal(result.code, EXIT.DATA);
+  assert.match(said, /repair is blocked/i,
+    `repair failed without saying it refused on purpose:\n${said}`);
+});
+
+test("machine mode carries the diagnosis, not just the failure", async t => {
+  const { run, project, header } = await brokenStore(t);
+
+  const result = await run("doctor", "--cwd", project, "--json");
+  const body = JSON.parse(result.stdout);
+
+  assert.equal(body.ok, false);
+  assert.equal(body.error.code, EXIT.DATA);
+  assert.equal(JSON.stringify(body.error.details).includes(header), true,
+    `the details name no file: ${JSON.stringify(body.error.details)}`);
+});
+
+test("a healthy store is still diagnosed the same way", async t => {
+  // The fix must not turn doctor into a command that only reports disasters.
+  const home = await realpath(await mkdtemp(path.join(tmpdir(), "acc-ok-home-")));
+  const dataHome = await realpath(await mkdtemp(path.join(tmpdir(), "acc-ok-data-")));
+  const project = await realpath(await mkdtemp(path.join(tmpdir(), "acc-ok-proj-")));
+  t.after(() => Promise.all([home, dataHome, project]
+    .map(dir => rm(dir, { recursive: true, force: true }))));
+
+  const { stdout } = await execFileAsync(process.execPath,
+    [binary, "doctor", "--cwd", project],
+    { cwd: home, env: { ...process.env, HOME: home, ACC_DATA_HOME: dataHome } });
+
+  assert.match(stdout, /store healthy/);
+});


### PR DESCRIPTION
Found while walking the machine shapes I had never tested: malformed client config, unwritable directory, corrupt store. The first two behave well. The third does not.

## The same bug, one frame earlier

This was fixed once. `collectStatus` read every record ahead of the diagnosis and died on a truncated file, so `acc doctor` answered `invalid JSON record` while the inspection had already found the file and put it in a list nobody ever saw. `runDoctor` was taught to check the report first, and the comment explaining why is still in the file.

But every command outside a short list opens the store **before its handler is called**, and `doctor` was not on that list. So the diagnosis still died — a frame earlier, in the setup:

```
$ acc doctor --cwd <project>
invalid JSON record: …/workspaces/workspace_662a…/protocol.json
```

One line. No framing, no list, no remedy. `--repair` did the same, rather than saying repair is blocked — which is what it is built to say, for a reason it already carries in a comment:

> Completing a journal on top of state we cannot even read would turn an ambiguous store into a confidently wrong one.

The fail-closed design was right all along; nothing ever reached it.

## The fix

Locating a workspace and opening it are now separate. `doctor` gets a context that knows *where* the store is and opens it *on request*, once the report says reading is safe:

```
store state is ambiguous; repair is blocked. 1 unreadable:
  …/workspaces/workspace_02407733…/protocol.json
```

## What splitting them exposed

Opening the store used to create it, so the inspection had never met a store that does not exist yet. With the report running first, "no `protocol.json`" looked exactly like "unreadable `protocol.json`" — and a person's first `acc doctor` in a new project would have been told their store was broken.

My own test caught it. Absent and unreadable are different things now.

## Verified live

```
1. new workspace, no store yet:      store healthy; 0 live; 4 of 4 adapter(s) installed
2. same store, protocol.json broken: store state is ambiguous; repair is blocked. 1 unreadable: …
                                     exit 4
3. --repair:                         says it is blocked, on purpose
4. the real machine:                 unchanged
```

## Also checked, and already correct

- **Malformed client config** — `acc install` fails that adapter with `settings.json is not valid JSON: Expected double-quoted property name at position 19`, installs the others, exits 4, leaves the user's file untouched, and a later `acc uninstall` still removes what got written (0 files left).
- **Unwritable client directory** — `EACCES: permission denied, open '…/.codex/config.toml'`, exit 4, nothing installed.

## Record

```
PASS  agents-can-communicate-0.1.11.tgz  sha256 178782d6…2d0cc6  built from 491b41b
```

148 KB, 112 entries. 953 tests passing, 0 failing · `syntax ok in 201 file(s)`.

Mutation-proved: opening the store first fails 2 of 4; treating an absent store as broken fails 1; reverting the dispatch so doctor takes the ordinary context fails 2.
