### PR TITLE
feat: warn a claim holder when a peer intends what they hold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## Unreleased
+
+| | |
+|---|---|
+| Built from | `07de49e` |
+| Tarball | `agents-can-communicate-0.1.14.tgz`, 154 KB, 114 entries |
+| sha256 | `bf8b6a720d7ecca1630a8c09f220a12b8ee8adf2df178b7ade05378c1b8eb888` |
+| Tests | 980 passing, 0 failing |
+
+Not published. A published record says what the registry serves and is not
+rewritten, so shipped code that changes after a release is measured here instead.
+
+Intent gains a reader that faces the other way. `claim_conflict` has always warned
+the agent declaring intent that its target is already claimed; nothing warned the
+claim holder. A new attention rule, `claim_contended`, closes that: when a peer's
+declared resource hints overlap a claim you hold, you are told - early, because a
+claim is advice, not a lock. Only your own claims, and never your own intent
+against them.
+
+The skill now teaches `--hint`. It taught `--summary` and `--mode` and left out the
+one field a peer's tools act on, so agents filled what a person reads and left empty
+what a tool can match. A summary is not a hint.
+
 ## 0.1.14
 
 Sessions that ended without saying so no longer haunt the roster. A client killed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,6 +99,7 @@ Computed from explicit rules, never from a hidden classifier. Lower sorts first:
 | 4 | `coordinator_missing` | An open workstream has no coordinator |
 | 5 | `request_stalled` | You asked for something and nobody is on it: work you requested is held by a session that has gone quiet or addressed to a participant that is not here, or a question of yours needing an answer is addressed to a participant that is not here |
 | 6 | `claim_expired` | A claim you took has run out. Peers can write to it again, and until now nothing said so |
+| 7 | `claim_contended` | A peer's declared resource hints overlap a live claim you hold. The mirror of `claim_conflict`: a claim is advice, not a lock, so the holder is told early that someone means to touch it |
 
 A task with unmet dependencies is `blocked`, and finishing the last one flips its dependents
 to `pending`. So `pending` already means ready, and nothing has to re-evaluate the graph.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -58,7 +58,7 @@ graph LR
 |---|---|
 | `acc status` | Who is here, claims, protection level. `--all` adds everyone who has been |
 | `acc sync` | New events since a cursor; silent when alone |
-| `acc work` | Publish what this session is doing. `--clear` when it has stopped |
+| `acc work` | Publish what this session is doing. `--hint` names a resource so a claim holder is warned; `--clear` when it has stopped |
 | `acc claim` | Reserve a resource. Exit `5` on conflict |
 | `acc release` | Give it back. `--resource` for what you claimed, `--claim` for its id |
 | `acc ack` | Answer a message that asked for one, so it stops asking |

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -208,9 +208,9 @@ A handoff contains:
 
 ## Sync and attention
 
-Adapters request deltas since a cursor. Core computes attention items from six explicit
+Adapters request deltas since a cursor. Core computes attention items from seven explicit
 rules — `direct_request`, `claim_conflict`, `task_unblocked`, `coordinator_missing`,
-`request_stalled`, `claim_expired` — listed with their exact trigger in
+`request_stalled`, `claim_expired`, `claim_contended` — listed with their exact trigger in
 [ARCHITECTURE.md](ARCHITECTURE.md).
 
 Semantic relevance may be assessed by the receiving model, but correctness cannot depend on a hidden central LLM classifier.

--- a/packages/adapter-claude-code/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-claude-code/plugin/skills/acc/SKILL.md
@@ -14,7 +14,7 @@ skill is how you stay legible to them and they to you.
 Once you understand the request, publish one line of Intent:
 
 ```bash
-{{ACC}} work --summary "porting the claim model" --mode edit
+{{ACC}} work --summary "porting the claim model" --mode edit --hint 'file:packages/core/**'
 ```
 
 When you stop working on something and are not starting anything else, say so with
@@ -24,6 +24,12 @@ progress.
 `--mode` is one of `observe`, `explore`, `edit`, `review`, `coordinate`, `wait`. Update it
 when the work changes character. Intent is awareness, not a reservation: it tells peers
 what you are up to, it does not stop anyone editing anything.
+
+`--hint` names a file or glob you are about to touch, and repeats for more than one. It is
+the part of Intent another agent's tools act on: a peer who holds a claim on that resource
+is told you are heading for it, and you are told if your hint lands on a claim someone else
+holds. A summary a person reads is not a hint a tool can match - leave it off and neither
+warning fires.
 
 ## Claim before you change shared work
 
@@ -62,6 +68,7 @@ to the command that answers it:
 - [direct_request] message_x    someone addressed this to you    -> ack
 - [task_unblocked] task_x       work is waiting for you          -> task --take
 - [claim_conflict] claim_x      someone holds what you want      -> ask, or release
+- [claim_contended] claim_x     a peer means to touch what you hold -> reach out, or hold
 - [request_stalled] task_x      you asked and nobody is on it    -> ask again, or take it back
 - [request_stalled] message_x   you asked and nobody is there    -> ask someone else
 ```

--- a/packages/adapter-codex/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-codex/plugin/skills/acc/SKILL.md
@@ -14,7 +14,7 @@ skill is how you stay legible to them and they to you.
 Once you understand the request, publish one line of Intent:
 
 ```bash
-{{ACC}} work --summary "porting the claim model" --mode edit
+{{ACC}} work --summary "porting the claim model" --mode edit --hint 'file:packages/core/**'
 ```
 
 When you stop working on something and are not starting anything else, say so with
@@ -24,6 +24,12 @@ progress.
 `--mode` is one of `observe`, `explore`, `edit`, `review`, `coordinate`, `wait`. Update it
 when the work changes character. Intent is awareness, not a reservation: it tells peers
 what you are up to, it does not stop anyone editing anything.
+
+`--hint` names a file or glob you are about to touch, and repeats for more than one. It is
+the part of Intent another agent's tools act on: a peer who holds a claim on that resource
+is told you are heading for it, and you are told if your hint lands on a claim someone else
+holds. A summary a person reads is not a hint a tool can match - leave it off and neither
+warning fires.
 
 ## Claim before you change shared work
 
@@ -62,6 +68,7 @@ to the command that answers it:
 - [direct_request] message_x    someone addressed this to you    -> ack
 - [task_unblocked] task_x       work is waiting for you          -> task --take
 - [claim_conflict] claim_x      someone holds what you want      -> ask, or release
+- [claim_contended] claim_x     a peer means to touch what you hold -> reach out, or hold
 - [request_stalled] task_x      you asked and nobody is on it    -> ask again, or take it back
 - [request_stalled] message_x   you asked and nobody is there    -> ask someone else
 ```

--- a/packages/adapter-gemini-cli/extension/skills/acc/SKILL.md
+++ b/packages/adapter-gemini-cli/extension/skills/acc/SKILL.md
@@ -14,7 +14,7 @@ skill is how you stay legible to them and they to you.
 Once you understand the request, publish one line of Intent:
 
 ```bash
-{{ACC}} work --summary "porting the claim model" --mode edit
+{{ACC}} work --summary "porting the claim model" --mode edit --hint 'file:packages/core/**'
 ```
 
 When you stop working on something and are not starting anything else, say so with
@@ -24,6 +24,12 @@ progress.
 `--mode` is one of `observe`, `explore`, `edit`, `review`, `coordinate`, `wait`. Update it
 when the work changes character. Intent is awareness, not a reservation: it tells peers
 what you are up to, it does not stop anyone editing anything.
+
+`--hint` names a file or glob you are about to touch, and repeats for more than one. It is
+the part of Intent another agent's tools act on: a peer who holds a claim on that resource
+is told you are heading for it, and you are told if your hint lands on a claim someone else
+holds. A summary a person reads is not a hint a tool can match - leave it off and neither
+warning fires.
 
 ## Claim before you change shared work
 
@@ -62,6 +68,7 @@ to the command that answers it:
 - [direct_request] message_x    someone addressed this to you    -> ack
 - [task_unblocked] task_x       work is waiting for you          -> task --take
 - [claim_conflict] claim_x      someone holds what you want      -> ask, or release
+- [claim_contended] claim_x     a peer means to touch what you hold -> reach out, or hold
 - [request_stalled] task_x      you asked and nobody is on it    -> ask again, or take it back
 - [request_stalled] message_x   you asked and nobody is there    -> ask someone else
 ```

--- a/packages/adapter-kimi/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-kimi/plugin/skills/acc/SKILL.md
@@ -14,7 +14,7 @@ skill is how you stay legible to them and they to you.
 Once you understand the request, publish one line of Intent:
 
 ```bash
-{{ACC}} work --summary "porting the claim model" --mode edit
+{{ACC}} work --summary "porting the claim model" --mode edit --hint 'file:packages/core/**'
 ```
 
 When you stop working on something and are not starting anything else, say so with
@@ -24,6 +24,12 @@ progress.
 `--mode` is one of `observe`, `explore`, `edit`, `review`, `coordinate`, `wait`. Update it
 when the work changes character. Intent is awareness, not a reservation: it tells peers
 what you are up to, it does not stop anyone editing anything.
+
+`--hint` names a file or glob you are about to touch, and repeats for more than one. It is
+the part of Intent another agent's tools act on: a peer who holds a claim on that resource
+is told you are heading for it, and you are told if your hint lands on a claim someone else
+holds. A summary a person reads is not a hint a tool can match - leave it off and neither
+warning fires.
 
 ## Claim before you change shared work
 
@@ -62,6 +68,7 @@ to the command that answers it:
 - [direct_request] message_x    someone addressed this to you    -> ack
 - [task_unblocked] task_x       work is waiting for you          -> task --take
 - [claim_conflict] claim_x      someone holds what you want      -> ask, or release
+- [claim_contended] claim_x     a peer means to touch what you hold -> reach out, or hold
 - [request_stalled] task_x      you asked and nobody is on it    -> ask again, or take it back
 - [request_stalled] message_x   you asked and nobody is there    -> ask someone else
 ```

--- a/packages/core/src/sync.mjs
+++ b/packages/core/src/sync.mjs
@@ -45,6 +45,7 @@ export const ATTENTION_PRIORITY = Object.freeze({
   coordinator_missing: 4,
   request_stalled: 5,
   claim_expired: 6,
+  claim_contended: 7,
 });
 
 function directRequests(snapshot, participantId) {
@@ -93,6 +94,41 @@ function claimConflicts(snapshot, session, now) {
     .map(claim => ({ kind: "claim_conflict", priority: ATTENTION_PRIORITY.claim_conflict,
       sourceId: claim.claimId,
       summary: `${claim.resource} is claimed by ${claim.ownerSessionId}` }));
+}
+
+/**
+ * A resource I hold that a peer has said they intend to touch.
+ *
+ * The mirror of `claimConflicts`. That one reads my own intent and warns me when
+ * what I mean to touch is already claimed. This one reads a peer's intent and
+ * warns me, the holder, that someone is heading for what I claimed. Without it
+ * intent's only wired reader faced inward: it protected the one declaring intent
+ * and told the claim holder nothing, so a claim was a wall nobody was told they
+ * were walking into. A claim is advisory - it does not stop the write - so being
+ * told early is the whole of the protection it offers.
+ *
+ * Only my own claims, and never my own intent against them: declaring intent on
+ * what you already hold is not someone reaching for it. The peer is named by
+ * participant where the roster knows it, because a session id cannot be used
+ * with `--to` and an id a reader cannot act on is the trap the projector warns of.
+ */
+function claimContended(snapshot, session, now) {
+  if (session === null || session === undefined) return [];
+  const theirs = (snapshot.intents ?? [])
+    .filter(intent => intent.sessionId !== session.sessionId);
+  const nameOf = sessionId => (snapshot.sessions ?? [])
+    .find(item => item.sessionId === sessionId)?.participantId ?? "a peer";
+  return (snapshot.claims ?? [])
+    .filter(claim => claim.ownerSessionId === session.sessionId
+      && Date.parse(claim.expiresAt) > Date.parse(now))
+    .flatMap(claim => {
+      const eyeing = theirs.find(intent =>
+        (intent.resourceHints ?? []).some(hint => overlaps(hint, claim.resource)));
+      return eyeing === undefined ? [] : [{
+        kind: "claim_contended", priority: ATTENTION_PRIORITY.claim_contended,
+        sourceId: claim.claimId,
+        summary: `${claim.resource} - ${nameOf(eyeing.sessionId)} means to work on what you hold` }];
+    });
 }
 
 /**
@@ -210,6 +246,7 @@ export function computeAttention(snapshot, { session, participantId, now, pidIsA
   return [
     ...directRequests(snapshot, participantId),
     ...claimConflicts(snapshot, session, now),
+    ...claimContended(snapshot, session, now),
     ...expiredClaims(snapshot, session, now),
     ...unblockedTasks(snapshot, session, participantId),
     ...coordinatorGaps(snapshot),

--- a/packages/core/test/sync.test.mjs
+++ b/packages/core/test/sync.test.mjs
@@ -110,6 +110,39 @@ test("attention ranks a direct request above a nearby claim conflict", async () 
     ["direct_request", "claim_conflict"]);
 });
 
+test("a peer intending a resource I hold tells me my claim is contended", async () => {
+  const { service } = makeService();
+  const { first, second } = await pair(service);
+  // I hold the claim; a peer declares intent on the same resource. The mirror of
+  // the conflict above: there the intent is mine and the claim a peer's; here the
+  // claim is mine and the intent a peer's.
+  await service.acquireClaim({ sessionId: first.sessionId, generation: first.generation,
+    resource: "file:packages/core/src/claims.mjs", reason: "editing" });
+  await service.setIntent({ sessionId: second.sessionId, generation: second.generation,
+    summary: "reading the claim model", mode: "explore",
+    resourceHints: ["file:packages/core/src/claims.mjs"] });
+
+  const result = await service.sync({ sessionId: first.sessionId });
+
+  assert.deepEqual(result.attention.map(item => item.kind), ["claim_contended"]);
+  assert.equal(result.attention[0].sourceId.startsWith("claim_"), true,
+    "the line carries the claim id, so `acc release --claim` has its argument");
+});
+
+test("my own intent over my own claim is not a contention", async () => {
+  const { service } = makeService();
+  const { first } = await pair(service);
+  await service.acquireClaim({ sessionId: first.sessionId, generation: first.generation,
+    resource: "file:src/mine.mjs", reason: "editing" });
+  await service.setIntent({ sessionId: first.sessionId, generation: first.generation,
+    summary: "editing mine", mode: "edit", resourceHints: ["file:src/mine.mjs"] });
+
+  const result = await service.sync({ sessionId: first.sessionId });
+
+  // Declaring intent on what you already hold is not someone reaching for it.
+  assert.equal(result.attention.some(item => item.kind === "claim_contended"), false);
+});
+
 test("an acknowledged request stops demanding attention", async () => {
   const { service } = makeService();
   const { first, second } = await pair(service);
@@ -148,13 +181,20 @@ test("every attention kind in the priority table is one a rule can produce", () 
     messages: [{ messageId: "message_a", subject: "Need slots", requiresAck: true }],
     receipts: [{ messageId: "message_a", recipientParticipantId: "participant_a",
       state: "injected" }],
-    intents: [{ sessionId: "session_a", resourceHints: ["file:src/**"] }],
+    intents: [
+      { sessionId: "session_a", resourceHints: ["file:src/**"] },
+      // A peer heading for what this session holds - triggers claim_contended.
+      { sessionId: "session_b", resourceHints: ["file:src/held.mjs"] },
+    ],
     claims: [
       { claimId: "claim_a", ownerSessionId: "session_b", resource: "file:src/main.mjs",
         expiresAt: "2026-08-16T02:00:00.000Z" },
       // This session's own, and its lease has run out.
       { claimId: "claim_b", ownerSessionId: "session_a", resource: "file:src/lapsed.mjs",
         expiresAt: "2026-08-16T00:30:00.000Z" },
+      // This session's own and still held, and a peer above means to touch it.
+      { claimId: "claim_c", ownerSessionId: "session_a", resource: "file:src/held.mjs",
+        expiresAt: "2026-08-16T02:00:00.000Z" },
     ],
     tasks: [
       { taskId: "task_a", state: "pending", assigneeSessionId: "session_a",


### PR DESCRIPTION
Intent gains a reader that faces the other way.

## The asymmetry

`claimConflicts` has always read intent — but only one direction of it. It takes **my** declared resource hints, finds a peer's claim that overlaps, and warns **me** that what I mean to touch is already held. Intent's only wired reader faced inward: it protected the agent declaring intent and told the claim holder nothing.

So a claim was a wall nobody was told they were walking into. And because a claim is **advisory** — it does not stop the write — being told early is the whole of the protection it offers. The holder was the one party that protection never reached.

## The rule

`claimContended` is the mirror. For each claim **I** hold, it finds a **peer's** intent whose hints overlap, and warns me that someone is heading for it.

```
for each claim I own, still held:
  for each peer intent (never my own):
    if a hint overlaps the claim's resource:
      → attention: "<resource> — <peer> means to work on what you hold"
```

New attention kind `claim_contended`, priority 7 — the lowest, because it is a soft heads-up, not a block. The line carries the claim id, so `acc release --claim` has its argument, and names the peer by participant (addressable with `--to`) rather than a session id a reader cannot act on.

It runs in `computeAttention`, which is pushed into every turn — the same fast channel messages travel, and the one intent's summary never reached.

## Why this ships with a documentation change, not just code

The rule reads a peer's `resourceHints`. The skill taught `work --summary` and `--mode` and **never `--hint`** — so agents filled the fields a person reads and left empty the one field a tool can match. A rule with no input fires for nobody.

So the skill now teaches `--hint`, in all four adapters, with the reason on the page: a summary a person reads is not a hint a tool acts on, and without it neither this warning nor its mirror fires.

## What enforced the rest

`tests/process/surface-coverage.test.mjs` refused the change until `claim_contended` was documented in both `ARCHITECTURE.md`'s priority table and `PROTOCOL.md`, and the prose count went from six rules to seven. That guard exists because `request_stalled` once shipped undocumented; it did its job here.

## Record

```
PASS  agents-can-communicate-0.1.14.tgz  sha256 bf8b6a72…1b8eb888  built from 07de49e
      154 KB, 114 entries
      982 tests, 981 passing, 0 failing, 1 skipped
```

An `## Unreleased` entry measures this, per `docs/RELEASING.md` — 0.1.14 is published and frozen; shipped code that changes after a release is recorded separately.

## Scope left for later

This does not rewrite intent's documentation claim that it "tells peers what you are up to" — the summary is still pull-only, reachable through `sync --scope full`. Making the summary itself push, or paring the claim back, is a separate design question. This change makes the one machine-actionable field of intent actually drive something.