### PR TITLE
release: 0.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,21 @@
 # Changelog
 
-## Unreleased
+## 0.1.13
+
+One fix, and it is the reason to upgrade off 0.1.12 rather than wait. Two agents
+starting in the same fresh workspace at the same moment - the ordinary way people
+begin work - could leave one of them refused, and under a hook that refusal is
+silent: the session simply never appears.
 
 | | |
 |---|---|
-| Built from | `25d8f99` |
-| Tarball | `agents-can-communicate-0.1.12.tgz`, 148 KB, 111 entries |
-| sha256 | `6cfe06d14c6ec0b056669482778525e03480955f1c62c9f49284b51a48806c43` |
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
 | Tests | 956 passing, 0 failing |
-
-Not published. A published record says what the registry serves and is not
-rewritten, so shipped code that changes after a release is measured here instead.
+| Node | 24 (current production LTS) |
+| Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
+| Not supported | Windows — untested rather than known-broken |
 
 A lock changing hands is not an attack. Reads inside the store are guarded
 against a directory being swapped between the check and the open: stat the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ silent: the session simply never appears.
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `8ef19b9` |
+| Tarball | `agents-can-communicate-0.1.13.tgz`, 148 KB, 111 entries |
+| sha256 | `13748bcbd3b0262b1c7ce6418ecb5e41290d0ceea39e243c5df16e6f159da86a` |
 | Tests | 956 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -102,51 +102,51 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.1.12"
+      "version": "0.1.13"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.1.12"
+      "version": "0.1.13"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.1.12"
+      "version": "0.1.13"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.1.12"
+      "version": "0.1.13"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.1.12"
+      "version": "0.1.13"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.1.12"
+      "version": "0.1.13"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.1.12"
+      "version": "0.1.13"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.1.12"
+      "version": "0.1.13"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.1.12"
+      "version": "0.1.13"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.1.12"
+      "version": "0.1.13"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.1.12"
+      "version": "0.1.13"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.1.12"
+      "version": "0.1.13"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "type": "module",
   "description": "Local-first coordination for independently opened AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.mjs" },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
One fix, and it is the reason to upgrade off 0.1.12 rather than wait.

| | |
|---|---|
| **#89** | **A lock changing hands is not an attack.** Two agents starting in the same fresh workspace at the same moment could leave one of them refused — and under a hook that refusal is silent: the session simply never appears |

## What it was

Reads inside the store defend against a directory being swapped between the check and the open: stat the parent, open with `O_NOFOLLOW`, stat the parent again, refuse if the identity changed. Right for a record — a state file's parent has no business being replaced while it is read.

The writer lock is the one directory whose **entire life** is being created and removed. `mkdir` grants it, `rm` releases it, so its inode changes every time it passes from one process to the next. Its owner file was read through that same strict path, so ordinary contention looked like an attack:

```
record parent directory changed while opening
```

Reading the owner now treats that as the lock having moved — which is what both callers were already written to handle: the acquiring loop waits and looks again, the releasing branch declines to remove a directory it did not create. The guard is untouched everywhere else, and a test holds that.

## How it was caught, and why that matters

CI on `main` went red on the 0.1.12 merge commit, after the same code passed the same job on PR #88 minutes earlier. Twelve rounds of six concurrent agents on macOS never reproduced it — which is exactly how it reached a release.

`main` is green again on the same job.

## Verified on the packed artifact

```
1. the handover, made deterministic — the lock passes to another holder inside
   the window between the two checks, through the opener seam:
     → the writer got through

2. the real thing, 10 rounds of 8 agents attaching to one fresh workspace at once:
     → 0 failures
```

Point 1 is the one that proves the fix: without it, that same check fails with the CI error. Point 2 is the shape a person actually meets.

One thing I will not claim: I tried to demonstrate the failure against the published 0.1.12 from outside and got a *different* error, because an external churner is more aggressive than a real handover. The evidence for the fix is CI's own failure on that commit plus the deterministic test, not that comparison.

## Record

```
PASS  agents-can-communicate-0.1.13.tgz  sha256 13748bcb…9da86a  built from 8ef19b9
```

148 KB, 111 entries. 956 tests passing, 0 failing · `syntax ok in 202 file(s)`.

Fourteenth release in a row without a broken bump.
