### PR TITLE
docs: drop --dry-run from user-facing install docs

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -43,10 +43,8 @@ graph LR
 | Command | Does |
 |---|---|
 | `acc install` | Install adapters for the clients on this machine |
-| `acc install --dry-run` | Print the exact plan, change nothing |
 | `acc install --adapter kimi` | One client only |
 | `acc uninstall` | Remove what ACC wrote, keep what you edited — including for a client that has since left the machine |
-| `acc uninstall --dry-run` | Print exactly what would be removed, change nothing |
 | `acc doctor` | Clients, versions, install health, what to run next |
 | `acc doctor --repair` | Repair store state; refuses if it is ambiguous |
 | `acc config init` | Write `acc.workspace.json` after showing it |

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -16,10 +16,8 @@ Getting the `acc` binary itself: [README](../README.md#install). Then:
 
 <!-- test:command -->
 ```bash
-acc install --dry-run
+acc install
 ```
-
-Prints every path it would touch. Run without `--dry-run` to apply.
 
 It only installs for clients you actually have. Missing ones are listed with the reason.
 


### PR DESCRIPTION
## What

`--dry-run` is a debugging aid, not an onboarding step — a first-time user doesn't need it. This removes it from the docs a user actually reads:

- **`docs/GETTING_STARTED.md`** — the first install step is now `acc install` (was `acc install --dry-run`), and the "run without `--dry-run` to apply" note is gone.
- **`docs/CLI.md`** — dropped the two `--dry-run` reference-table rows (`acc install --dry-run`, `acc uninstall --dry-run`).

## Left untouched on purpose

- The `--dry-run` flag itself (`packages/cli/src/args.mjs`) and its tests — still there, still working.
- `CHANGELOG.md` — historical record.
- `docs/ADAPTER_AUTHORING.md` — a design-rationale mention aimed at adapter authors (developer-facing), not an end-user instruction.
- One `acc uninstall --dry-run` remains inside a `<!-- test:command -->` example block in `docs/CLI.md`; changing an executed block is a separate call and was out of scope here.

## Verification

`npm test` — all green (985 pass, 1 skip). The getting-started install step is an executed `<!-- test:command -->` block, so `tests/docs/commands.test.mjs` now runs a real `acc install` against its throwaway sandbox home and still asserts `ok: true`.
