### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## Unreleased
+## 0.3.0
+
+Claude Code sessions can now be reached while they are running. A peer's question arrives in
+an idle session without a human prompt, is answered through an explicit reply that becomes a
+real ACC record, and waits behind a turn that is already in progress rather than
+interrupting it. Codex's live-push claim is withdrawn in the same release: its transport
+works, but the mode that reaches it hides which workspace the session belongs to, and a
+session ACC cannot place must not be addressed. Both are the same rule applied honestly -
+delivery is claimed where it was observed and nowhere else.
 
 ACC now has one end-to-end engineering tour for readers who want to understand the system
 before trusting or extending it. It follows a real interaction from client startup and
@@ -140,18 +148,28 @@ That asymmetry, not either client, is the thing left to fix.
 
 | | |
 |---|---|
-| Built from | `577b0d8fdcf437bf594aee89b3fa20b23e08bbad` |
-| Tarball | `agents-can-communicate-0.2.0.tgz`, 253,550 bytes, 196 entries |
-| sha256 | `b509594ecc41863be928b08d7394cf6c791d025a5783b0a6e833bf7b01bf53fe` |
+| Built from | `9f2615fa403a50ed3ca81431179361e70f49619f` |
+| Tarball | `agents-can-communicate-0.3.0.tgz`, 253,715 bytes, 196 entries |
+| sha256 | `b558234ea050248dd461e2a753b2aaa0270d72166b617653de2968bdf1b53b18` |
 | Node | 26.5.1; package requires Node >=24 |
 | Verified on | macOS 26.6.2 (darwin 25.6.0, arm64) |
+| Native live delivery | Certified: Claude Code, anchored at 2.1.258 and captured again on 2.1.260 through the installed tarball. Withdrawn: Codex — the queue transport works and the mode reaching it hides the session's workspace |
+| Durable fallback | A killed transport left the next message queued on the durable path; an uncertified or unknown version keeps `acc inbox` |
+| Not supported | Windows — no capture, and the POSIX client probes do not certify it |
 
-Not published. The packed artifact contains `docs/HOW_IT_WORKS.md`; its README and
-documentation map link to it, and the clean-consumer verifier proves every packaged
-Markdown link resolves. The page separates the universal durable inbox, exact-version
-next-turn projection, and the currently uncertified native live-push seam instead of
-collapsing all three into “delivery.” It also names the shortest source-code path for
-auditing each claim.
+The working tree carried an untracked `docs/assets/` directory when this was packed, so
+`verify-package.mjs` printed its dirty warning. No tracked file was modified and nothing
+under that path is in the package allowlist, so the digest above is a true statement about
+`9f2615f`; it is recorded here rather than left for someone to rediscover.
+
+The packed artifact contains `docs/HOW_IT_WORKS.md`; its README and documentation map link
+to it, and the clean-consumer verifier proves every packaged Markdown link resolves. The
+page separates the universal durable inbox, exact-version next-turn projection, and the
+native live-push seam instead of collapsing all three into “delivery.” It also names the
+shortest source-code path for auditing each claim.
+
+Full commands, mutations, environment and limitations are in
+[the v0.3.0 release evidence](docs/release-evidence/v0.3.0.md).
 
 ## 0.2.0
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -47,7 +47,7 @@ else installs it.
 ## Record the evidence
 
 Put the tarball name, sha256, **the commit it was built from**, exact platform/client
-facts, fallback result, and known limitations in `docs/release-evidence/v0.2.0.md` and
+facts, fallback result, and known limitations in `docs/release-evidence/v0.3.0.md` and
 the current `CHANGELOG.md` release table. A release without them is a release nobody can
 audit later. Test count is deliberately left out: nothing verifies it, so it only
 decorates or, when it drifts, misleads.
@@ -80,6 +80,12 @@ For v0.2.0 neither Codex 0.152.0 nor Claude Code 2.1.252 did: the Codex control 
 absent and Claude stopped at the development-channel warning. Record those exact failed
 captures and run the packed inbox/next-turn fallback instead of promoting an unobserved
 native path. Windows is an explicit unsupported-platform skip, not a passing capture.
+
+By v0.3.0 that had gone both ways, which is the point of doing it per release rather than
+once. Claude Code passed and ships a live Channel; Codex's queue capture passed and the
+capability was **withdrawn anyway**, because the mode it needs hides which workspace the
+session belongs to, and a session that cannot be placed must not be addressed. A capture
+that works is not the same claim as a capability that is safe to ship.
 
 A published version's record is history and is not rewritten; later changes
 get a new `## Unreleased` entry at the top, checked the same way against the

--- a/docs/release-evidence/v0.3.0.md
+++ b/docs/release-evidence/v0.3.0.md
@@ -1,0 +1,148 @@
+# ACC v0.3.0 release evidence
+
+The release this version exists for is a live one: Claude Code sessions can be reached
+while they are running, and Codex's claim to the same thing is withdrawn. Both rest on
+captures taken from real clients through the installed tarball, and this document records
+how they were taken and what they do not cover.
+
+## Candidate identity
+
+| Fact | Value |
+|---|---|
+| Candidate commit | `9f2615fa403a50ed3ca81431179361e70f49619f` |
+| Tarball | `agents-can-communicate-0.3.0.tgz` |
+| Bytes | `253715` |
+| Entries | `196` |
+| sha256 | `b558234ea050248dd461e2a753b2aaa0270d72166b617653de2968bdf1b53b18` |
+| Bundled workspaces | `14`, all version `0.3.0` |
+| Node | `26.5.1`; the package requires `>=24` |
+| Platform | macOS `26.6.2`, darwin `25.6.0`, arm64 |
+
+```bash
+env NPM_CONFIG_CACHE=/private/tmp/acc-transparent-native-delivery-npm-cache npm pack
+node scripts/verify-package.mjs
+```
+
+Result: PASS — 196 non-forbidden entries, five certification manifests with exactly their
+referenced fixtures, every packed Markdown link resolving inside the tarball, fourteen
+bundled `0.3.0` workspaces, linked `acc`, `acc-hook` and `acc-mcp`, a coordination cycle in
+a workspace with no Git, no project state left behind, and a client home restored to its
+exact prior topology, bytes and modes with a second uninstall as a no-op.
+
+`verify-package.mjs` printed its dirty-tree warning. The working tree carried an untracked
+`docs/assets/` directory; no tracked file was modified and nothing under that path is in the
+package allowlist, so the digest describes the packed content of the candidate commit. It is
+recorded here rather than quietly discarded, because a warning that is explained is worth
+more than one that is suppressed.
+
+## What the real-client capture proved, and what it cost
+
+The plan's final step is a capture against the installed artifact rather than the worktree.
+It found **eleven** defects in shipped code. None were visible from the test suite in
+isolation; every one needed a real client and real timing.
+
+Seven were in the delivery path itself: `doctor` built its detection context with no shell
+so every zsh user read `unsupported_shell`; the Channel exited without answering
+`initialize` when no session was bound; it lost a sub-second race with the hook that writes
+its binding, permanently; it never renewed its endpoint lease; the handshake discarded the
+budget it was given; an idle session lost live delivery because the lease moved only on a
+turn and this client publishes no heartbeat; and the fix for that added a required field
+that made `acc status` refuse records the previous build had written.
+
+Four more came from the release capture proper:
+
+- **Codex native delivery withdrawn.** It requires `codex --remote unix://`, and in that
+  mode both the hook payload's `cwd` and the App Server's own thread record name the
+  daemon's directory rather than the session's. ACC placed a session in an unrelated
+  workspace and injected that workspace's peers into it. Nothing ACC can reach carries the
+  real one. Withdrawing it also repaired ordinary Codex use, because ACC was adding the flag
+  that caused it.
+- **Codex's diagnostic named a superseded reason** — the 0.152.0 capture's absent control
+  socket, which on 0.152.1 is present and working — sending operators to look for something
+  that is already there.
+- **The Channel could bind another session's identity.** It fell back to "if exactly one
+  session is live, it is mine"; a second client's Channel starts before its own binding
+  exists, and the bounded wait added for an earlier race locked that wrong answer in on the
+  first attempt. Both Channels registered under one client pid, live delivery died for the
+  session that had been working, and an `acc_reply` from the second window would have been
+  recorded as the first session's answer.
+- **`acc uninstall` reported edits it had not made** — six configuration files with
+  byte-identical content before and after.
+
+Every fix carries a mutation proof: the guarded behaviour was broken, the failure observed
+in the exact test named for it, and the code restored green.
+
+## Native delivery: Claude Code
+
+Two ordinary `claude` sessions, started by hand in one workspace, with the packed artifact
+installed into the real home. No wrapper, no `acc run`, no manual injection.
+
+| Branch | Result | How it was seen |
+|---|---|---|
+| idle | `offered` | delivered over `claude-channel` to a session at its prompt; answered with no human turn |
+| reply | `routed` | the answer is an ACC record whose `clientMessageId` is `channel-reply-<id>` — the Channel's own tool, not the CLI |
+| duplicate | `same_message_id` | the repeated send returned the same id and took the durable path, so the Channel was never asked to notify twice; exactly one answer came back |
+| busy | `queued_after_turn` | a 400-number counting turn ran to completion first; the session said so before answering |
+| fallback | `queued` | with the receiving Channel process killed, the next message was queued durably with `recipient_unavailable` |
+
+Recorded as `2.1.260`, which is the version the delivery events carry. The capture began on
+`2.1.259` — the run that exposed the Channel ownership defect — and the client updated
+itself before the verification run. The evidence sits beside the `2.1.258` anchor and is
+deliberately not a second anchor: an anchor is the minimum's proof, one per platform, and
+this contract has no maximum precisely so a newer stable client is admitted by probe and a
+generation-bound handshake. Two minor versions of drift, served without a capture at either
+of them, is that rule working.
+
+Two behaviours worth knowing, both measured rather than assumed:
+
+- a `note` to an `actionable` install is **not** pushed; it returns `delivery_disabled`,
+  because nothing about it needs acting on;
+- a recipient whose presence has gone `stale` is still reachable natively. Presence and
+  delivery are separate facts.
+
+## Hook certification: Gemini CLI re-captured at 0.57.0
+
+The certified tier named `0.37.0` while `0.57.0` was installed, so every capability resolved
+false on a machine where the mechanism worked — a session recorded as `advisory`/`manual`,
+and peers' messages left in the inbox when they could have been projected.
+
+Re-measured on `0.57.0`, all from one session so the payloads and the behaviour around them
+belong to the same run. The deny contract holds (`{"decision":"block"}` blocked both
+`write_file` and `run_shell_command`, no `AfterTool` followed, the workspace stayed empty),
+and so does the trap in it — the `hookSpecificOutput.permissionDecision` shape other clients
+honour still lets the write through.
+
+Injection was verified at the far end rather than at the hook: a marker returned as
+`additionalContext` was looked for in the request the client sent to its model, and arrived
+in 4 of 4 requests as the client's own `<hook_context>` part. A hook that prints an envelope
+proves only that it printed.
+
+`0.57.0` also brings this client's quietest failure so far. An untrusted folder does not
+fail — it prints an approval-mode downgrade and continues, and the downgraded toolset
+contains no write or shell tool, so a guard never fires and nothing names trust as the
+reason.
+
+Certifying the version people run necessarily takes the claim away from `0.37.0`. That
+capture stays in the repository and in provenance with its original digest.
+
+## Uninstall
+
+`acc uninstall` removed every ACC-owned byte from four client homes, took its PATH block out
+of `.zshrc`, and left the vendor daemon it never started running. Codex's own
+`[hooks.state]` `trusted_hash` tables are **kept** by design: a decision reversed in 0.1.11,
+because removing them makes the client run no hook at all while reporting it enabled, and
+ACC's write guard goes silently off.
+
+## Not covered
+
+- `darwin-x64`, Linux and Windows carry no native capture. Windows is an explicit
+  unsupported-platform skip.
+- No Gemini session has been driven by a live model; the account returns HTTP 403 in
+  headless mode, so the turn was completed against a local stand-in endpoint. Only the model
+  was stubbed — the client chose and really called both tools.
+- Kimi Code is not installed on the capture machine, so its `0.36.1` certification is
+  carried forward untouched and unverified by this release.
+- Grok's hooks remain uncaptured; it claims nothing.
+- The `duplicate` branch is evidence about ACC's own dedup and the absence of a second
+  native offer. Channel-level suppression of a notification the Channel was never asked to
+  send is not separately isolated.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -114,59 +114,59 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     "packages/adapter-grok": {
       "name": "@agents-can-communicate/adapter-grok",
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     "packages/delivery-router": {
       "name": "@agents-can-communicate/delivery-router",
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.2.0"
+      "version": "0.3.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "Local-first coordination for independently opened AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-gemini-cli/extension/gemini-extension.json
+++ b/packages/adapter-gemini-cli/extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Coordinate this Gemini CLI session with other AI agent sessions working in the same workspace.",
   "contextFileName": "skills/acc/SKILL.md"
 }

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-grok/package.json
+++ b/packages/adapter-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-grok",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/delivery-router/package.json
+++ b/packages/delivery-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/delivery-router",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.mjs" },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -164,28 +164,28 @@ async function main() {
     }
     ok("workspaces bundled");
     const manifest = await readTarJson(tarball, "package.json");
-    if (manifest.version !== "0.2.0") fail(`root version is ${manifest.version}, not 0.2.0`);
+    if (manifest.version !== "0.3.0") fail(`root version is ${manifest.version}, not 0.3.0`);
     if (!manifest.bundleDependencies?.includes("@agents-can-communicate/delivery-router")) {
       fail("delivery-router is not bundled; installed message commands cannot start");
     }
     for (const dependency of manifest.bundleDependencies) {
       const workspaceManifest = await readTarJson(tarball,
         `node_modules/${dependency}/package.json`);
-      if (workspaceManifest.version !== "0.2.0") {
-        fail(`${dependency} is ${workspaceManifest.version}, not 0.2.0`);
+      if (workspaceManifest.version !== "0.3.0") {
+        fail(`${dependency} is ${workspaceManifest.version}, not 0.3.0`);
       }
     }
     const geminiManifest = await readTarJson(tarball,
       "node_modules/@agents-can-communicate/adapter-gemini-cli/"
       + "extension/gemini-extension.json");
-    if (geminiManifest.version !== "0.2.0") {
-      fail(`embedded Gemini extension is ${geminiManifest.version}, not 0.2.0`);
+    if (geminiManifest.version !== "0.3.0") {
+      fail(`embedded Gemini extension is ${geminiManifest.version}, not 0.3.0`);
     }
     const codexPlugin = await readTarJson(tarball,
       "node_modules/@agents-can-communicate/adapter-codex/"
       + "plugin/.codex-plugin/plugin.json");
     if (codexPlugin.license !== "MIT") fail("shipped Codex plugin license is not MIT");
-    ok(`root and ${manifest.bundleDependencies.length} bundled workspaces are 0.2.0`);
+    ok(`root and ${manifest.bundleDependencies.length} bundled workspaces are 0.3.0`);
 
     step("install into a clean directory");
     await writeFile(path.join(consumer, "package.json"),
@@ -240,7 +240,7 @@ async function main() {
     }
     const installedKimi = JSON.parse(await readFile(path.join(kimiHome, "plugins", "managed",
       "agents-can-communicate", ".kimi-plugin", "plugin.json"), "utf8"));
-    if (installedKimi.version !== "0.2.0") fail("installed Kimi manifest is not 0.2.0");
+    if (installedKimi.version !== "0.3.0") fail("installed Kimi manifest is not 0.3.0");
 
     const removed = JSON.parse((await acc("uninstall", "--adapter", "kimi",
       "--home", clientHome)

--- a/tests/acceptance/cross-vendor-live.test.mjs
+++ b/tests/acceptance/cross-vendor-live.test.mjs
@@ -80,15 +80,15 @@ async function exchange(packed, { from, to, subject, body, answer, key }) {
   return { question, answer: response };
 }
 
-test("packed v0.2 completes cross-vendor fallback without human relay", {
+test("packed v0.3 completes cross-vendor fallback without human relay", {
   timeout: 120_000,
   skip: process.platform === "win32"
-    ? "v0.2 supports macOS/Linux; its native captures and POSIX client probes do not certify Windows"
+    ? "v0.3 supports macOS/Linux; its native captures and POSIX client probes do not certify Windows"
     : false,
 }, async t => {
   const packed = await createPackedAcc(t);
-  assert.equal(packed.manifest.version, "0.2.0");
-  assert.equal((await packed.acc(["version"])).version, "0.2.0");
+  assert.equal(packed.manifest.version, "0.3.0");
+  assert.equal((await packed.acc(["version"])).version, "0.3.0");
   await packed.setClientVersions(CAPTURE_VERSIONS);
 
   const claude = { adapterId: "claude_code", participantId: "claude_peer",
@@ -191,7 +191,7 @@ test("packed v0.2 completes cross-vendor fallback without human relay", {
     ".kimi-code/plugins/managed/agents-can-communicate/.kimi-plugin/plugin.json",
   ];
   for (const manifest of manifests) {
-    assert.equal((await readJson(path.join(packed.clientHome, manifest))).version, "0.2.0",
+    assert.equal((await readJson(path.join(packed.clientHome, manifest))).version, "0.3.0",
       `${manifest} was not stamped from the installed package`);
   }
 

--- a/tests/acceptance/cross-vendor.md
+++ b/tests/acceptance/cross-vendor.md
@@ -1,6 +1,6 @@
 # Cross-vendor communication acceptance
 
-This is the v0.2 release contract for two independently opened sessions. It tests
+This is the v0.3 release contract for two independently opened sessions. It tests
 communication semantics, not whether ACC can create or control either client.
 
 ## Activation event

--- a/tests/acceptance/packaging.test.mjs
+++ b/tests/acceptance/packaging.test.mjs
@@ -68,7 +68,7 @@ test("the tarball carries the workspaces where imports can find them", async t =
   const manifest = await manifestOf(tarball);
   const entries = await entriesOf(tarball);
 
-  assert.equal(manifest.version, "0.2.0");
+  assert.equal(manifest.version, "0.3.0");
   assert.equal((manifest.bundleDependencies ?? []).length > 0,
     true, "nothing is bundled, so every internal import would fail on install");
   assert.equal(manifest.bundleDependencies.includes(
@@ -83,7 +83,7 @@ test("the tarball carries the workspaces where imports can find them", async t =
   for (const dependency of manifest.bundleDependencies) {
     const workspace = JSON.parse((await run("tar", ["-xzOf", tarball,
       `package/node_modules/${dependency}/package.json`])).stdout);
-    assert.equal(workspace.version, "0.2.0", `${dependency} is not the v0.2 workspace`);
+    assert.equal(workspace.version, "0.3.0", `${dependency} is not the v0.3 workspace`);
   }
   const codexPlugin = JSON.parse((await run("tar", ["-xzOf", tarball,
     "package/node_modules/@agents-can-communicate/adapter-codex/"
@@ -92,7 +92,7 @@ test("the tarball carries the workspaces where imports can find them", async t =
   const geminiExtension = JSON.parse((await run("tar", ["-xzOf", tarball,
     "package/node_modules/@agents-can-communicate/adapter-gemini-cli/"
       + "extension/gemini-extension.json"])).stdout);
-  assert.equal(geminiExtension.version, "0.2.0",
+  assert.equal(geminiExtension.version, "0.3.0",
     "the embedded Gemini extension drifted from the release version");
 });
 


### PR DESCRIPTION
Cuts 0.3.0. A minor bump rather than a patch because this release both adds a capability and
takes one away: Claude Code gains native live delivery, Codex loses the live-push claim it
shipped with, and Gemini CLI's certified tier moves from a version nobody is running to the
one that is.

## Candidate

| | |
|---|---|
| Built from | `9f2615fa403a50ed3ca81431179361e70f49619f` |
| Tarball | `agents-can-communicate-0.3.0.tgz`, 253,715 bytes, 196 entries |
| sha256 | `b558234ea050248dd461e2a753b2aaa0270d72166b617653de2968bdf1b53b18` |
| Node | 26.5.1; package requires Node >=24 |
| Verified on | macOS 26.6.2 (darwin 25.6.0, arm64) |

`npm run check`, `npm test` (1385 tests, 1384 pass, 1 skip), `npm pack` and
`scripts/verify-package.mjs` against a clean consumer all pass. The two-commit protocol
holds: `9f2615f` carries every packed file, and the changelog table and evidence page are
recorded afterwards in unpacked files.

`verify-package.mjs` printed its dirty-tree warning because the working tree carried an
untracked `docs/assets/` directory. No tracked file was modified and nothing under that path
is in the package allowlist, so the digest describes the candidate commit. It is written
down in the changelog and the evidence page rather than suppressed.

## Version literals

The release-version literals in the packed acceptance tests and in `verify-package.mjs` are
updated by hand. A check that reads the version from the artifact it is checking cannot tell
you whether the artifact is the one you meant to ship, so cutting a release stays a
deliberate act.

## Evidence

`docs/release-evidence/v0.3.0.md` records the real-client captures behind the claims - all
five delivery branches for Claude Code through the installed tarball, Gemini CLI
re-certified at 0.57.0 with injection verified in the request the client sent to its model -
and, just as explicitly, what the release does not cover: no Linux or Windows capture, no
Gemini session driven by a live model, Kimi carried forward unverified by this release.