### PR TITLE
Publishing auth, and the Linux CI failure that pre-dates it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## Unreleased
+
+`docs/RELEASING.md` now says how publishing here is actually authenticated. It claimed every
+publish needs a two-factor code, on the strength of what `npm profile get` once reported.
+Publishing 0.3.0 needed no code, and that same command now answers `403 Forbidden` on the
+account's own profile - which is the diagnosis rather than a separate puzzle: a credential
+that can publish but cannot read its own profile is a token, and a token with write access
+bypasses two-factor entirely. Both commands are written down together, because the pair is
+what tells you which route a machine is on. It also records the part with a deadline - npm
+now warns that tokens bypassing 2FA are being restricted for direct publishing, so the route
+that made this release possible is going away - and the habit that kept 0.3.0 honest:
+publish the tarball by name, because a bare `npm publish` repacks and sends the registry an
+artifact nobody verified.
+
+| | |
+|---|---|
+| Built from | `2d6b113747ab458f96400b47516e1eac2f4161be` |
+| Tarball | `agents-can-communicate-0.3.0.tgz`, 254,217 bytes, 196 entries |
+| sha256 | `9e6f93b6ea823f3b202cb20e340f270d33472da1d26a4d49196c4b4751524720` |
+| Node | 26.5.1; package requires Node >=24 |
+| Verified on | macOS 26.6.2 (darwin 25.6.0, arm64) |
+
+Not published. The published 0.3.0 artifact is the one recorded in its own section below;
+this candidate carries a documentation change only.
+
 ## 0.3.0
 
 Claude Code sessions can now be reached while they are running. A peer's question arrives in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+Two tests wrote down facts about the machine that ran them as if those facts were universal,
+and CI had been red since 0.3.0's feature merge because of it - through the release, which
+went out with a red matrix nobody had looked at.
+
+One asserted that installing with `--delivery actionable` reports native delivery wired.
+Native delivery is captured on `darwin-arm64` and nowhere else, so on Linux the install
+correctly reports it off. It is now two tests instead of a skip, because the second is worth
+having on its own: a platform with no capture must be told so and have **nothing** wired -
+no channel entry, no launch shim carrying the native flag - which is the rule the whole
+contract exists for, and is only checkable where there is no capture.
+
+The other bound a fake Codex control socket under the temporary directory. macOS caps a Unix
+socket path at 104 bytes; the client dictates a 42-byte suffix, and a macOS runner's
+temporary directory is about 47 more, so binding failed with a bare `listen EINVAL` that
+named nothing. Measured: 113 bytes on CI against 61 for the replacement. The socket now
+lives under a short base, as the Channel already does for this reason, and the length is
+asserted before binding so the next path that grows says why it broke.
+
+Both passed locally and only failed elsewhere, which is the point: a suite run on one
+machine cannot see them, and the platform matrix is what does.
+
 `docs/RELEASING.md` now says how publishing here is actually authenticated. It claimed every
 publish needs a two-factor code, on the strength of what `npm profile get` once reported.
 Publishing 0.3.0 needed no code, and that same command now answers `403 Forbidden` on the
@@ -16,7 +37,7 @@ artifact nobody verified.
 
 | | |
 |---|---|
-| Built from | `2d6b113747ab458f96400b47516e1eac2f4161be` |
+| Built from | `ea31740f6121f6362cc3b1ceffbc70ab7c45b4fc` |
 | Tarball | `agents-can-communicate-0.3.0.tgz`, 254,217 bytes, 196 entries |
 | sha256 | `9e6f93b6ea823f3b202cb20e340f270d33472da1d26a4d49196c4b4751524720` |
 | Node | 26.5.1; package requires Node >=24 |

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -96,19 +96,48 @@ current tree.
 Publishing, tagging, and cutting a GitHub release are **external mutations**.
 They need explicit approval from the maintainer, every time.
 
-With two-factor authentication set to `auth-and-writes` — which is what `npm
-profile get` reports for this account — every publish needs a code, and npm
-does not prompt for one:
+Which credential is configured decides whether a code is needed, so check
+rather than assume. Publishing v0.3.0 needed no code at all:
+
+```bash
+npm publish agents-can-communicate-0.3.0.tgz   # no --otp; it succeeded
+npm profile get                                # 403 Forbidden on /-/npm/v1/user
+```
+
+That pair is the whole diagnosis. A credential that can publish but cannot read
+the account's own profile is a token rather than an interactive login, and a
+token with write access bypasses two-factor entirely. This page previously said
+every publish needs a code, which sent the next release looking for one it did
+not need.
+
+With an interactive login and two-factor set to `auth-and-writes`, a code *is*
+required and npm does not prompt for it:
 
 ```bash
 npm publish --otp=123456
 ```
 
-An npm *Automation* token, or a granular token with write access, publishes
-without a code. A granular token scoped to selected packages cannot create a
-package that does not exist yet, which is the case exactly once per package.
-The `Release` workflow builds and verifies a candidate and uploads it as an
-artifact; it does not publish.
+Publish the tarball by name rather than bare `npm publish`. A bare publish
+repacks, and what reaches the registry is then an artifact nobody verified; the
+file named above is the one the digest and the evidence page describe. After
+publishing, compare `npm view <pkg>@<version> dist.shasum` with `shasum` of the
+local file — they must be equal, and the registry can take a few minutes to
+answer at all.
+
+A granular token scoped to selected packages cannot create a package that does
+not exist yet, which is the case exactly once per package. The `Release`
+workflow builds and verifies a candidate and uploads it as an artifact; it does
+not publish.
+
+**This route has an expiry.** npm now prints, on any authenticated command:
+
+> npm tokens that bypass 2FA are being restricted for account changes and
+> direct publishing
+
+So the token that made the v0.3.0 publish possible without a code is on a path
+to being refused. Worth settling before it turns a release into an outage:
+either move publishing to a trusted-publisher workflow, or accept the
+interactive login and its code.
 
 ---
 

--- a/packages/adapter-codex/test/native-delivery.test.mjs
+++ b/packages/adapter-codex/test/native-delivery.test.mjs
@@ -11,13 +11,23 @@ import { bindNativeSession, offerMessage, planNativeActivation, probeNativeDeliv
 const THREAD = "01a063ed-a384-7fe2-b443-7fedf1593f6b";
 const CWD = "/work/capture";
 
+// macOS caps a Unix socket path at 104 bytes, and this one carries a suffix the
+// client dictates: `app-server-control/app-server-control.sock` is 42 bytes on
+// its own. A macOS runner's TMPDIR is around 48
+// (`/var/folders/../T/`), so binding under it fails with a bare `EINVAL` -
+// which passed on a laptop with a short TMPDIR and failed on CI. The product
+// keeps its own sockets in a short private directory for exactly this reason.
+const shortTmp = () => (process.platform === "win32" ? tmpdir() : "/tmp");
+
 // A CODEX_HOME whose control socket really is a Unix socket, so socketReady
 // passes; the App Server client itself is injected as a fake peer.
 function codexHome(t) {
-  const home = mkdtempSync(path.join(tmpdir(), "acc-codex-home-"));
+  const home = mkdtempSync(path.join(shortTmp(), "acc-cx-"));
   const dir = path.join(home, "app-server-control");
   mkdirSync(dir, { recursive: true });
   const socketPath = path.join(dir, "app-server-control.sock");
+  assert.ok(Buffer.byteLength(socketPath) < 104,
+    `socket path is too long for this platform: ${socketPath}`);
   const server = net.createServer();
   const listening = new Promise(resolve => server.listen(socketPath, resolve));
   t.after(() => { server.close(); rmSync(home, { recursive: true, force: true }); });

--- a/tests/process/claude-native-delivery.test.mjs
+++ b/tests/process/claude-native-delivery.test.mjs
@@ -45,7 +45,22 @@ const run = (place, args) => import("node:child_process").then(({ execFile }) =>
     { env: place.env }, (error, stdout, stderr) =>
       error ? reject(Object.assign(error, { stdout, stderr })) : resolve({ stdout, stderr }))));
 
-test("an eligible live install writes a channel .mcp.json pointing at packed binaries", async t => {
+/**
+ * Native delivery is captured on `darwin-arm64` and nowhere else, so eligibility
+ * is a property of the machine running this file. Written as one test that
+ * assumed a capture, it passed on the author's laptop and failed on Linux CI -
+ * which is how it was found, after the release had already gone out.
+ *
+ * So it is two tests rather than a skip. Where there is a capture, the install
+ * wires the channel. Where there is none, it must say so and wire nothing at
+ * all, which is the rule that actually matters - an uncaptured platform must
+ * never be promoted to a native path - and it is only checkable off darwin.
+ */
+const CAPTURED_PLATFORM = process.platform === "darwin" && process.arch === "arm64";
+
+test("an eligible live install writes a channel .mcp.json pointing at packed binaries", {
+  skip: CAPTURED_PLATFORM ? false : "native delivery is captured on darwin-arm64 only",
+}, async t => {
   const place = await machine(t);
   const installed = await run(place, ["install", "--adapter", "claude_code", "--delivery",
     "actionable", "--home", place.home]);
@@ -69,6 +84,35 @@ test("an eligible live install writes a channel .mcp.json pointing at packed bin
   assert.match(await readFile(shim, "utf8"), /dangerously-load-development-channels/);
   await run(place, ["uninstall", "--adapter", "claude_code", "--home", place.home]);
   await assert.rejects(readFile(source), { code: "ENOENT" });
+});
+
+test("a platform with no capture is told so, and no channel is wired", {
+  skip: CAPTURED_PLATFORM ? "this platform has a passing capture" : false,
+}, async t => {
+  const place = await machine(t);
+  const installed = await run(place, ["install", "--adapter", "claude_code", "--delivery",
+    "actionable", "--home", place.home]);
+
+  // Asking for `actionable` on an uncaptured platform is not an error and not a
+  // silent downgrade: the install happens, and it says which delivery the
+  // machine actually gets.
+  assert.doesNotMatch(installed.stdout, /native delivery is wired/i,
+    "an uncaptured platform was told a native path had been wired");
+  assert.match(installed.stdout, /native delivery is off/i,
+    "the downgrade was applied without saying so");
+  assert.match(installed.stdout, /acc inbox|next-turn/i,
+    "the downgrade did not name what is left");
+
+  // The claim and the artefact have to agree. A channel wired here would be a
+  // native path on a platform nobody captured, which is the exact thing the
+  // whole contract exists to refuse.
+  const source = path.join(place.home, ".claude", "plugins", "marketplaces", "acc-local",
+    "agents-can-communicate", ".mcp.json");
+  await assert.rejects(readFile(source), { code: "ENOENT" },
+    "a channel was wired on a platform with no passing capture");
+  const shim = path.join(place.dataHome, "acc", "bin", "claude");
+  await assert.rejects(readFile(shim), { code: "ENOENT" },
+    "a launch shim carrying the native flag was written with nothing to bind to");
 });
 
 test("a message is durably recorded before a native offer, and an explicit reply is a real answer",

--- a/tests/process/codex-native-delivery.test.mjs
+++ b/tests/process/codex-native-delivery.test.mjs
@@ -12,12 +12,20 @@ import { acceptKey, decodeFrames, encodeFrame } from "../../packages/adapter-cod
 
 const THREAD = "01a063ed-a384-7fe2-b443-7fedf1593f6b";
 
+// macOS caps a Unix socket path at 104 bytes, and the client dictates a 42-byte
+// suffix here: `app-server-control/app-server-control.sock`. A macOS runner's
+// TMPDIR is around 48 (`/var/folders/../T/`), so binding under it fails with a
+// bare `EINVAL` - which passed on a laptop with a short TMPDIR and failed on CI.
+const shortTmp = () => (process.platform === "win32" ? tmpdir() : "/tmp");
+
 // A fake daemon at the real control-socket path under a temp CODEX_HOME, so the
 // adapter's own socket discovery and WebSocket client are exercised end to end.
 async function daemon(t, { cwd }) {
-  const home = await realpath(await mkdtemp(path.join(tmpdir(), "acc-codex-nd-")));
+  const home = await realpath(await mkdtemp(path.join(shortTmp(), "acc-cx-nd-")));
   await mkdir(path.join(home, "app-server-control"), { recursive: true });
   const socketPath = path.join(home, "app-server-control", "app-server-control.sock");
+  assert.ok(Buffer.byteLength(socketPath) < 104,
+    `socket path is too long for this platform: ${socketPath}`);
   const server = http.createServer((request, response) => response.writeHead(404).end());
   const state = { queue: [] };
   const sockets = new Set();


### PR DESCRIPTION
Two things, one of which is urgent: **CI has been red on `main` since #109 merged**, and the
0.3.0 release went out with it red.

## The CI failure

`tests/process/claude-native-delivery.test.mjs` asserted that installing with
`--delivery actionable` reports `native delivery is wired`. Native delivery is captured on
`darwin-arm64` and nowhere else, so on Linux the install correctly reports it **off** — the
test encoded the author's laptop as if it were every machine. Local `npm test` on macOS
cannot see this; the platform matrix is what covers it, and nobody looked at it before
merging.

It becomes two tests rather than a skip, because the second is worth having on its own: on a
platform with no capture the install must say so and wire **nothing** — no channel entry, no
launch shim carrying the native flag. That is the rule the whole native contract exists for,
and it is only checkable where there is no capture.

The absence assertions were checked against the code rather than assumed:
`plan.mjs` computes `effectiveLivePolicy = liveDeliverySupported ? delivery : "off"`,
`apply.mjs` hands that to the adapter, and the adapter writes the channel entry only for a
live policy. Linux CI on this PR is what confirms it.

## The documentation correction

`docs/RELEASING.md` claimed every publish needs a two-factor code. Publishing v0.3.0 needed
none, so the page was sending the next release looking for something it does not have. The
diagnosis is a pair of commands, now recorded together:

```bash
npm publish agents-can-communicate-0.3.0.tgz   # no --otp; it succeeded
npm profile get                                # 403 Forbidden on /-/npm/v1/user
```

A credential that can publish but cannot read its own account profile is a token rather than
an interactive login, and a token with write access bypasses two-factor entirely. The
`--otp` instructions stay for the interactive case, which is still real.

Two additions the old text did not have:

- **Publish the tarball by name.** A bare `npm publish` repacks, and what reaches the
  registry is then an artifact nobody verified. Comparing `dist.shasum` against the local
  file afterwards is what turns that from an intention into a check — it is how v0.3.0 was
  confirmed.
- **This route has an expiry.** npm now warns on every authenticated command that tokens
  bypassing 2FA are being restricted for direct publishing.

## Candidate

| | |
|---|---|
| Built from | `2d6b113747ab458f96400b47516e1eac2f4161be` |
| Tarball | `agents-can-communicate-0.3.0.tgz`, 254,217 bytes, 196 entries |
| sha256 | `9e6f93b6ea823f3b202cb20e340f270d33472da1d26a4d49196c4b4751524720` |

`tests/` is not packed, so the test fix does not move that digest. `npm run check` and
`npm test` pass locally (1386 tests, 1384 pass, 2 skipped — one of them the new test, which
runs only off darwin-arm64).