### PR TITLE
release: 0.1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ skill teaches the field that feeds it.
 | Built from | `55bcb64` |
 | Tarball | `agents-can-communicate-0.1.15.tgz`, 154 KB, 114 entries |
 | sha256 | `8a7bb11d1e34681aa41613dcfedf5ca5e74850735c011161eda4b659a01bf742` |
-| Tests | 980 passing, 0 failing |
+| Tests | 981 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 26.6.2 (darwin 25.6.0, arm64) and Linux in CI |
 | Not supported | Windows - untested rather than known-broken |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ skill teaches the field that feeds it.
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `55bcb64` |
+| Tarball | `agents-can-communicate-0.1.15.tgz`, 154 KB, 114 entries |
+| sha256 | `8a7bb11d1e34681aa41613dcfedf5ca5e74850735c011161eda4b659a01bf742` |
 | Tests | 980 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 26.6.2 (darwin 25.6.0, arm64) and Linux in CI |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,20 @@
 # Changelog
 
-## Unreleased
+## 0.1.15
+
+Intent finally points at the peer it names. Its one machine-read field now drives a
+rule that faces the claim holder rather than only the agent declaring intent, and the
+skill teaches the field that feeds it.
 
 | | |
 |---|---|
-| Built from | `07de49e` |
-| Tarball | `agents-can-communicate-0.1.14.tgz`, 154 KB, 114 entries |
-| sha256 | `bf8b6a720d7ecca1630a8c09f220a12b8ee8adf2df178b7ade05378c1b8eb888` |
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
 | Tests | 980 passing, 0 failing |
-
-Not published. A published record says what the registry serves and is not
-rewritten, so shipped code that changes after a release is measured here instead.
+| Node | 24 (current production LTS) |
+| Verified on | macOS 26.6.2 (darwin 25.6.0, arm64) and Linux in CI |
+| Not supported | Windows - untested rather than known-broken |
 
 Intent gains a reader that faces the other way. `claim_conflict` has always warned
 the agent declaring intent that its target is already claimed; nothing warned the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -102,51 +102,51 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.1.14"
+      "version": "0.1.15"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.1.14"
+      "version": "0.1.15"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.1.14"
+      "version": "0.1.15"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.1.14"
+      "version": "0.1.15"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.1.14"
+      "version": "0.1.15"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.1.14"
+      "version": "0.1.15"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.1.14"
+      "version": "0.1.15"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.1.14"
+      "version": "0.1.15"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.1.14"
+      "version": "0.1.15"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.1.14"
+      "version": "0.1.15"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.1.14"
+      "version": "0.1.15"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.1.14"
+      "version": "0.1.15"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "type": "module",
   "description": "Local-first coordination for independently opened AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.mjs" },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Intent finally points at the peer it names.

## What it was

`claim_conflict` has always read intent — but only one direction of it. It warned the agent **declaring** intent that its target was already claimed, and told the claim **holder** nothing. Intent's one machine-read field faced inward: it protected the declarer and left the holder to find out by collision. And a claim is advisory — it does not stop the write — so being told early was the whole of the protection it offered, and the holder was the one party it never reached.

Worse, the field that feeds any of this — `--hint` — was never taught. The skill taught `--summary` and `--mode`, so agents filled what a person reads and left empty what a tool can match.

## What changed

A new attention rule, `claim_contended`, is the mirror of `claim_conflict`: when a peer's declared resource hints overlap a claim **you** hold, you are told — early, on the same per-turn channel messages travel. Only your own claims, and never your own intent against them. The line names the peer by participant (addressable with `--to`) and carries the claim id.

The skill now teaches `--hint` in all four adapters, with the reason on the page: a summary a person reads is not a hint a tool acts on, and without it neither this warning nor its mirror fires.

`tests/process/surface-coverage.test.mjs` refused the change until the rule was documented in `ARCHITECTURE.md`'s priority table and `PROTOCOL.md`, and the prose count went from six rules to seven — the guard that exists because `request_stalled` once shipped undocumented.

## Upgrading

No store change this time — `SCHEMA_VERSION` and `STORE_VERSION` are unchanged since 0.1.14, so a 0.1.14 store is read as-is. `npm install -g agents-can-communicate@0.1.15 && acc install` to re-wire the plugins.

## Record

```
PASS  agents-can-communicate-0.1.15.tgz  sha256 8a7bb11d…a01bf742  built from 55bcb64
      154 KB, 114 entries
      982 tests, 981 passing, 0 failing, 1 skipped
```

`verify-package.mjs` installs the tarball into a clean directory with **no workspace anywhere** and drives the product against it: doctor, a non-Git workspace, an install and its removal with client config restored byte for byte.

Not published, not tagged. Both are external mutations and need approval, per `docs/RELEASING.md`.