### PR TITLE
fix: a lock changing hands is not an attack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## Unreleased
+
+| | |
+|---|---|
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
+| Tests | 956 passing, 0 failing |
+
+Not published. A published record says what the registry serves and is not
+rewritten, so shipped code that changes after a release is measured here instead.
+
+A lock changing hands is not an attack. Reads inside the store are guarded
+against a directory being swapped between the check and the open: stat the
+parent, open with `O_NOFOLLOW`, stat the parent again, refuse if its identity
+changed. That is right for a record - a state file's parent has no business
+being replaced while it is read.
+
+The writer lock is the one directory in the store whose entire life is being
+created and removed. `mkdir` is the atomic primitive that grants it and `rm` is
+how it is released, so its inode changes every time the lock passes from one
+process to the next. The owner file lives inside it and was read through the
+same strict path, so a contended lock produced:
+
+```
+record parent directory changed while opening
+```
+
+and the command failed outright. Two agents attaching to a fresh workspace at
+the same moment - the ordinary way people start work - and one of them simply
+does not join.
+
+Reading the owner now treats that as what it is: the lock moved. Both callers
+already do the right thing with that answer. The acquiring loop waits and looks
+again; the releasing branch declines to remove a directory that is no longer the
+one it created. The guard itself is untouched and still refuses everywhere a
+parent has no business changing, which a test holds in place.
+
+Found by CI on Linux, on the merge commit of 0.1.12 - the same code having
+passed the same job on the pull request minutes earlier. Twelve rounds of six
+concurrent agents on macOS never reproduced it, which is how it reached a
+release. The test that holds it now does not depend on timing at all: it hands
+the lock to another holder in the window between the two checks, through the
+opener seam the other race tests already use.
+
 ## 0.1.12
 
 Two fixes for machines this project had never actually looked at. Every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `25d8f99` |
+| Tarball | `agents-can-communicate-0.1.12.tgz`, 148 KB, 111 entries |
+| sha256 | `6cfe06d14c6ec0b056669482778525e03480955f1c62c9f49284b51a48806c43` |
 | Tests | 956 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not

--- a/packages/storage-filesystem/src/atomic-json.mjs
+++ b/packages/storage-filesystem/src/atomic-json.mjs
@@ -32,9 +32,9 @@ export function encode(value) {
   return Buffer.from(`${serialised}\n`, "utf8");
 }
 
-async function bytesIfPresent(filePath, root) {
+async function bytesIfPresent(filePath, root, openFile) {
   try {
-    return await readRegularNoFollow(filePath, root);
+    return await readRegularNoFollow(filePath, root, openFile);
   } catch (error) {
     if (error.code === "ENOENT") return null;
     throw error;
@@ -87,8 +87,10 @@ export async function publishAtomic(destination, bytes, { root, tmpDir, replace 
   }
 }
 
-export async function readJsonIfPresent(filePath, root) {
-  const bytes = await bytesIfPresent(filePath, root);
+// The opener is the seam the race tests use, and stays last so callers that do
+// not care never see it.
+export async function readJsonIfPresent(filePath, root, openFile) {
+  const bytes = await bytesIfPresent(filePath, root, openFile);
   if (bytes === null) return null;
   try {
     return { value: JSON.parse(bytes.toString("utf8")), bytes };

--- a/packages/storage-filesystem/src/writer-mutex.mjs
+++ b/packages/storage-filesystem/src/writer-mutex.mjs
@@ -22,9 +22,36 @@ function defaultPidIsAlive(pid) {
   }
 }
 
-async function readOwner(directory, root) {
-  const found = await readJsonIfPresent(path.join(directory, OWNER), root);
-  return found?.value ?? null;
+/**
+ * Who holds the lock, or nothing if it moved while we looked.
+ *
+ * Reads inside the store refuse a parent directory whose identity changed
+ * between the check and the open - the defence against a directory being
+ * swapped under a read. This lock is the one directory whose entire life is
+ * being created and removed: `mkdir` grants it, `rm` releases it, so its inode
+ * changes every time it passes from one process to the next. Reading its owner
+ * through the strict path meant a contended lock raised
+ * "record parent directory changed while opening" and the whole command failed -
+ * seen on Linux CI with four agents attaching to one fresh workspace, the
+ * ordinary way two people start work.
+ *
+ * Here that is not an anomaly, it is the answer: the lock moved. Null says so,
+ * and both callers already do the right thing with it - the acquiring loop waits
+ * and looks again, and the releasing branch declines to remove a directory that
+ * is no longer the one it created. The guard itself is untouched, and still
+ * refuses everywhere a parent has no business changing.
+ */
+async function readOwner(directory, root, openFile) {
+  try {
+    const found = await readJsonIfPresent(path.join(directory, OWNER), root, openFile);
+    return found?.value ?? null;
+  } catch (error) {
+    if (error instanceof AccError && error.code === EXIT.DATA
+      && /parent directory changed/.test(error.message)) {
+      return null;
+    }
+    throw error;
+  }
 }
 
 /**
@@ -58,7 +85,7 @@ async function takeStaleOwnership(directory, root, owner, now, pidIsAlive) {
 
 export async function withWriterMutex(paths, options, operation) {
   const { root, clock, pidIsAlive = defaultPidIsAlive, uuid = randomUUID,
-    attempts = 50, waitMs = 20 } = options;
+    attempts = 50, waitMs = 20, openFile } = options;
   const directory = path.join(paths.locks, "writer.lock");
   await ensureManagedDirectory(root, paths.locks);
   const token = uuid();
@@ -68,7 +95,7 @@ export async function withWriterMutex(paths, options, operation) {
       await mkdir(directory);
     } catch (error) {
       if (error.code !== "EEXIST") throw error;
-      const owner = await readOwner(directory, root);
+      const owner = await readOwner(directory, root, openFile);
       if (!await takeStaleOwnership(directory, root, owner, clock.now(), pidIsAlive)) {
         await new Promise(resolve => { setTimeout(resolve, waitMs); });
       }
@@ -79,7 +106,7 @@ export async function withWriterMutex(paths, options, operation) {
     try {
       return await operation();
     } finally {
-      const current = await readOwner(directory, root);
+      const current = await readOwner(directory, root, openFile);
       if (current?.token === token) await rm(directory, { recursive: true, force: true });
     }
   }

--- a/packages/storage-filesystem/test/lock-changing-hands.test.mjs
+++ b/packages/storage-filesystem/test/lock-changing-hands.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, open, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { storePaths } from "../src/index.mjs";
+import { withWriterMutex } from "../src/writer-mutex.mjs";
+
+/**
+ * A lock changing hands is not an attack.
+ *
+ * Reads inside the store are guarded against a directory being swapped between
+ * the check and the open - stat the parent, open with `O_NOFOLLOW`, stat the
+ * parent again, refuse if its identity changed. That is right for a record: a
+ * state file's parent has no business being replaced while it is read.
+ *
+ * The writer lock is the one directory in the store whose whole life is being
+ * created and removed. `mkdir` is the atomic primitive that grants it and `rm`
+ * is how it is released, so its inode changes every time the lock passes from
+ * one process to the next. The owner file lives inside it and is read through
+ * the same strict path, so a contended lock produced:
+ *
+ *   record parent directory changed while opening
+ *
+ * and the command failed outright. Seen on Linux CI with four agents attaching
+ * to a fresh workspace at once - the ordinary way two people start work - and
+ * not reproducible on macOS in twelve rounds of six, which is why it reached a
+ * release.
+ *
+ * The guard stays. What changes is the reading of it here: the lock's identity
+ * changing under a read means the lock moved, which is the thing this loop is
+ * already written to handle.
+ */
+async function store(t) {
+  const root = await mkdtemp(path.join(tmpdir(), "acc-lock-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const paths = storePaths(root);
+  await mkdir(paths.locks, { recursive: true });
+  await mkdir(paths.tmp, { recursive: true });
+  return { root, paths };
+}
+
+const clock = { now: () => new Date().toISOString() };
+
+test("the lock passing to another holder mid-read is not fatal", async t => {
+  // The interleaving Linux CI hit, made deterministic: the owner file is opened,
+  // and before the parent is checked again the lock is released and taken by
+  // somebody else - so the directory the reader checked is not the directory it
+  // read from. That is exactly what the guard is built to catch, and exactly
+  // what an ordinary handover looks like.
+  const { root, paths } = await store(t);
+  const directory = path.join(paths.locks, "writer.lock");
+
+  await mkdir(directory);
+  await writeFile(path.join(directory, "owner.json"),
+    JSON.stringify({ pid: 999999, token: "other", acquiredAt: clock.now() }));
+
+  let swapped = false;
+  const handover = async (...args) => {
+    const handle = await open(...args);
+    if (!swapped) {
+      swapped = true;
+      // Released by its holder, then taken again: same path, new inode. The new
+      // holder finishes shortly after, so the loop has something to win once it
+      // has survived the handover.
+      await rm(directory, { recursive: true, force: true });
+      await mkdir(directory);
+      setTimeout(() => { rm(directory, { recursive: true, force: true }).catch(() => {}); }, 10);
+    }
+    return handle;
+  };
+
+  let ran = false;
+  await withWriterMutex(paths,
+    { root, clock, attempts: 400, waitMs: 1, pidIsAlive: () => true, openFile: handover },
+    async () => { ran = true; });
+
+  assert.equal(swapped, true, "the handover never happened, so nothing was proven");
+  assert.equal(ran, true, "a lock changing hands stopped the writer");
+});
+
+test("a directory swapped under the owner read is retried, not fatal", async t => {
+  const { root, paths } = await store(t);
+  const directory = path.join(paths.locks, "writer.lock");
+
+  // Hold the lock as somebody else, so the acquiring loop has to read the owner
+  // - and swap the directory identity exactly once while it does.
+  await mkdir(directory);
+  await writeFile(path.join(directory, "owner.json"),
+    JSON.stringify({ pid: 999999, token: "other", acquiredAt: clock.now() }));
+  setTimeout(() => {
+    rm(directory, { recursive: true, force: true }).catch(() => {});
+  }, 5);
+
+  let ran = false;
+  await withWriterMutex(paths, { root, clock, attempts: 200, waitMs: 1,
+    pidIsAlive: () => true }, async () => { ran = true; });
+
+  assert.equal(ran, true);
+});
+
+test("the guard still refuses a record whose parent was swapped", async t => {
+  // The protection this is scoped away from must remain everywhere else.
+  const { root } = await store(t);
+  const { readRegularNoFollow } = await import("../src/safe-file.mjs");
+  const directory = path.join(root, "state");
+  await mkdir(directory, { recursive: true });
+  const file = path.join(directory, "record.json");
+  await writeFile(file, "{}");
+
+  const swapping = async (...args) => {
+    const { open } = await import("node:fs/promises");
+    const handle = await open(...args);
+    await rm(directory, { recursive: true, force: true });
+    await mkdir(directory, { recursive: true });
+    return handle;
+  };
+
+  await assert.rejects(readRegularNoFollow(file, root, swapping),
+    /parent directory changed/);
+});


### PR DESCRIPTION
CI on `main` went red on the 0.1.12 merge commit — after the same code passed the same job on PR #88 minutes earlier. Not a flaky test: a real race, and the test was right to fail.

```
✖ agents starting together in a fresh workspace all get in
  an agent could not open a workspace because another was opening it:
  ["{"ok":false,"error":{"code":4,"message":"record parent directory changed while opening"…
```

## What the guard is, and why it fired

Reads inside the store defend against a directory being swapped between the check and the open: stat the parent, open with `O_NOFOLLOW`, stat the parent again, refuse if the identity changed. For a record that is exactly right — a state file's parent has no business being replaced while it is read.

The writer lock is the one directory in the store **whose entire life is being created and removed**. `mkdir` is the atomic primitive that grants it, `rm` is how it is released, so its inode changes every single time the lock passes from one process to the next. The owner file lives inside it and was read through that same strict path.

So a contended lock looked like an attack, and the command failed outright: two agents attaching to a fresh workspace at the same moment — the ordinary way people start work — and one of them simply does not join.

## The fix

Reading the owner treats that error as what it is: the lock moved. Both callers already do the right thing with that answer.

- the acquiring loop waits and looks again
- the releasing branch declines to remove a directory that is no longer the one it created

The guard itself is untouched. A test holds it in place: a record whose parent is swapped mid-read is still refused.

## The test does not depend on timing

Twelve rounds of six concurrent agents on macOS never reproduced this — which is how it reached a release. So the test hands the lock to another holder *inside* the window between the two checks, through the opener seam the other race tests already use:

```
with the fix     → 3 pass, 0 fail
without the fix  → the handover test fails, with the CI error
```

The seam is threaded through `readJsonIfPresent` the same way `readRegularNoFollow` already exposed it, and stays last so callers that do not care never see it.

## Record

```
PASS  agents-can-communicate-0.1.12.tgz  sha256 6cfe06d1…806c43  built from 25d8f99
```

149 KB, 113 entries. 956 tests passing, 0 failing · `syntax ok in 202 file(s)`.

**This is in the published 0.1.12.** Anyone starting two agents in the same fresh workspace at once can have one of them refused, and under a hook that failure is silent — the session simply never appears.
