### PR TITLE
release: 0.1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,19 @@
 # Changelog
 
-## Unreleased
+## 0.1.17
+
+A peer message no longer starves behind a standing reminder. The turn a client
+injects put messages last, so a reminder about your own lapsed claim could hide
+a decision a peer sent you - which is exactly what happened to two agents.
 
 | | |
 |---|---|
-| Built from | `7077c3e` |
-| Tarball | `agents-can-communicate-0.1.16.tgz`, 155 KB, 114 entries |
-| sha256 | `baf0f7175c8b25c8ebcc4cf5b163fd4eceeec46a28a84074e96a5eaac023ea0e` |
-
-Not published. A published record says what the registry serves and is not
-rewritten, so shipped code that changes after a release is measured here instead.
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
+| Node | 24 (current production LTS) |
+| Verified on | macOS 26.6.2 (darwin 25.6.0, arm64) and Linux in CI |
+| Not supported | Windows - untested rather than known-broken |
 
 A peer message no longer starves behind a standing reminder. The turn projector
 placed messages last, after all attention, so a `claim_expired` reminder - which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ a decision a peer sent you - which is exactly what happened to two agents.
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `e6518cc` |
+| Tarball | `agents-can-communicate-0.1.17.tgz`, 155 KB, 114 entries |
+| sha256 | `4ccc3fd64aa218af977e864ba69344ccc788a5e665120c739f2dfbe18b200c2a` |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 26.6.2 (darwin 25.6.0, arm64) and Linux in CI |
 | Not supported | Windows - untested rather than known-broken |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -102,51 +102,51 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.1.16"
+      "version": "0.1.17"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.1.16"
+      "version": "0.1.17"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.1.16"
+      "version": "0.1.17"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.1.16"
+      "version": "0.1.17"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.1.16"
+      "version": "0.1.17"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.1.16"
+      "version": "0.1.17"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.1.16"
+      "version": "0.1.17"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.1.16"
+      "version": "0.1.17"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.1.16"
+      "version": "0.1.17"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.1.16"
+      "version": "0.1.17"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.1.16"
+      "version": "0.1.17"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.1.16"
+      "version": "0.1.17"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "type": "module",
   "description": "Local-first coordination for independently opened AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.mjs" },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
A peer message no longer starves behind a standing reminder.

## What it fixes

Two agents worked one repo for hours. The coordination was real — one warned the other that a new surface type touched its file and asked a decision; the other replied. But the reply never reached the first agent for ~2.5 hours: it told its human it was *blocked*, on a question already answered and sitting in its queue. A second agent independently missed a message about a numbering collision. Both found their missed message only after re-reading the skill and running `acc sync` by hand.

The store had everything, correctly. The failure was pure projection.

The turn projector built its required tier as `[ ...attention, ...claims, ...messages ]` — messages **last**. The budget is spent top-down, so a `claim_expired` reminder (priority 6) was placed before the message and ate the budget. An expired claim regenerates every turn and never clears, so it pushed the one-time message into the "+N not shown" overflow **permanently**.

## The change

- Messages now sit after "act now" attention (`direct_request`, `claim_conflict`) and ahead of standing reminders. A message is delivered once and its receipt then clears it; a reminder that never clears must not starve it.
- A dropped message gets its own loud line — `⚠ N message(s) addressed to you did not fit; run acc sync --scope full` — not the footnote both agents read as noise.
- The note push is guarded against the budget, closing a latent overrun the longer line exposed.
- All four adapter skills present the loud line as an imperative and tell the agent to pull before concluding it is blocked on a peer.

## Upgrading

No store change — `SCHEMA_VERSION` and `STORE_VERSION` unchanged since 0.1.14. `npm install -g agents-can-communicate@0.1.17 && acc install`. Running agents pick up the projector on their next turn; the new skill imperative needs a fresh session.

## Record

```
PASS  agents-can-communicate-0.1.17.tgz  sha256 4ccc3fd6…8b200c2a  built from e6518cc
      155 KB, 114 entries
      986 tests, 985 passing, 0 failing, 1 skipped
```

`verify-package.mjs` installs the tarball into a clean directory with **no workspace anywhere** and drives the product against it: doctor, a non-Git workspace, an install and its removal with client config restored byte for byte.

## Known and pre-existing

`tests/process/store-concurrency.test.mjs` can fail under heavy machine load with exit 5 `another writer holds the store lock` — the writer mutex's budget is a retry count rather than a wall-clock deadline. Predates this work (PR #91), its own change against `writer-mutex.mjs`.

Not published, not tagged. Both are external mutations and need approval, per `docs/RELEASING.md`.