### PR TITLE
release: 0.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,19 @@
 # Changelog
 
-## Unreleased
+## 0.1.16
+
+`acc doctor` tells the truth about what an upgrade left stale: the skills copied
+into a client, not the hook runtime, which `npm install -g` already refreshed.
 
 | | |
 |---|---|
-| Built from | `4fcc56d` |
-| Tarball | `agents-can-communicate-0.1.15.tgz`, 154 KB, 114 entries |
-| sha256 | `c179f61249c15667f74177dcc2d06f1af976dc208311b05c5b843d69b9802137` |
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
 | Tests | 981 passing, 0 failing |
-
-Not published. A published record says what the registry serves and is not
-rewritten, so shipped code that changes after a release is measured here instead.
+| Node | 24 (current production LTS) |
+| Verified on | macOS 26.6.2 (darwin 25.6.0, arm64) and Linux in CI |
+| Not supported | Windows - untested rather than known-broken |
 
 `acc doctor` names the stale bundle, not the runtime. After `npm install -g` with
 no `acc install`, the client's shim points into the npm directory, so the hook

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ into a client, not the hook runtime, which `npm install -g` already refreshed.
 | Built from | `0b75f4e` |
 | Tarball | `agents-can-communicate-0.1.16.tgz`, 154 KB, 114 entries |
 | sha256 | `098a8f48c96718c64e348ebe6d71803f513bf5dc1413ab0fc9996ffe8a43a93e` |
-| Tests | 981 passing, 0 failing |
+| Tests | 982 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 26.6.2 (darwin 25.6.0, arm64) and Linux in CI |
 | Not supported | Windows - untested rather than known-broken |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ into a client, not the hook runtime, which `npm install -g` already refreshed.
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `0b75f4e` |
+| Tarball | `agents-can-communicate-0.1.16.tgz`, 154 KB, 114 entries |
+| sha256 | `098a8f48c96718c64e348ebe6d71803f513bf5dc1413ab0fc9996ffe8a43a93e` |
 | Tests | 981 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 26.6.2 (darwin 25.6.0, arm64) and Linux in CI |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -102,51 +102,51 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.1.15"
+      "version": "0.1.16"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.1.15"
+      "version": "0.1.16"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.1.15"
+      "version": "0.1.16"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.1.15"
+      "version": "0.1.16"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.1.15"
+      "version": "0.1.16"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.1.15"
+      "version": "0.1.16"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.1.15"
+      "version": "0.1.16"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.1.15"
+      "version": "0.1.16"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.1.15"
+      "version": "0.1.16"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.1.15"
+      "version": "0.1.16"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.1.15"
+      "version": "0.1.16"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.1.15"
+      "version": "0.1.16"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "type": "module",
   "description": "Local-first coordination for independently opened AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.mjs" },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
`acc doctor` now tells the truth about what an upgrade left stale.

## What it was

`npm install -g` replaces the CLI and the hook runtime — a client's shim points into the npm directory, so after the upgrade the runner it executes is already current. But the **skills and manifests** are a copy written into each client's cache, refreshed only by `acc install`. Between `npm i -g` and `acc install`, the runtime is current and the bundle is stale.

Doctor's remediation said `plugin is 0.1.14, acc is 0.1.15` — which reads as a stale **runtime**, contradicts the `wired` field that correctly shows the runner is current, and so gets dismissed. It named the wrong artifact.

## The fix

Detection already existed; the message was wrong. Now:

- The remediation names what is actually stale: `skills and manifests here are from 0.1.14, acc is 0.1.15 - reinstall to refresh the bundle`. It says nothing about the runtime — `wired` speaks for that.
- A new per-adapter `bundleVersion` field carries the acc that wrote the skills and manifests, beside `wired` for the runner. They diverge only after an npm upgrade, and reporting both makes the divergence legible instead of hidden behind one reassuring number.

`docs/CLI.md` already described this behavior; only the message wording lagged.

## Upgrading

No store change — `SCHEMA_VERSION` and `STORE_VERSION` are unchanged since 0.1.14. `npm install -g agents-can-communicate@0.1.16 && acc install`.

## Record

```
PASS  agents-can-communicate-0.1.16.tgz  sha256 098a8f48…8a43a93e  built from 0b75f4e
      154 KB, 114 entries
      983 tests, 982 passing, 0 failing, 1 skipped
```

`verify-package.mjs` installs the tarball into a clean directory with **no workspace anywhere** and drives the product against it: doctor, a non-Git workspace, an install and its removal with client config restored byte for byte.

## Known and pre-existing

`tests/process/store-concurrency.test.mjs` can fail under heavy machine load with exit 5 `another writer holds the store lock` — the writer mutex's budget is a retry count rather than a wall-clock deadline. It predates this work (see PR #91), passed 0/3 in isolation on this branch, and belongs in its own change against `writer-mutex.mjs`.

Not published, not tagged. Both are external mutations and need approval, per `docs/RELEASING.md`.