### PR TITLE
fix: doctor names the stale bundle, not the runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Unreleased
+
+| | |
+|---|---|
+| Built from | `4fcc56d` |
+| Tarball | `agents-can-communicate-0.1.15.tgz`, 154 KB, 114 entries |
+| sha256 | `c179f61249c15667f74177dcc2d06f1af976dc208311b05c5b843d69b9802137` |
+| Tests | 981 passing, 0 failing |
+
+Not published. A published record says what the registry serves and is not
+rewritten, so shipped code that changes after a release is measured here instead.
+
+`acc doctor` names the stale bundle, not the runtime. After `npm install -g` with
+no `acc install`, the client's shim points into the npm directory, so the hook
+runtime is already current while the skills and manifests copied into the client
+are from whatever acc last installed them. Doctor called that "plugin is <old>",
+which reads as a stale runtime and contradicts the `wired` field that shows the
+runtime is current. The remediation now names the skills and manifests, and a new
+`bundleVersion` field carries the acc that wrote them, beside `wired` for the
+runner - the two diverge only after an npm upgrade, and reporting both makes the
+divergence legible.
+
 ## 0.1.15
 
 Intent finally points at the peer it names. Its one machine-read field now drives a

--- a/packages/cli/src/doctor-command.mjs
+++ b/packages/cli/src/doctor-command.mjs
@@ -134,10 +134,18 @@ async function diagnoseAdapters({ options, runtime }) {
     // trust prompt, most of all. It goes where a person reads, not into --json.
     remediation.push(...(entry.needsAction ?? []));
     const installed = record.installs.find(one => one.adapterId === entry.adapterId);
-    const stale = staleInstall({ recorded: installed?.accVersion ?? null, running });
+    const bundleVersion = installed?.accVersion ?? null;
+    const stale = staleInstall({ recorded: bundleVersion, running });
     if (stale !== null) {
+      // Names the skills and manifests, not "the plugin". Updating the npm
+      // package replaces the CLI and the hook runtime the client's shim points
+      // at, so the runner can already be current - `wired` says whether it is -
+      // while the skills and manifests copied into the client stay at whatever
+      // acc last ran `acc install`. Calling the whole plugin stale reads as a
+      // stale runtime and contradicts a `wired` that says otherwise.
       remediation.push(`acc install --adapter ${entry.adapterId}`
-        + `  # plugin is ${stale.recorded}, acc is ${stale.running}`);
+        + `  # skills and manifests here are from ${stale.recorded}, acc is ${stale.running}`
+        + ` - reinstall to refresh the bundle`);
     }
     // Read from the wiring rather than from the record. An ACC old enough not to
     // know the record's version field still rewrites that record - blank - while
@@ -149,7 +157,11 @@ async function diagnoseAdapters({ options, runtime }) {
       remediation.push(`acc install --adapter ${entry.adapterId}`
         + `  # wired to acc ${wired}, this is ${running}`);
     }
-    return { ...entry, stale, wired, owned: { modified: owned.modified,
+    // `wired` is the version of the runner the client executes; `bundleVersion`
+    // is the acc that copied the skills and manifests into it. They diverge after
+    // an npm upgrade with no `acc install`, and reporting both is what makes the
+    // divergence legible rather than hidden behind a single reassuring number.
+    return { ...entry, stale, wired, bundleVersion, owned: { modified: owned.modified,
       missing: owned.missing, intact: owned.intact.length }, remediation };
   }));
 }

--- a/packages/cli/test/doctor-names-the-wired-version.test.mjs
+++ b/packages/cli/test/doctor-names-the-wired-version.test.mjs
@@ -22,7 +22,7 @@ const binary = path.join(repoRoot, "bin", "acc.mjs");
  * its `readdir` import: every test passed, and the real `acc doctor` died with
  * `readdir is not defined` on the first machine that had a tree recorded.
  */
-async function machine(t, wiredVersion) {
+async function machine(t, wiredVersion, accVersion = null) {
   const home = await realpath(await mkdtemp(path.join(tmpdir(), "acc-wired-home-")));
   const dataHome = await realpath(await mkdtemp(path.join(tmpdir(), "acc-wired-data-")));
   t.after(() => Promise.all([home, dataHome]
@@ -45,7 +45,7 @@ async function machine(t, wiredVersion) {
     `#!/bin/sh\nexec "/usr/bin/node" "${path.join(other, "bin", "acc-hook.mjs")}" claude_code "$@"\n`);
 
   await recordInstall({ dataHome, adapterId: "claude_code", version: "2.1.0",
-    accVersion: null, artifacts: [{ path: tree, kind: "tree" }] });
+    accVersion, artifacts: [{ path: tree, kind: "tree" }] });
   return { home, dataHome };
 }
 
@@ -94,3 +94,32 @@ test("wiring that matches the running acc says nothing", async t => {
   assert.equal(entry.remediation.some(line => /wired to acc/.test(line)), false,
     "a healthy machine was told to reinstall");
 });
+
+test("a stale bundle names the skills, not the runtime, and reports its version", async t => {
+  // The real npm-upgrade case: `npm i -g` refreshed the CLI and the hook
+  // runtime, so the runner the client points at is already the running version,
+  // but the skills and manifests copied into the client are from the acc that
+  // last ran `acc install`. Doctor used to call that "plugin is <old>", which
+  // reads as a stale runtime and sits beside a `wired` that says otherwise.
+  const running = JSON.parse(
+    await (await import("node:fs/promises")).readFile(
+      path.join(repoRoot, "package.json"), "utf8")).version;
+  const place = await machine(t, running, "0.0.1");
+
+  const body = await doctor(place);
+  const entry = body.data.adapters.find(one => one.adapterId === "claude_code");
+
+  // The runtime is current; the bundle is not - and the record now says both.
+  assert.equal(entry.wired, running, "the runner the client executes is current");
+  assert.equal(entry.bundleVersion, "0.0.1",
+    "the recorded install version is surfaced as the bundle's version");
+
+  const line = entry.remediation.find(one => /skills|manifests|bundle/.test(one));
+  assert.notEqual(line, undefined,
+    `no remediation names the stale bundle: ${JSON.stringify(entry.remediation)}`);
+  assert.match(line, /acc install --adapter claude_code/,
+    "the bundle line is not the reinstall command");
+  assert.match(line, /0\.0\.1/, "the bundle line does not name the stale version");
+  assert.equal(entry.remediation.some(one => /\bplugin is\b/.test(one)), false,
+    "a remediation still calls the whole plugin stale when only the bundle is");
+})

--- a/tests/process/doctor-reports.test.mjs
+++ b/tests/process/doctor-reports.test.mjs
@@ -83,8 +83,11 @@ test("doctor says when a client is wired to an older acc than the one running", 
   // hook runtime, and the bundle written into the client stays where it was.
   await place.record4({ adapterId: "claude_code", accVersion: "0.0.9" });
 
+  // Names the skills and manifests, not "the plugin": the runtime the client's
+  // shim points at may already be current (npm replaced it), while the bundle
+  // copied into the client is what stayed behind.
   assert.match(await place.doctor(),
-    /acc install --adapter claude_code {2}# plugin is 0\.0\.9, acc is \d+\.\d+\.\d+/);
+    /acc install --adapter claude_code {2}# skills and manifests here are from 0\.0\.9, acc is \d+\.\d+\.\d+ - reinstall to refresh the bundle/);
 });
 
 test("an install records the acc that made it", async t => {
@@ -106,7 +109,10 @@ test("an install with no recorded acc version is not called stale", async t => {
   // every run is not a diagnosis.
   await place.record4({ adapterId: "claude_code", accVersion: undefined });
 
-  assert.doesNotMatch(await place.doctor(), /plugin is/);
+  // The new staleness phrase, not the old "plugin is", so this still probes
+  // whether the stale-bundle message fired rather than passing because a string
+  // that no longer exists anywhere is absent.
+  assert.doesNotMatch(await place.doctor(), /skills and manifests here are from/);
 });
 
 test("doctor mentions a newer release without asking the registry itself", async t => {


### PR DESCRIPTION
`acc doctor` could report a client's runtime as current while its skills were stale, with no clear signal — and the message it did print pointed at the wrong artifact.

## What happens on an upgrade

`npm install -g` replaces the CLI and the hook runtime. A client's shim points **into the npm directory** (via a shared `.agents/.../acc-hook.sh`), so after the upgrade the runner the client executes is already the new version. But the **skills and manifests** are a *copy* written into each client's cache, and only `acc install` refreshes them. So between `npm i -g` and `acc install`, the runtime is current and the bundle is stale.

`docs/CLI.md` already describes this exactly: "*`npm install -g` replaces this CLI and the hook runtime … and leaves the bundle written into the client alone, including the skills the agents read. That is why an upgrade is two commands, and why `acc doctor` says so when they disagree.*"

## The defect

Doctor's staleness remediation said:

```
acc install --adapter codex  # plugin is 0.1.14, acc is 0.1.15
```

"plugin is 0.1.14" reads as a stale **runtime** — but the runtime is 0.1.15. And it sat beside `wired: 0.1.15`, which correctly shows the runner is current. The two contradict each other, and a reader trusting `wired` (the field that looks like *the* version) concludes nothing is wrong. The message named the wrong artifact.

This is not hypothetical — it is exactly what tripped up an upgrade in practice: `wired: 0.1.15` looked done, and the reworded release's whole value (new skills teaching `--hint`) was silently still the old copy.

## The fix

Detection already existed (`staleInstall` compares the recorded install version against the running acc, and its remediation is printed). Two changes make it truthful and legible:

- The remediation now names what is actually stale:
  ```
  acc install --adapter codex  # skills and manifests here are from 0.1.14, acc is 0.1.15 - reinstall to refresh the bundle
  ```
  It does not claim anything about the runtime — `wired` speaks for that.

- A new per-adapter `bundleVersion` field carries the acc that wrote the skills and manifests, beside `wired` for the runner. They diverge only after an npm upgrade, and reporting both is what makes the divergence legible rather than hidden behind one reassuring number.

No new detection, no docs change — `docs/CLI.md` already promised this behavior; the message wording was what lagged.

## Tests

- New: an adapter whose recorded install version is older than running, with a runtime that IS current, produces a remediation naming skills/manifests (never "plugin is"), a `bundleVersion` of the old version, and a `wired` of the current one.
- Updated `doctor-reports.test.mjs`: the positive assertion now matches the new wording; the negative probe changed from `/plugin is/` to the new phrase — otherwise it would pass vacuously, since "plugin is" no longer appears anywhere.

## Record

```
PASS  agents-can-communicate-0.1.15.tgz  sha256 c179f612…9802137  built from 4fcc56d
      983 tests, 982 passing, 0 failing, 1 skipped
```

An `## Unreleased` entry measures this, per `docs/RELEASING.md` — 0.1.15 is published and frozen; shipped code that changes after a release is recorded separately.