### PR TITLE
chore(cli): the owner set lists only commands that exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## Unreleased
+
+| | |
+|---|---|
+| Built from | `00a2bc6a095e63241b187f8b4962de5093aee256` |
+| Tarball | `agents-can-communicate-0.3.1.tgz`, 256,368 bytes, 196 entries |
+| sha256 | `05ad35d8d6dbd64612fd4ce177a19d7fcd55374c7713e2ba077235d5411a6e90` |
+
+Not published. A published record says what the registry serves and is not
+rewritten, so shipped code that changes after a release is measured here instead.
+
+The set that decides which commands need a session owner named three the CLI does
+not have. `task`, `workstream` and `decide` went with the orchestration surface
+they belonged to and stayed behind in `NEEDS_OWNER`, unreachable: the parser
+refuses an unknown command before anything asks who owns the session.
+
+Nothing ran differently, and that is the point. A frozen set of command names
+reads as an authoritative list, and this one had been wrong since those commands
+were removed - long enough for the names to be copied out of it as though they
+were real. `orchestration-is-absent` guards the public command table, the packed
+text, the MCP tools and the service operations; this set is not among them, which
+is how three names outlived what they named.
+
 ## 0.3.1
 
 The one question a new user is asked is now a decision rather than a manifest. It opened

--- a/packages/cli/src/session-owner.mjs
+++ b/packages/cli/src/session-owner.mjs
@@ -19,8 +19,13 @@ import { AccError, EXIT } from "@agents-can-communicate/protocol";
  * way for a shell inside that session to find its own binding. Each step below
  * answers that from something the caller demonstrably has.
  */
+// Communication and lifecycle only. `task`, `workstream` and `decide` sat here
+// long after those commands were removed: unreachable, because the parser
+// refuses an unknown command before anything asks who owns the session, and
+// unnoticed, because `orchestration-is-absent` watches the public command table
+// and the packed text rather than this set.
 const NEEDS_OWNER = Object.freeze(new Set(["work", "claim", "release", "message",
-  "inbox", "reply", "request", "ack", "workstream", "task", "finish", "decide"]));
+  "inbox", "reply", "request", "ack", "finish"]));
 
 /**
  * Reads that are answers about *you*.


### PR DESCRIPTION
`NEEDS_OWNER` in `packages/cli/src/session-owner.mjs` listed `task`, `workstream` and
`decide` — three names that went with the orchestration surface they belonged to. They were
unreachable: the parser refuses an unknown command before anything asks who owns the session,
so nothing ran differently either way.

What they did do is read as authoritative. A frozen set of command names is exactly the kind
of list someone copies from, and this one had been wrong since those commands were removed.

`orchestration-is-absent` already guards the public command table, the packed text, the MCP
tools and the service operations against these names — it does not look at this set, which is
how they outlived what they named.

After the change the set is exactly the commands in `COMMANDS` that accept `--session` and
`--generation`, minus `sync`, which resolves softly through `WANTS_OWNER` alongside `status`.

## Candidate record

The change touches a packed file, so it comes with its own candidate record under
`Unreleased`, per `docs/RELEASING.md`. Nothing is published by this PR.

| | |
|---|---|
| Built from | `00a2bc6a095e63241b187f8b4962de5093aee256` |
| Tarball | `agents-can-communicate-0.3.1.tgz`, 256,368 bytes, 196 entries |
| sha256 | `05ad35d8d6dbd64612fd4ce177a19d7fcd55374c7713e2ba077235d5411a6e90` |
| `verify-package.mjs` | PASS, exit 0 |
| `npm test` | 1397 passed, 0 failed, 2 skipped |

Before the record was written the suite failed exactly one gate — `the changelog's digest
describes the code that is here now` — naming `packages/cli/src/session-owner.mjs` as the only
changed packed file, which is the behaviour that gate exists for.