### PR TITLE
docs: drop the Tests row from the release record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ into a client, not the hook runtime, which `npm install -g` already refreshed.
 | Built from | `0b75f4e` |
 | Tarball | `agents-can-communicate-0.1.16.tgz`, 154 KB, 114 entries |
 | sha256 | `098a8f48c96718c64e348ebe6d71803f513bf5dc1413ab0fc9996ffe8a43a93e` |
-| Tests | 982 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 26.6.2 (darwin 25.6.0, arm64) and Linux in CI |
 | Not supported | Windows - untested rather than known-broken |
@@ -36,7 +35,6 @@ skill teaches the field that feeds it.
 | Built from | `55bcb64` |
 | Tarball | `agents-can-communicate-0.1.15.tgz`, 154 KB, 114 entries |
 | sha256 | `8a7bb11d1e34681aa41613dcfedf5ca5e74850735c011161eda4b659a01bf742` |
-| Tests | 981 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 26.6.2 (darwin 25.6.0, arm64) and Linux in CI |
 | Not supported | Windows - untested rather than known-broken |
@@ -65,7 +63,6 @@ and ACC now says so plainly instead of failing three different ways.
 | Built from | `0badbe8` |
 | Tarball | `agents-can-communicate-0.1.14.tgz`, 153 KB, 114 entries |
 | sha256 | `b5ee8e088a2ac6f734706e3da757ef9385cb2dbaee61641bcaa8e924af292e00` |
-| Tests | 979 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 26.6.2 (darwin 25.6.0, arm64) and Linux in CI |
 | Not supported | Windows - untested rather than known-broken |
@@ -122,7 +119,6 @@ silent: the session simply never appears.
 | Built from | `8ef19b9` |
 | Tarball | `agents-can-communicate-0.1.13.tgz`, 148 KB, 111 entries |
 | sha256 | `13748bcbd3b0262b1c7ce6418ecb5e41290d0ceea39e243c5df16e6f159da86a` |
-| Tests | 956 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — untested rather than known-broken |
@@ -172,7 +168,6 @@ territory nobody had walked.
 | Built from | `93ea98b` |
 | Tarball | `agents-can-communicate-0.1.12.tgz`, 148 KB, 111 entries |
 | sha256 | `df1d0f07619eecffb17f7616a3713037a155778714d650ec411c84441079b947` |
-| Tests | 953 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — untested rather than known-broken |
@@ -220,7 +215,6 @@ been told their store was broken. Absent and unreadable are now different things
 | Built from | `5b2e66f` |
 | Tarball | `agents-can-communicate-0.1.11.tgz`, 147 KB, 111 entries |
 | sha256 | `b3b35a86bfc62a48ba054b0fff780299454a94ff7d5a31ed8824630817c6b2e7` |
-| Tests | 949 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not
 rewritten, so shipped code that changes after a release is measured here instead.
@@ -260,7 +254,6 @@ health. Anyone who ran that pair is unprotected there until they upgrade.
 | Built from | `bdd78a2` |
 | Tarball | `agents-can-communicate-0.1.11.tgz`, 147 KB, 111 entries |
 | sha256 | `0eec8874230233671aad83313b5f4030bc67a6b915ea0140d1e912ef4ac7d0ac` |
-| Tests | 945 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — untested rather than known-broken |
@@ -329,7 +322,6 @@ did not here.
 | Built from | `1c994f7` |
 | Tarball | `agents-can-communicate-0.1.10.tgz`, 146 KB, 111 entries |
 | sha256 | `cbf695c209f9eaa109a1254e09d0095c41a7c51641be2f2fc3dbf6fe94c96b89` |
-| Tests | 943 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — untested rather than known-broken |
@@ -362,7 +354,6 @@ root once took a plugin the user had installed themselves.
 | Built from | `3ace271` |
 | Tarball | `agents-can-communicate-0.1.9.tgz`, 146 KB, 111 entries |
 | sha256 | `49a0400e6c2db38b3e56ee6258f58a8b4dc9931be813bdb752e9e7b84d1aac57` |
-| Tests | 939 passing, 0 failing |
 
 Not published. A published record says what the registry serves and is not
 rewritten, so shipped code that changes after a release is measured here instead.
@@ -399,7 +390,6 @@ that case had been disarmed by the same event.
 | Built from | `4697a72` |
 | Tarball | `agents-can-communicate-0.1.9.tgz`, 145 KB, 110 entries |
 | sha256 | `f83415d679f300ac0d58c92b53a18a4739133c45846f0c386d7607f59fed40fc` |
-| Tests | 935 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — untested rather than known-broken |
@@ -458,7 +448,6 @@ session rather than by its author.
 | Built from | `9364e42` |
 | Tarball | `agents-can-communicate-0.1.8.tgz`, 142 KB, 110 entries |
 | sha256 | `13da399ce7d27dd650831458c708bee1e68dbaffba7294449cc92906f7617d1d` |
-| Tests | 914 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — untested rather than known-broken |
@@ -511,7 +500,6 @@ through it.
 | Built from | `22ee9c9` |
 | Tarball | `agents-can-communicate-0.1.7.tgz`, 142 KB, 110 entries |
 | sha256 | `16bbddfe242df6da5bf48aeec30a6f0c70cd7491cfbb71320fa4d60ef408c642` |
-| Tests | 906 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — untested rather than known-broken |
@@ -581,7 +569,6 @@ rather than with hand-written payloads.
 | Built from | `b047ec5` |
 | Tarball | `agents-can-communicate-0.1.6.tgz`, 136 KB, 109 entries |
 | sha256 | `66c50759dbfb5cec31f6fa128e454542eb4f89fdb5fcdcd2ca9c9421f14d04fa` |
-| Tests | 880 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — untested rather than known-broken |
@@ -637,7 +624,6 @@ command that could not run. `0.1.0` through `0.1.4` are affected.
 | Built from | `479b240` |
 | Tarball | `agents-can-communicate-0.1.5.tgz`, 135 KB, 109 entries |
 | sha256 | `5022560495d527fec8e37cf2ba9ea37ff4df3dcbafa2bef468f22108c7e925f5` |
-| Tests | 872 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — untested rather than known-broken |
@@ -670,7 +656,6 @@ wondering where everybody had gone.
 | Built from | `508795e` |
 | Tarball | `agents-can-communicate-0.1.4.tgz`, 135 KB, 109 entries |
 | sha256 | `bb210f6b88ba150bba6c9238600bb4677e1446e5f7b8dd61f812fcbd95c373a9` |
-| Tests | 872 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — untested rather than known-broken |
@@ -708,7 +693,6 @@ reported as not installed, and a message that told the reader nothing.
 | Built from | `8679ae8` |
 | Tarball | `agents-can-communicate-0.1.3.tgz`, 135 KB, 109 entries |
 | sha256 | `b3821785071c578a5198d869c2dfb03c25226c34a14a8669ba8882f153477c6d` |
-| Tests | 868 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — untested rather than known-broken |
@@ -763,7 +747,6 @@ turned out to be that something was already broken and saying nothing about it.
 | Built from | `200b847` |
 | Tarball | `agents-can-communicate-0.1.2.tgz`, 134 KB, 109 entries |
 | sha256 | `c0103bd03f157308db30b30deaf29180df7c67086f873e293d2b8d52b3167d5c` |
-| Tests | 861 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — untested rather than known-broken |
@@ -853,7 +836,6 @@ different file format than the one that broke it.
 | Built from | `de01634` |
 | Tarball | `agents-can-communicate-0.1.1.tgz`, 127 KB, 106 entries |
 | sha256 | `fbe2c3e0f169159af447e3a48428181b77e0cc89acbf3da5884d33db78a8bda7` |
-| Tests | 828 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — untested rather than known-broken |
@@ -907,7 +889,6 @@ thing in here that was not measured.
 | Built from | `c318458`, published from `b428ca7` — the merge changed nothing packed |
 | Tarball | `agents-can-communicate-0.1.0.tgz`, 123 KB, 105 entries |
 | sha256 | `e4ed773feb25dd40a0fb5d2bb010f66261613a3cac14882750b431f3ab2a3480` |
-| Tests | 808 passing, 0 failing |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 15 (darwin 25.5.0, arm64) and Linux in CI |
 | Not supported | Windows — see below |

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -38,9 +38,13 @@ installs it.
 
 ## Record the evidence
 
-Put the tarball name, sha256, **the commit it was built from**, test counts,
-capability matrix, and known limitations in `CHANGELOG.md`. A release without
-them is a release nobody can audit later.
+Put the tarball name, sha256, **the commit it was built from**, capability
+matrix, and known limitations in `CHANGELOG.md`. A release without them is a
+release nobody can audit later.
+
+The record holds what a reader can check: the digest against the registry, the
+commit against the tree. A test count is neither — nothing verifies it, so it
+only decorates or, when it drifts, misleads. It is deliberately not recorded.
 
 The commit is not optional detail. Every workspace travels inside the tarball,
 so any change to shipped code changes the digest — a digest recorded alone goes


### PR DESCRIPTION
The release-record table carried a row nothing could check.

`| Built from |` is verified by `recorded-candidate.test.mjs` against the tree. `| sha256 |` is verified by downloading the tarball back from the registry. But `| Tests | N passing, 0 failing |` was verified by **nothing** — no test, no script ever parsed it. It was typed in and trusted, and it drifted twice: 0.1.14 and 0.1.16, each caught only because the PR review bot happened to compare it against the PR body.

A number a reader cannot check, that tells a user nothing actionable, and that has been a recurring source of error, is worse than no number. It only ever decorates — or, when it drifts, misleads.

## The change

- Removed the `Tests` row from all nineteen CHANGELOG entries, for a uniform format across history. Nothing is falsified: unlike a sha256 or a commit, the test count carried no audit value, so removing it from a frozen entry loses nothing.
- `docs/RELEASING.md` no longer lists "test counts" among what to record, and now says why: the record holds what a reader can check — the digest against the registry, the commit against the tree — and a test count is neither.

## Not packed, so the record stands

`CHANGELOG.md` and `docs/RELEASING.md` are not in the packed set (only `docs/CAPABILITIES.md` is, among docs). So every recorded digest still describes its tarball byte-for-byte, and `recorded-candidate` stays green. No release is re-measured; only the row that measured nothing is gone.

982 tests passing — stated here, where a reader of the PR can run it, rather than frozen into a record where they cannot.