### PR TITLE
release: 0.1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.1.18
 
 Grok is a first-class adapter. `acc install` writes `$GROK_HOME/hooks` and
 `$GROK_HOME/skills` (default `~/.grok`) and does not depend on a Claude Code
@@ -14,9 +14,9 @@ targeted inbox/reply path recovers and closes the exact message that matters.
 
 | | |
 |---|---|
-| Built from | `52a9500` |
-| Tarball | `agents-can-communicate-0.1.17.tgz`, 159 KB, 122 entries |
-| sha256 | `f482917525d4012c55c9fffcf13004286735d2953aa1f23a5abd2b4eee0ddacd` |
+| Built from | `PENDING` |
+| Tarball | `PENDING` |
+| sha256 | `PENDING` |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 26.6.2 (darwin 25.6.0, arm64) and Linux in CI |
 | Not supported | Windows - untested rather than known-broken |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ targeted inbox/reply path recovers and closes the exact message that matters.
 
 | | |
 |---|---|
-| Built from | `PENDING` |
-| Tarball | `PENDING` |
-| sha256 | `PENDING` |
+| Built from | `3ab46be` |
+| Tarball | `agents-can-communicate-0.1.18.tgz`, 159 KB, 122 entries |
+| sha256 | `5ede54cd894f41adc24089638356896e8284b95e4170ad6beede4753b88f386b` |
 | Node | 24 (current production LTS) |
 | Verified on | macOS 26.6.2 (darwin 25.6.0, arm64) and Linux in CI |
 | Not supported | Windows - untested rather than known-broken |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -108,55 +108,55 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.1.17"
+      "version": "0.1.18"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.1.17"
+      "version": "0.1.18"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.1.17"
+      "version": "0.1.18"
     },
     "packages/adapter-grok": {
       "name": "@agents-can-communicate/adapter-grok",
-      "version": "0.1.17"
+      "version": "0.1.18"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.1.17"
+      "version": "0.1.18"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.1.17"
+      "version": "0.1.18"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.1.17"
+      "version": "0.1.18"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.1.17"
+      "version": "0.1.18"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.1.17"
+      "version": "0.1.18"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.1.17"
+      "version": "0.1.18"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.1.17"
+      "version": "0.1.18"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.1.17"
+      "version": "0.1.18"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.1.17"
+      "version": "0.1.18"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "type": "module",
   "description": "Local-first coordination for independently opened AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-grok/package.json
+++ b/packages/adapter-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-grok",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.mjs" },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Grok is a first-class adapter, and coordination survives compaction without flooding the next context.

## What lands

Since 0.1.17 this is four merged changes, shipped as one package:

- **Grok** (`#104`). `acc install` writes `$GROK_HOME/hooks` and `$GROK_HOME/skills` (default `~/.grok`) and does not depend on a Claude Code plugin. Sessions attach as harness `grok`. Turn injection and write/shell guards stay false until captured on this client; `UserPromptSubmit` `additionalContext` is discarded on Grok 1.0.13.
- **Compact coordination** (`#102`). Client compaction used to run `SessionStart` again and attach a duplicate. The runner now resumes the bound generation. Ambient hooks show one compact trigger; `acc inbox` / `acc reply` recover and close the exact message. Delivery bookkeeping uses projector metadata rather than searching peer text for ids.
- **Docs rewrite** (`#103`). New information architecture (`docs/index.md`, glossary, on-ramp), threat model folded into the security model, planning notes under `docs/internal/`.
- **Note delivery** (`#100`). A delivered note gets one recoverable breadcrumb, and a note that reads like a question is nudged toward an answerable form.

## Upgrading

No store change — `SCHEMA_VERSION` and `STORE_VERSION` unchanged since 0.1.14. After this is tagged and published:

```
npm install -g agents-can-communicate@0.1.18 && acc install
```

Grok needs `acc install --adapter grok` (or a full `acc install`) so `$GROK_HOME` is wired. The new skill needs a fresh session; running agents pick up the hook runner on their next turn.

## Record

```
PASS  agents-can-communicate-0.1.18.tgz  sha256 5ede54cd894f41adc24089638356896e8284b95e4170ad6beede4753b88f386b  built from 3ab46be
      159 KB, 122 entries
```

`verify-package.mjs` installs the tarball into a clean directory with **no workspace anywhere** and drives the product against it: doctor, a non-Git workspace, and an install with its removal with client config restored byte for byte.

Pre-push on this branch: 1040 tests, 1039 passing, 0 failing, 1 skipped.

## Known and honest

Grok `beforeTurnInjection`, `beforeWrite`, and `beforeShell` remain `false`. Those capabilities need a live capture on this client; the adapter does not claim them.

Not tagged, not published. Both are external mutations and need a maintainer OTP after this merges, per `docs/RELEASING.md`.