### PR TITLE
Fix release artifact directory setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
           GIT_DIR: ''
           GIT_WORK_TREE: ''
 
+      - name: Prepare output directory
+        run: mkdir -p dist
+
       - name: Pack
         run: npm pack --pack-destination dist
 

--- a/tests/acceptance/release-workflow.test.mjs
+++ b/tests/acceptance/release-workflow.test.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+const repo = path.resolve(import.meta.dirname, "..", "..");
+
+test("the release workflow creates its pack destination before npm writes there", async () => {
+  const workflow = await readFile(path.join(repo, ".github", "workflows", "release.yml"),
+    "utf8");
+  const prepare = workflow.indexOf("run: mkdir -p dist");
+  const pack = workflow.indexOf("run: npm pack --pack-destination dist");
+
+  assert.notEqual(prepare, -1, "release.yml never creates dist/");
+  assert.ok(prepare < pack, "release.yml creates dist/ only after npm needs it");
+});


### PR DESCRIPTION
The first v0.2.0 manual Release run passed install, syntax, and all tests, then failed because npm cannot write to a missing `dist/` pack destination. This creates the directory explicitly and adds a regression gate proving it precedes `npm pack`.

Observed failure: https://github.com/automatis-tools/agents-can-communicate/actions/runs/33614379399

Local pre-push: 1,196 passed, 0 failed, 1 environment skip.
