### PR TITLE
release: ACC v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.3.1
 
 The one question a new user is asked is now a decision rather than a manifest. It opened
 with `Enable native live delivery for Claude Code 2.1.260?` over internal artefact names -
@@ -84,14 +84,18 @@ as history rather than generalized into current npm credential advice.
 
 | | |
 |---|---|
-| Built from | `b6710270d2de9eacbabbcce5222d100840f49be5` |
-| Tarball | `agents-can-communicate-0.3.0.tgz`, 256,238 bytes, 196 entries |
-| sha256 | `8edcdd9de4dcc7619f839f22e492b3628fde835cd509f4c2482d44c18671066b` |
+| Built from | `bb15eca373b194019372dd4e08b35de247c0bc4b` |
+| Tarball | `agents-can-communicate-0.3.1.tgz`, 256,236 bytes, 196 entries |
+| sha256 | `2de2aa9f55053baac078d181423984ee2e91660b7945ad8f8bbba7b2ddcbbb0a` |
 | Node | 26.5.1; package requires Node >=24 |
 | Verified on | macOS 26.6.2 (darwin 25.6.0, arm64) |
+| Native live delivery | Not re-captured. `cli/src/install-command.mjs` and `core/src/conversations.mjs` are the only shipped `src/` files that changed since `v0.3.0`, and neither is transport, so 0.3.0's Claude Code certification and its Codex withdrawal still describe what ships here |
+| Durable fallback | Exercised through the installed tarball: a full coordination cycle in a workspace with no Git, leaving nothing behind in the project |
+| Not supported | Windows - still no capture, and the POSIX client probes do not certify it |
 
-Not published. The published 0.3.0 artifact is the one recorded in its own section below;
-this candidate carries a documentation change only.
+The tree was clean at `bb15eca`, so `verify-package.mjs` printed no dirty warning. It was
+given the saved tarball rather than the tree and therefore reported `revision unknown`; the
+candidate commit above was captured while the tree was clean immediately before packing.
 
 ## 0.3.0
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,7 +1,7 @@
 # Releasing
 
 Use this procedure to build one auditable npm artifact, verify that exact tarball, and keep
-its evidence tied to the commit that supplied its bytes. The package is currently `0.3.0`;
+its evidence tied to the commit that supplied its bytes. The package is currently `0.3.1`;
 the commands derive the version from `package.json` so the filename cannot drift.
 
 ```mermaid

--- a/docs/release-evidence/v0.3.1.md
+++ b/docs/release-evidence/v0.3.1.md
@@ -1,0 +1,80 @@
+# ACC v0.3.1 release evidence
+
+This release carries no new capability capture, and says so plainly. What it changes is what
+a person reads and what a peer name resolves to: the one consent question asked at install,
+the way `--to` accepts the name of a client, and the documentation that had been describing
+three different products at once. The transport that 0.3.0 certified is byte-identical here,
+so this document records what was verified now and what is carried forward unretested.
+
+## Candidate identity
+
+| Fact | Value |
+|---|---|
+| Candidate commit | `bb15eca373b194019372dd4e08b35de247c0bc4b` |
+| Tarball | `agents-can-communicate-0.3.1.tgz` |
+| Bytes | `256236` |
+| Entries | `196` |
+| sha256 | `2de2aa9f55053baac078d181423984ee2e91660b7945ad8f8bbba7b2ddcbbb0a` |
+| Bundled workspaces | `14`, all version `0.3.1` |
+| Node | `26.5.1`; the package requires `>=24` |
+| npm | `11.17.0` |
+| Platform | macOS `26.6.2`, darwin `25.6.0`, arm64 |
+
+```bash
+npm pack --pack-destination "$candidate_dir"
+node scripts/verify-package.mjs "$candidate_dir/agents-can-communicate-0.3.1.tgz"
+```
+
+Result: PASS, exit `0` — 196 non-forbidden entries, five certification manifests with
+exactly their referenced fixtures, every packed Markdown link resolving inside the tarball,
+fourteen bundled `0.3.1` workspaces, linked `acc`, `acc-hook` and `acc-mcp`, five adapters
+reported by doctor, a coordination cycle in a workspace with no Git, no project state left
+behind, and a client home restored to its exact prior topology, bytes and modes with a
+second uninstall as a no-op.
+
+The tree was clean when this was packed, so the verifier printed no dirty-tree warning. It
+was handed the saved tarball rather than the working tree and therefore reported
+`revision unknown`; the candidate commit above was captured from a clean tree immediately
+before packing, which is what ties those bytes to that commit.
+
+## What actually changed in shipped code
+
+Two source files, and nothing else under `packages/*/src/` or `bin/`:
+
+- `packages/cli/src/install-command.mjs` — the native-delivery consent question. It had
+  opened with internal artefact names and never said what the reader lives with, which is
+  that the client will ask to allow development channels at every start.
+- `packages/core/src/conversations.mjs` — a `--to` name matching no participant is now tried
+  as a client name. One live session of that client resolves; two refuse and name them; an
+  exact participant id is never overruled.
+
+Alongside them, the five `SKILL.md` files each name a peer client rather than their own, and
+the entry documentation was rewritten. Skills and documentation are packed, so they belong
+to this artifact even though they run no code.
+
+## Carried forward from 0.3.0, unretested here
+
+No file under `packages/adapter-claude-code/src/`, `packages/delivery-router/src/`,
+`packages/hook-runner/src/` or `bin/` differs from `v0.3.0`. The native transport, the
+durable queue and the hook entry points are therefore the same bytes that 0.3.0 certified,
+and this release makes no new claim about them:
+
+- Claude Code native live delivery stays anchored at its captured `darwin-arm64` minimum,
+  with the per-session handshake and the vendor development-channel warning unchanged.
+- Codex live delivery remains withdrawn; its queue capture stands, and the mode that would
+  reach it still hides the session's workspace identity.
+- Gemini CLI's hook certification at `0.57.0` and Kimi Code's at `0.36.1` are carried
+  forward untouched.
+
+Carried forward is not re-verified. A reader who needs a fresh capture should take one; the
+procedure is in [Releasing](../RELEASING.md).
+
+## Not covered
+
+- No real-client session was driven for this release. The consent question's new wording was
+  exercised by the suite, not by a person installing into a live client.
+- `darwin-x64`, Linux and Windows still carry no native capture. Windows remains an explicit
+  unsupported-platform skip.
+- Client-name addressing was verified by unit and acceptance tests, including the gate that
+  checks every `--to` in the documentation and the skills. It was not exercised between two
+  live vendor clients as part of this release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -114,59 +114,59 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     "packages/adapter-grok": {
       "name": "@agents-can-communicate/adapter-grok",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     "packages/delivery-router": {
       "name": "@agents-can-communicate/delivery-router",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.3.0"
+      "version": "0.3.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "Local-first coordination for independently opened AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-gemini-cli/extension/gemini-extension.json
+++ b/packages/adapter-gemini-cli/extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Coordinate this Gemini CLI session with other AI agent sessions working in the same workspace.",
   "contextFileName": "skills/acc/SKILL.md"
 }

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-grok/package.json
+++ b/packages/adapter-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-grok",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/delivery-router/package.json
+++ b/packages/delivery-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/delivery-router",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
-  "exports": { ".": "./src/index.mjs" },
+  "exports": {
+    ".": "./src/index.mjs"
+  },
   "files": [
     "src/"
   ]

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -164,28 +164,28 @@ async function main() {
     }
     ok("workspaces bundled");
     const manifest = await readTarJson(tarball, "package.json");
-    if (manifest.version !== "0.3.0") fail(`root version is ${manifest.version}, not 0.3.0`);
+    if (manifest.version !== "0.3.1") fail(`root version is ${manifest.version}, not 0.3.1`);
     if (!manifest.bundleDependencies?.includes("@agents-can-communicate/delivery-router")) {
       fail("delivery-router is not bundled; installed message commands cannot start");
     }
     for (const dependency of manifest.bundleDependencies) {
       const workspaceManifest = await readTarJson(tarball,
         `node_modules/${dependency}/package.json`);
-      if (workspaceManifest.version !== "0.3.0") {
-        fail(`${dependency} is ${workspaceManifest.version}, not 0.3.0`);
+      if (workspaceManifest.version !== "0.3.1") {
+        fail(`${dependency} is ${workspaceManifest.version}, not 0.3.1`);
       }
     }
     const geminiManifest = await readTarJson(tarball,
       "node_modules/@agents-can-communicate/adapter-gemini-cli/"
       + "extension/gemini-extension.json");
-    if (geminiManifest.version !== "0.3.0") {
-      fail(`embedded Gemini extension is ${geminiManifest.version}, not 0.3.0`);
+    if (geminiManifest.version !== "0.3.1") {
+      fail(`embedded Gemini extension is ${geminiManifest.version}, not 0.3.1`);
     }
     const codexPlugin = await readTarJson(tarball,
       "node_modules/@agents-can-communicate/adapter-codex/"
       + "plugin/.codex-plugin/plugin.json");
     if (codexPlugin.license !== "MIT") fail("shipped Codex plugin license is not MIT");
-    ok(`root and ${manifest.bundleDependencies.length} bundled workspaces are 0.3.0`);
+    ok(`root and ${manifest.bundleDependencies.length} bundled workspaces are 0.3.1`);
 
     step("install into a clean directory");
     await writeFile(path.join(consumer, "package.json"),
@@ -240,7 +240,7 @@ async function main() {
     }
     const installedKimi = JSON.parse(await readFile(path.join(kimiHome, "plugins", "managed",
       "agents-can-communicate", ".kimi-plugin", "plugin.json"), "utf8"));
-    if (installedKimi.version !== "0.3.0") fail("installed Kimi manifest is not 0.3.0");
+    if (installedKimi.version !== "0.3.1") fail("installed Kimi manifest is not 0.3.1");
 
     const removed = JSON.parse((await acc("uninstall", "--adapter", "kimi",
       "--home", clientHome)

--- a/tests/acceptance/cross-vendor-live.test.mjs
+++ b/tests/acceptance/cross-vendor-live.test.mjs
@@ -87,8 +87,8 @@ test("packed v0.3 completes cross-vendor fallback without human relay", {
     : false,
 }, async t => {
   const packed = await createPackedAcc(t);
-  assert.equal(packed.manifest.version, "0.3.0");
-  assert.equal((await packed.acc(["version"])).version, "0.3.0");
+  assert.equal(packed.manifest.version, "0.3.1");
+  assert.equal((await packed.acc(["version"])).version, "0.3.1");
   await packed.setClientVersions(CAPTURE_VERSIONS);
 
   const claude = { adapterId: "claude_code", participantId: "claude_peer",
@@ -191,7 +191,7 @@ test("packed v0.3 completes cross-vendor fallback without human relay", {
     ".kimi-code/plugins/managed/agents-can-communicate/.kimi-plugin/plugin.json",
   ];
   for (const manifest of manifests) {
-    assert.equal((await readJson(path.join(packed.clientHome, manifest))).version, "0.3.0",
+    assert.equal((await readJson(path.join(packed.clientHome, manifest))).version, "0.3.1",
       `${manifest} was not stamped from the installed package`);
   }
 

--- a/tests/acceptance/packaging.test.mjs
+++ b/tests/acceptance/packaging.test.mjs
@@ -68,7 +68,7 @@ test("the tarball carries the workspaces where imports can find them", async t =
   const manifest = await manifestOf(tarball);
   const entries = await entriesOf(tarball);
 
-  assert.equal(manifest.version, "0.3.0");
+  assert.equal(manifest.version, "0.3.1");
   assert.equal((manifest.bundleDependencies ?? []).length > 0,
     true, "nothing is bundled, so every internal import would fail on install");
   assert.equal(manifest.bundleDependencies.includes(
@@ -83,7 +83,7 @@ test("the tarball carries the workspaces where imports can find them", async t =
   for (const dependency of manifest.bundleDependencies) {
     const workspace = JSON.parse((await run("tar", ["-xzOf", tarball,
       `package/node_modules/${dependency}/package.json`])).stdout);
-    assert.equal(workspace.version, "0.3.0", `${dependency} is not the v0.3 workspace`);
+    assert.equal(workspace.version, "0.3.1", `${dependency} is not the v0.3 workspace`);
   }
   const codexPlugin = JSON.parse((await run("tar", ["-xzOf", tarball,
     "package/node_modules/@agents-can-communicate/adapter-codex/"
@@ -92,7 +92,7 @@ test("the tarball carries the workspaces where imports can find them", async t =
   const geminiExtension = JSON.parse((await run("tar", ["-xzOf", tarball,
     "package/node_modules/@agents-can-communicate/adapter-gemini-cli/"
       + "extension/gemini-extension.json"])).stdout);
-  assert.equal(geminiExtension.version, "0.3.0",
+  assert.equal(geminiExtension.version, "0.3.1",
     "the embedded Gemini extension drifted from the release version");
 });
 


### PR DESCRIPTION
Releases the 37 commits that have accumulated on `main` since `v0.3.0`. npm still serves
`0.3.0`, so everything below is unavailable to anyone who installs today.

## What ships

- `core`: a `--to` name matching no participant is tried as a client name, so `--to claude_code`
  resolves instead of failing with exit 4. One live session of that client resolves; two refuse
  and name them; an exact participant id is never overruled.
- `cli`: the native-delivery consent question is a decision rather than a manifest — it names
  what the reader lives with instead of internal artefact names.
- Five `SKILL.md` files each name a peer client rather than their own.
- The entry documentation was rewritten around peer coordination among independent sessions.
- Two tests that recorded facts about the machine running them were fixed; CI has been green
  on `main` since.

## Release procedure

Both commits follow `docs/RELEASING.md`:

- `bb15eca` — candidate A: version bump across the root and 14 workspaces, the embedded Gemini
  extension manifest, the verifier's version assertions, and the two acceptance tests that
  pin it. Packed from a clean tree.
- `1add520` — candidate B: `CHANGELOG.md` and `docs/release-evidence/v0.3.1.md` only, neither
  of which npm packs.

| | |
|---|---|
| Tarball | `agents-can-communicate-0.3.1.tgz`, 256,236 bytes, 196 entries |
| sha256 | `2de2aa9f55053baac078d181423984ee2e91660b7945ad8f8bbba7b2ddcbbb0a` |
| `verify-package.mjs` | PASS, exit 0 |
| `npm test` | 1397 passed, 0 failed, 2 skipped |
| Verified on | macOS 26.6.2 (darwin 25.6.0, arm64), Node 26.5.1 |

No new capability capture was taken. No file under `adapter-claude-code/src`,
`delivery-router/src`, `hook-runner/src` or `bin/` differs from `v0.3.0`, so 0.3.0's native
delivery certification and Codex withdrawal describe this artifact unchanged — recorded as
carried forward rather than re-verified.

Publication waits for a green matrix on this PR.