### PR TITLE
release: 0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,21 @@
 # Changelog
 
-## Unreleased
+## 0.1.12
+
+Two fixes for machines this project had never actually looked at. Every
+end-to-end run until now was done on one carrying all four clients and a healthy
+store, so a machine with fewer clients - or a store that cannot be read - was
+territory nobody had walked.
 
 | | |
 |---|---|
-| Built from | `491b41b` |
-| Tarball | `agents-can-communicate-0.1.11.tgz`, 148 KB, 111 entries |
-| sha256 | `178782d6553b7bb40d931a394c31f71581142ff7f443d1b19f1666c75a2d0cc6` |
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
 | Tests | 953 passing, 0 failing |
-
-Not published. A published record says what the registry serves and is not
-rewritten, so shipped code that changes after a release is measured here instead.
+| Node | 24 (current production LTS) |
+| Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
+| Not supported | Windows — untested rather than known-broken |
 
 `acc doctor` runs on the store it exists to diagnose. This was fixed once
 already, and the throw moved rather than went away. The first time, `collectStatus`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ territory nobody had walked.
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `93ea98b` |
+| Tarball | `agents-can-communicate-0.1.12.tgz`, 148 KB, 111 entries |
+| sha256 | `df1d0f07619eecffb17f7616a3713037a155778714d650ec411c84441079b947` |
 | Tests | 953 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -102,51 +102,51 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.1.11"
+      "version": "0.1.12"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.1.11"
+      "version": "0.1.12"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.1.11"
+      "version": "0.1.12"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.1.11"
+      "version": "0.1.12"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.1.11"
+      "version": "0.1.12"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.1.11"
+      "version": "0.1.12"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.1.11"
+      "version": "0.1.12"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.1.11"
+      "version": "0.1.12"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.1.11"
+      "version": "0.1.12"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.1.11"
+      "version": "0.1.12"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.1.11"
+      "version": "0.1.12"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.1.11"
+      "version": "0.1.12"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "type": "module",
   "description": "Local-first coordination for independently opened AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.mjs" },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Two fixes for machines this project had never actually looked at. Every end-to-end run until now was done on one carrying all four clients and a healthy store.

| | |
|---|---|
| **#87** | **`acc doctor` runs on the store it exists to diagnose.** The same bug as an earlier fix, one frame earlier: every command outside a short list opens the store before its handler runs, and `doctor` was not on that list. One unreadable `protocol.json` and the diagnosis died in the setup |
| **#86** | **An install that wired nothing says what still works.** On a machine with no supported client, four true skip lines together read as "ACC has nothing for you" — while `acc-mcp`, which needs no adapter at all, works fine |

## Verified on the packed artifact, on four machines

```
1. only Codex:
     installed 1 adapter(s)
     store healthy; 0 live; protection none; 1 of 4 adapter(s) installed
       start codex once and accept the hook trust prompt  # its hooks run nothing until then

2. no clients at all:
     no client was wired, but any MCP client can still take part: point it at the acc-mcp command
     store healthy; 0 live; protection none; 0 of 4 adapter(s) installed
       no client is wired; any MCP client can still take part through acc-mcp

3. a store that cannot be read:
     new store        → store healthy; …                    (absent ≠ unreadable)
     protocol.json broken → store state is ambiguous; repair is blocked. 1 unreadable: …
                            exit 4
     --repair         → says it is blocked, on purpose

4. the MCP path that (2) now names, on that same bare machine:
     tools/list → 10 tools
```

Point 3's first line is the case splitting the context exposed: opening the store used to create it, so the inspection had never met a store that does not exist yet. Without that distinction a person's first `acc doctor` in a new project would report a broken store.

## Also checked and already correct

- **Malformed client config** — the adapter refuses by name and position, the others still install, exit 4, the user's file untouched, and a later uninstall still removes what got written.
- **Unwritable client directory** — `EACCES` naming the path, exit 4, nothing installed.

## Record

```
PASS  agents-can-communicate-0.1.12.tgz  sha256 df1d0f07…79b947  built from 93ea98b
```

148 KB, 111 entries. 953 tests passing, 0 failing · `syntax ok in 201 file(s)`.

Thirteenth release in a row without a broken bump.
