### PR TITLE
release: 0.1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and ACC now says so plainly instead of failing three different ways.
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `0badbe8` |
+| Tarball | `agents-can-communicate-0.1.14.tgz`, 153 KB, 114 entries |
+| sha256 | `b5ee8e088a2ac6f734706e3da757ef9385cb2dbaee61641bcaa8e924af292e00` |
 | Tests | 979 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 26.6.2 (darwin 25.6.0, arm64) and Linux in CI |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,23 @@
 # Changelog
 
-## Unreleased
+## 0.1.14
+
+Sessions that ended without saying so no longer haunt the roster. A client killed
+with its terminal, or one that has no session-end event at all, left a record open
+forever - one real workspace had accumulated 227 of them, and `acc doctor` reported
+the pile as a fault. Upgrading requires deleting the store; there is no migration,
+and ACC now says so plainly instead of failing three different ways.
 
 | | |
 |---|---|
-| Built from | `6db5937` |
-| Tarball | `agents-can-communicate-0.1.13.tgz`, 153 KB, 114 entries |
-| sha256 | `7fe1191e0c8d18bc01593ab2b43cac0138db215739d168f5e76569e818b10ee3` |
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
 | Tests | 979 passing, 0 failing |
-
-Not published. A published record says what the registry serves and is not
-rewritten, so shipped code that changes after a release is measured here instead.
+| Node | 24 (current production LTS) |
+| Verified on | macOS 26.6.2 (darwin 25.6.0, arm64) and Linux in CI |
+| Not supported | Windows - untested rather than known-broken |
+| Pid resolution | `codex` and `claude_code` only; `gemini_cli` and `kimi` run through an interpreter, so they fall back to the age floor. See [CAPABILITIES.md](docs/CAPABILITIES.md) |
 
 A session whose process is gone now says so. A record is opened by a hook at
 session start and closed by one at session end, and when a client never fires the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -102,51 +102,51 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.1.13"
+      "version": "0.1.14"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.1.13"
+      "version": "0.1.14"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.1.13"
+      "version": "0.1.14"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.1.13"
+      "version": "0.1.14"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.1.13"
+      "version": "0.1.14"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.1.13"
+      "version": "0.1.14"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.1.13"
+      "version": "0.1.14"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.1.13"
+      "version": "0.1.14"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.1.13"
+      "version": "0.1.14"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.1.13"
+      "version": "0.1.14"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.1.13"
+      "version": "0.1.14"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.1.13"
+      "version": "0.1.14"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "type": "module",
   "description": "Local-first coordination for independently opened AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.mjs" },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Sessions that ended without saying so no longer haunt the roster.

A record is opened by a hook at session start and closed by one at session end. A client killed with its terminal — or one with no session-end event at all — left the record open forever, because nothing could ask whether the process still existed. One real workspace had accumulated 227 of them, and `acc doctor` reported the pile as "not answering", which reads as a fault and is not one.

Presence now pairs the process with two floors, the way `writer-mutex.mjs` already reclaims a lock that is dead **and** old.

## Upgrading is not free — the store must be deleted

`SCHEMA_VERSION` is 2 and `STORE_VERSION` moves with it, so a store written by 0.1.13 or earlier is refused before a single record is read, with one plain `unknown store version`. There is no migration.

That refusal is the feature. Without the store bump the failure was three-way and none of it said what to do: `acc status` appeared to work, `heartbeatSession` threw deep inside on `unknown schemaVersion: 1`, and `acc doctor` filed every record under `corrupt`.

```
rm -rf "~/Library/Application Support/acc/workspaces"     # macOS
rm -rf "${XDG_DATA_HOME:-~/.local/share}/acc/workspaces"  # Linux
```

## What each client gets

The pid is resolved by walking the process ancestry until the adapter's declared binary appears in `ps -o comm=`, and the operating system reports the *interpreter's* name for a script:

| Client | Pid resolves | Effect |
|---|---|---|
| `codex`, `claude_code` | yes — native executables | a dead session leaves the roster immediately and exactly |
| `gemini_cli` | no — `gemini.js` runs through `node` | leaves after thirty minutes of silence |
| `kimi` | almost certainly not, unmeasured — ships as a Node CLI | leaves after thirty minutes of silence |

So the age floor is what fixes the pile-up for all four clients, from "never leaves" to "leaves after thirty minutes"; the pid is what makes it immediate, and today for two of them. `docs/CAPABILITIES.md` carries the per-client table. A `null` pid means *nobody knows* and is never read as dead.

## Replacing a session id is stricter than presence

Presence is a reading, never an edit — `acc status --all` still lists everyone who was ever here. But one consumer takes something away, and there the cost is asymmetric: a wrong presence verdict costs a roster row and self-corrects on the session's next turn, while a wrong replacement takes a live session's generation, after which its own heartbeats fail with exit 5 and nothing undoes it.

So only a pid confirmed dead is authority to replace an id. Silence, however long, is not. A claim is still released only by lease expiry or an explicit force release; a workstream coordinator and a task assignment are contestable once the holder reads `offline`, because taking either is reversible.

That coordinator case is a second fix hiding in the first: before this, an open session could never classify `offline`, so a coordinator whose process was killed left its workstream permanently uncontestable.

## Record

```
PASS  agents-can-communicate-0.1.14.tgz  sha256 b5ee8e08…af292e00  built from 0badbe8
      153 KB, 114 entries
      980 tests, 979 passing, 0 failing, 1 skipped
```

`verify-package.mjs` installs the tarball into a clean directory with **no workspace anywhere** and then drives the product: doctor, a non-Git workspace, an install and its removal with client config restored byte for byte.

## Known and deliberately left

`tests/process/store-concurrency.test.mjs` can fail under heavy machine load with exit 5 `another writer holds the store lock`. It predates this release — `acc attach` resolves no pid, so that test's processes are untouched by this work. The defect is that the writer mutex's budget is a retry count rather than a wall-clock deadline (50 × 20 ms, ~1066 ms), so it is nearly load-invariant while the critical section it waits on is not. Its own change, against `writer-mutex.mjs`.

Not published, not tagged. Both are external mutations and need the maintainer's approval, per `docs/RELEASING.md`.