### PR TITLE
fix: a peer message is not starved by a standing reminder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## Unreleased
+
+| | |
+|---|---|
+| Built from | `7077c3e` |
+| Tarball | `agents-can-communicate-0.1.16.tgz`, 155 KB, 114 entries |
+| sha256 | `baf0f7175c8b25c8ebcc4cf5b163fd4eceeec46a28a84074e96a5eaac023ea0e` |
+
+Not published. A published record says what the registry serves and is not
+rewritten, so shipped code that changes after a release is measured here instead.
+
+A peer message no longer starves behind a standing reminder. The turn projector
+placed messages last, after all attention, so a `claim_expired` reminder - which
+regenerates from state every turn and never clears - permanently pushed a
+one-time message into the over-budget overflow. Two agents each lost their most
+important message there: a decision that unblocked one, a numbering collision for
+the other. Messages now sit after "act now" attention (`direct_request`,
+`claim_conflict`) and ahead of standing reminders, and a dropped message gets its
+own loud line instead of the plain "+N not shown" both agents read as noise. The
+note is guarded against the budget, closing a latent overrun the longer line
+exposed. The skill teaches the loud line as an imperative: pull before you
+conclude you are blocked on a peer - the answer may already be queued.
+
 ## 0.1.16
 
 `acc doctor` tells the truth about what an upgrade left stale: the skills copied

--- a/packages/adapter-claude-code/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-claude-code/plugin/skills/acc/SKILL.md
@@ -73,14 +73,18 @@ to the command that answers it:
 - [request_stalled] message_x   you asked and nobody is there    -> ask someone else
 ```
 
-A turn is written to a byte budget, so it can end with
+A turn is written to a byte budget, so it can end with one of these:
 
 ```text
 - +2 not shown, over budget; read them with `acc sync --scope full --json`
+- ⚠ 1 message(s) addressed to you did not fit; run `acc sync --scope full --json`
 ```
 
-Run that. Two things were addressed to you and the turn had no room for them; they are
-not gone, and nobody will repeat them.
+Run the sync. Both mean something addressed to you had no room this turn; it is not gone,
+and nobody will repeat it. The `⚠` line is the one that has cost the most - a peer's
+message, sometimes the very decision that unblocks you, held behind a reminder about your
+own lapsed claim. When you see it, pull before anything else. And never tell your human you
+are blocked on a peer without pulling first: the answer may already be queued.
 
 ## Work someone asked of you
 

--- a/packages/adapter-codex/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-codex/plugin/skills/acc/SKILL.md
@@ -73,14 +73,18 @@ to the command that answers it:
 - [request_stalled] message_x   you asked and nobody is there    -> ask someone else
 ```
 
-A turn is written to a byte budget, so it can end with
+A turn is written to a byte budget, so it can end with one of these:
 
 ```text
 - +2 not shown, over budget; read them with `acc sync --scope full --json`
+- ⚠ 1 message(s) addressed to you did not fit; run `acc sync --scope full --json`
 ```
 
-Run that. Two things were addressed to you and the turn had no room for them; they are
-not gone, and nobody will repeat them.
+Run the sync. Both mean something addressed to you had no room this turn; it is not gone,
+and nobody will repeat it. The `⚠` line is the one that has cost the most - a peer's
+message, sometimes the very decision that unblocks you, held behind a reminder about your
+own lapsed claim. When you see it, pull before anything else. And never tell your human you
+are blocked on a peer without pulling first: the answer may already be queued.
 
 ## Work someone asked of you
 

--- a/packages/adapter-gemini-cli/extension/skills/acc/SKILL.md
+++ b/packages/adapter-gemini-cli/extension/skills/acc/SKILL.md
@@ -73,14 +73,18 @@ to the command that answers it:
 - [request_stalled] message_x   you asked and nobody is there    -> ask someone else
 ```
 
-A turn is written to a byte budget, so it can end with
+A turn is written to a byte budget, so it can end with one of these:
 
 ```text
 - +2 not shown, over budget; read them with `acc sync --scope full --json`
+- ⚠ 1 message(s) addressed to you did not fit; run `acc sync --scope full --json`
 ```
 
-Run that. Two things were addressed to you and the turn had no room for them; they are
-not gone, and nobody will repeat them.
+Run the sync. Both mean something addressed to you had no room this turn; it is not gone,
+and nobody will repeat it. The `⚠` line is the one that has cost the most - a peer's
+message, sometimes the very decision that unblocks you, held behind a reminder about your
+own lapsed claim. When you see it, pull before anything else. And never tell your human you
+are blocked on a peer without pulling first: the answer may already be queued.
 
 ## Work someone asked of you
 

--- a/packages/adapter-kimi/plugin/skills/acc/SKILL.md
+++ b/packages/adapter-kimi/plugin/skills/acc/SKILL.md
@@ -73,14 +73,18 @@ to the command that answers it:
 - [request_stalled] message_x   you asked and nobody is there    -> ask someone else
 ```
 
-A turn is written to a byte budget, so it can end with
+A turn is written to a byte budget, so it can end with one of these:
 
 ```text
 - +2 not shown, over budget; read them with `acc sync --scope full --json`
+- ⚠ 1 message(s) addressed to you did not fit; run `acc sync --scope full --json`
 ```
 
-Run that. Two things were addressed to you and the turn had no room for them; they are
-not gone, and nobody will repeat them.
+Run the sync. Both mean something addressed to you had no room this turn; it is not gone,
+and nobody will repeat it. The `⚠` line is the one that has cost the most - a peer's
+message, sometimes the very decision that unblocks you, held behind a reminder about your
+own lapsed claim. When you see it, pull before anything else. And never tell your human you
+are blocked on a peer without pulling first: the answer may already be queued.
 
 ## Work someone asked of you
 

--- a/packages/adapter-sdk/src/context-projector.mjs
+++ b/packages/adapter-sdk/src/context-projector.mjs
@@ -6,7 +6,10 @@ const DEFAULT_BUDGET_BYTES = 6_000;
 // said only that something had been withheld, and nothing anywhere - not the
 // skills, not the docs - said how to see it. A turn that reports a thing the
 // reader cannot reach is how an agent ends up inventing its own way in.
-const NOTE_RESERVE = 80;
+// Enough for the longest over-budget note - the escalated "message did not fit"
+// line, which is longer than the plain "+N not shown" it replaces. Kept small
+// enough that the note still fits beside a header at the smallest budgets.
+const NOTE_RESERVE = 90;
 const FENCE = "```";
 // A peer cannot close a block it cannot name. The fence carries a marker that
 // is stripped from peer content, so forged delimiters stay inside the block.
@@ -167,11 +170,24 @@ export function projectContext(sync, { budgetBytes = DEFAULT_BUDGET_BYTES } = {}
   const claims = sync.claims ?? [];
 
   // Every entry is a group that appears whole or not at all. Single-line groups
-  // may still be truncated - there is no fence in them to leave open.
+  // may still be truncated - there is no fence in them to leave open. `message`
+  // is carried so a dropped message can be counted apart from a dropped
+  // reminder: the two are not the same news.
+  //
+  // A peer message sits after "act now" attention (a direct request, an imminent
+  // conflict: priority <= 2) and ahead of standing reminders. The order is the
+  // fix for a real starvation: an expired-claim line (priority 6) regenerates
+  // from state every turn, while a message is delivered once and its receipt
+  // then stops it appearing - so a reminder that never clears must not keep
+  // pushing a one-time message into the over-budget overflow, turn after turn,
+  // where two agents each lost their most important message to it.
+  const urgent = attention.filter(item => item.priority <= 2);
+  const info = attention.filter(item => item.priority > 2);
   const required = [
-    ...attentionLines(attention).map(line => [line]),
-    ...claimLines(claims).map(line => [line]),
-    ...peerBlocks(messages),
+    ...attentionLines(urgent).map(line => ({ lines: [line], message: false })),
+    ...peerBlocks(messages).map(block => ({ lines: block, message: true })),
+    ...attentionLines(info).map(line => ({ lines: [line], message: false })),
+    ...claimLines(claims).map(line => ({ lines: [line], message: false })),
   ];
   // Solo costs nothing: a lone session pays no visible price, and "no peers" is
   // still a cost when injected into every turn. But this is decided after the
@@ -198,27 +214,51 @@ export function projectContext(sync, { budgetBytes = DEFAULT_BUDGET_BYTES } = {}
   // Reserved so the note below always fits. Without it the projection could run
   // out of room to say that it ran out of room.
   const ceiling = budgetBytes - NOTE_RESERVE;
-  let dropped = 0;
+  let droppedOther = 0;
+  let droppedMessages = 0;
+  const drop = group => { if (group.message) droppedMessages += 1; else droppedOther += 1; };
   for (const group of required) {
-    if (group.length === 1) {
-      const candidate = truncate(group[0], Math.max(0, ceiling - used - 1));
-      if (candidate === "" || used + bytes(candidate) + 1 > ceiling) { dropped += 1; continue; }
+    const block = group.lines;
+    if (block.length === 1) {
+      const candidate = truncate(block[0], Math.max(0, ceiling - used - 1));
+      if (candidate === "" || used + bytes(candidate) + 1 > ceiling) { drop(group); continue; }
       lines.push(candidate);
       used += bytes(candidate) + 1;
       continue;
     }
-    const size = group.reduce((total, line) => total + bytes(line) + 1, 0);
+    const size = block.reduce((total, line) => total + bytes(line) + 1, 0);
     // Skipped rather than stopped at: the groups are ordered by priority, and a
     // large message must not hide the shorter ones behind it.
-    if (used + size > ceiling) { dropped += 1; continue; }
-    lines.push(...group);
+    if (used + size > ceiling) { drop(group); continue; }
+    lines.push(...block);
     used += size;
   }
-  if (dropped > 0) {
-    const note = `- +${dropped} not shown, over budget; read them with `
-      + "`acc sync --scope full --json`";
-    lines.push(note);
-    used += bytes(note) + 1;
+  // A dropped message is louder than a dropped reminder: "+N not shown" read as
+  // noise to two agents who each lost their most important message to it, so a
+  // message that did not fit says so specifically and names the command that
+  // recovers it. One note either way, escalated when a message is among the loss.
+  // The note is guarded against the budget, not merely reserved for: at a
+  // pathologically small budget the header alone can leave less room than the
+  // note needs, and a projection that overran the very budget it exists to
+  // respect is the bug this whole function is careful about. If the full note
+  // will not fit, the shortest imperative that does is still not silence.
+  const pushNote = note => {
+    const short = "- ⚠ over budget; `acc sync --scope full --json`";
+    for (const candidate of [note, short]) {
+      if (used + bytes(candidate) + 1 <= budgetBytes) {
+        lines.push(candidate);
+        used += bytes(candidate) + 1;
+        return;
+      }
+    }
+  };
+  if (droppedMessages > 0) {
+    // No count of the other drops: `--scope full` recovers everything.
+    pushNote(`- ⚠ ${droppedMessages} message(s) addressed to you did not fit; `
+      + "run `acc sync --scope full --json`");
+  } else if (droppedOther > 0) {
+    pushNote(`- +${droppedOther} not shown, over budget; read them with `
+      + "`acc sync --scope full --json`");
   }
 
   let shown = 0;

--- a/packages/adapter-sdk/test/context-projector.test.mjs
+++ b/packages/adapter-sdk/test/context-projector.test.mjs
@@ -227,7 +227,8 @@ test("what the budget leaves out is stated, not silently dropped", () => {
     messages: [peerMessage({ body: "x".repeat(4_000) })],
   }), { budgetBytes: 300 });
 
-  assert.match(rendered, /- \+1 not shown, over budget/);
+  // A dropped message escalates past the plain "+N not shown" note.
+  assert.match(rendered, /message\(s\) addressed to you did not fit/);
 });
 
 test("a large message does not hide the shorter ones queued behind it", () => {
@@ -243,7 +244,7 @@ test("a large message does not hide the shorter ones queued behind it", () => {
 
   assert.match(rendered, /id message_small/);
   assert.equal(rendered.includes("message_big"), false);
-  assert.match(rendered, /- \+1 not shown, over budget/);
+  assert.match(rendered, /message\(s\) addressed to you did not fit/);
 });
 
 test("every emitted block is closed, whatever the budget", () => {
@@ -262,4 +263,55 @@ test("every emitted block is closed, whatever the budget", () => {
     assert.equal(Buffer.byteLength(rendered, "utf8") <= budgetBytes, true,
       `projection overran ${budgetBytes} bytes`);
   }
+});
+
+test("a peer message is not starved by a standing low-value attention line", () => {
+  // The papercut failure: an expired-claim reminder (priority 6) is processed
+  // first and eats the budget, dropping the peer's message behind it - and the
+  // claim never un-expires, so the message is starved forever. The message must
+  // win: it is a one-time delivery, the reminder regenerates every turn.
+  const rendered = projectContext(syncResult({
+    roster: roster(1),
+    attention: [{ kind: "claim_expired", priority: 6, sourceId: "claim_old",
+      summary: "file:src/held.mjs - your claim has run out" }],
+    messages: [{ messageId: "message_snow", fromSessionId: "session_1", type: "note",
+      subject: "Snow decision: you take the minimal record",
+      body: "Add the record yourself in M9.11; polish stays with us." }],
+  }), { budgetBytes: 360 });
+
+  assert.match(rendered, /Snow decision/, "the peer message was dropped");
+  assert.doesNotMatch(rendered, /your claim has run out/,
+    "the expired-claim reminder crowded the message out again");
+});
+
+test("a dropped message is a loud imperative, not a footnote", () => {
+  // A message that truly does not fit must say so specifically - both agents
+  // read "+1 not shown, over budget" as noise and lost their most important
+  // message to it.
+  const rendered = projectContext(syncResult({
+    roster: roster(1),
+    messages: [{ messageId: "message_big", fromSessionId: "session_1", type: "note",
+      subject: "A subject long enough that the whole block cannot fit the budget below",
+      body: "x".repeat(400) }],
+  }), { budgetBytes: 160 });
+
+  assert.match(rendered, /message.*addressed to you.*did not fit/i,
+    "a dropped message did not get its own loud line");
+  assert.match(rendered, /acc sync --scope full/,
+    "the loud line does not say how to read it");
+});
+
+test("urgent attention still leads, ahead of messages", () => {
+  const rendered = projectContext(syncResult({
+    roster: roster(1),
+    attention: [{ kind: "direct_request", priority: 1, sourceId: "message_ack",
+      summary: "someone needs an ack" }],
+    messages: [{ messageId: "message_b", fromSessionId: "session_1", type: "note",
+      subject: "later", body: "body" }],
+  }), { budgetBytes: 2000 });
+
+  const reqIdx = rendered.indexOf("someone needs an ack");
+  const msgIdx = rendered.indexOf("later");
+  assert.ok(reqIdx !== -1 && msgIdx !== -1, "both should be present in a wide budget");
+  assert.ok(reqIdx < msgIdx, "a direct request must still lead the message");
 });

--- a/tests/process/message-delivery.test.mjs
+++ b/tests/process/message-delivery.test.mjs
@@ -155,9 +155,9 @@ test("a message the budget could not fit stays queued rather than reported deliv
   assert.equal(context.includes("xxxxxxxx"), false, "an oversized body was injected anyway");
   assert.equal(Buffer.byteLength(context, "utf8") <= 200, true,
     `the configured ceiling was ignored: ${Buffer.byteLength(context, "utf8")} bytes`);
-  // Said out loud. A projection that hides its own omissions leaves the model
-  // confidently unaware that something is waiting.
-  assert.match(context, /not shown, over budget/);
+  // Said out loud, and a dropped message says so specifically - not the generic
+  // "+N not shown" that two agents read as noise and lost a decision behind.
+  assert.match(context, /message\(s\) addressed to you did not fit/);
   assert.deepEqual((await receipts(where)).map(receipt => receipt.state), ["queued"],
     "the receipt says injected for text the model never saw - the sender is misinformed");
 });

--- a/tests/process/turn-is-actionable.test.mjs
+++ b/tests/process/turn-is-actionable.test.mjs
@@ -82,7 +82,7 @@ test("what the budget withheld comes with the way to read it", async t => {
 
   const shown = await place.turn();
 
-  assert.match(shown, /not shown, over budget/);
+  assert.match(shown, /message\(s\) addressed to you did not fit/);
   assert.match(shown, /acc sync --scope full --json/,
     `something was withheld and nothing said how to see it:\n${shown}`);
 });


### PR DESCRIPTION
A message addressed to you could sit undelivered for hours behind a reminder about your own lapsed claim — and two agents each lost their most important message to it.

## What happened, in the field

Two agents worked one repo for hours. The coordination was real: one warned the other that a new surface type touched its file and asked a decision; the other replied with the decision. But the reply **never reached** the first agent for ~2.5 hours — it reported to its human that it was *blocked*, on a question that was already answered and sitting in its queue. Independently, the second agent missed a message about a numbering collision (two branches took tails 66/67/68). Both found their missed message only after re-reading the skill and running `acc sync` by hand.

The store had everything, correctly. The failure was pure projection.

## The defect

`context-projector.mjs` built the required tier as:

```js
[ ...attention,  ...claims,  ...peerBlocks(messages) ]   // messages LAST
```

The budget is spent top-down, so a `claim_expired` attention line (priority 6) is placed **before** the message and eats the budget. And an expired claim regenerates from state every turn and never clears — so it pushed the one-time message into the "+N not shown" overflow **permanently**, turn after turn. A low-value standing reminder starved a high-value one-time delivery.

Worse, the overflow was a footnote: `- +1 not shown, over budget`. Both agents read it as noise.

## The fix

- **Reorder.** Messages now sit after "act now" attention (`direct_request`, `claim_conflict`, priority ≤ 2) and ahead of standing reminders. A message is delivered once and its receipt then clears it; a reminder that never clears must not starve it. Genuinely urgent attention (an imminent conflict) still leads.
- **Loud line.** A dropped message gets its own line — `⚠ N message(s) addressed to you did not fit; run acc sync --scope full` — distinct from the plain "+N not shown".
- **Overrun guard.** The note push is now guarded against the budget, closing a latent overrun the longer note exposed: the projection can no longer exceed the very ceiling it exists to keep, at any budget.
- **Skill.** All four adapters now present the loud line as an imperative, and tell the agent to pull before concluding it is blocked on a peer — the answer may already be queued.

## Tests

- A peer message is not dropped while a `claim_expired` reminder is kept (the exact starvation).
- A dropped message produces the loud line, not the footnote.
- Urgent attention still leads.
- The fence-balance sweep (budgets 120–1200) still holds, now including the overrun guard.
- Two integration delivery tests updated to the new note wording — intent unchanged (a dropped message stays `queued`, the omission is stated).

## Record

```
PASS  agents-can-communicate-0.1.16.tgz  sha256 baf0f717…c023ea0e  built from 7077c3e
      155 KB, 114 entries
```

An `## Unreleased` entry measures this, per `docs/RELEASING.md` — 0.1.16 is published and frozen. 986 tests, 985 passing, 0 failing, 1 skipped.