### PR TITLE
release: ACC 0.4.2 delivery diagnostics and session recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Doctor reports the last native binding attempt for each current session, including
+  absent delivery consent, an unidentified client process and handshake failures/timeouts.
+  Diagnostics replace one small record per hook owner, stay outside repositories and
+  agent context, and cannot establish current delivery from a previous handshake.
+
 - Installation offers to save Codex delivery consent even before a compatible local
   service/session is available. It leaves activation gated by the live verification.
 - Install and doctor report delivery policy, missing setup, current channel state and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 | Candidate artifact | Value |
 |---|---|
-| Built from | `c3fde79aa26d462ddf99e3476e5a60656d2701fa` |
+| Built from | `3f46045e390f153cb36e8a47981f2f7c1964401c` |
 | Tarball | `agents-can-communicate-0.4.2.tgz`, 340,886 bytes, 255 files |
 | sha256 | `d509cd6a43c92e6fc0a5227a1a5499dfde0636385ede910f289a5c81c059a555` |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 | Candidate artifact | Value |
 |---|---|
-| Built from | `3f46045e390f153cb36e8a47981f2f7c1964401c` |
+| Built from | `7b082884f55e6ccc86d9e292c4dd647a6696352e` |
 | Tarball | `agents-can-communicate-0.4.2.tgz`, 340,886 bytes, 255 files |
 | sha256 | `d509cd6a43c92e6fc0a5227a1a5499dfde0636385ede910f289a5c81c059a555` |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,16 @@
 
 | Development artifact | Value |
 |---|---|
-| Built from | `5503e2a867f23215c7e8fc8aa072ab4efd9b725f` |
-| Tarball | `agents-can-communicate-0.4.1.tgz`, 335,661 bytes, 251 files |
-| sha256 | `04ce871d1a79f47f4bac14795a7c26d9bfe627df08b57bd300534fe97990d064` |
+| Built from | `93cb614f1a663d7246b6451584f41356354ed253` |
+| Tarball | `agents-can-communicate-0.4.1.tgz`, 336,574 bytes, 251 files |
+| sha256 | `d594cefd629c7a50f4baf24188b211f0a430a269cdb7338d856229e082c3d0d5` |
 
 This unpublished development build retains the 0.4.1 manifest version. Its archive passed
 installed-package verification and all 251 files match the recorded source commit.
 On macOS arm64 with Node 24, all 1,943 executed tests passed (2 skipped). Syntax checks
-and the installed interactive consent/doctor/uninstall scenario passed; five intentional
-regression mutations were caught. No new client capability is certified by these fixes.
+and the installed Claude consent/doctor/off/uninstall scenario passed.
+The native startup check is documented in the Claude compatibility record; it is not
+a model delivery capture. No new client capability is certified by these fixes.
 
 ## 0.4.1 — release candidate
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 | Candidate artifact | Value |
 |---|---|
-| Built from | `1a3249d2602a80d362cfcce412afeb548f378f51` |
+| Built from | `c3fde79aa26d462ddf99e3476e5a60656d2701fa` |
 | Tarball | `agents-can-communicate-0.4.2.tgz`, 340,886 bytes, 255 files |
 | sha256 | `d509cd6a43c92e6fc0a5227a1a5499dfde0636385ede910f289a5c81c059a555` |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,16 +19,18 @@
 
 | Development artifact | Value |
 |---|---|
-| Built from | `93cb614f1a663d7246b6451584f41356354ed253` |
-| Tarball | `agents-can-communicate-0.4.1.tgz`, 336,574 bytes, 251 files |
-| sha256 | `d594cefd629c7a50f4baf24188b211f0a430a269cdb7338d856229e082c3d0d5` |
+| Built from | `34b084a3a9608df36f9ca2b7ab894370df97d17f` |
+| Tarball | `agents-can-communicate-0.4.1.tgz`, 340,538 bytes, 255 files |
+| sha256 | `be2c9c8a8b9a105cbcd1b0ad4af2b9ca67162601c1775783babc78bdde99dc36` |
 
 This unpublished development build retains the 0.4.1 manifest version. Its archive passed
-installed-package verification and all 251 files match the recorded source commit.
-On macOS arm64 with Node 24, all 1,943 executed tests passed (2 skipped). Syntax checks
-and the installed Claude consent/doctor/off/uninstall scenario passed.
-The native startup check is documented in the Claude compatibility record; it is not
-a model delivery capture. No new client capability is certified by these fixes.
+installed-package verification and all 255 files match the recorded source commit.
+On macOS arm64 with Node 24, all 1,949 executed tests passed (2 skipped). Syntax checks
+passed for 474 files. Installed hooks, per-session doctor results and SessionEnd cleanup
+were exercised; delayed diagnostic I/O and nearly expired hook budgets retain normal output.
+The offer-rejection fixture deliberately expires its old startup budget before closing
+through the current service, so suite load cannot substitute a timeout for its assertion.
+No new client capability is certified by these diagnostics.
 
 ## 0.4.1 — release candidate
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Unreleased
+
+- Installation offers to save Codex delivery consent even before a compatible local
+  service/session is available. It leaves activation gated by the live verification.
+- Install and doctor report delivery policy, missing setup, current channel state and
+  the actual fallback separately. Declining live delivery no longer promises uncertified
+  next-turn delivery. Doctor distinguishes existing Claude launch policy from current
+  Codex recorded consent and ignores hook-only bindings when reporting native delivery.
+
+| Development artifact | Value |
+|---|---|
+| Built from | `5503e2a867f23215c7e8fc8aa072ab4efd9b725f` |
+| Tarball | `agents-can-communicate-0.4.1.tgz`, 335,661 bytes, 251 files |
+| sha256 | `04ce871d1a79f47f4bac14795a7c26d9bfe627df08b57bd300534fe97990d064` |
+
+This unpublished development build retains the 0.4.1 manifest version. Its archive passed
+installed-package verification and all 251 files match the recorded source commit.
+On macOS arm64 with Node 24, all 1,943 executed tests passed (2 skipped). Syntax checks
+and the installed interactive consent/doctor/uninstall scenario passed; five intentional
+regression mutations were caught. No new client capability is certified by these fixes.
+
 ## 0.4.1 — release candidate
 
 - Grok install, doctor, and uninstall respect `GROK_HOME`, including paths with spaces;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   the actual fallback separately. Declining live delivery no longer promises uncertified
   next-turn delivery. Doctor distinguishes existing Claude launch policy from current
   Codex recorded consent and ignores hook-only bindings when reporting native delivery.
+- Claude install and doctor now ask users to check client-side Channels activation.
+  A connected MCP server and an active ACC transport do not verify that Claude admits
+  inbound messages. Historical capture failures are no longer presented as current state.
 
 | Development artifact | Value |
 |---|---|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## Unreleased
+## 0.4.2 — release candidate
 
+- A genuine prompt restores ACC participation after detaching a solo session whose
+  ephemeral owner was removed. It retains the participant address, uses fresh session
+  credentials and refuses a replacement that appears during client probing.
 - Doctor reports the last native binding attempt for each current session, including
   absent delivery consent, an unidentified client process and handshake failures/timeouts.
   Diagnostics replace one small record per hook owner, stay outside repositories and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
   absent delivery consent, an unidentified client process and handshake failures/timeouts.
   Diagnostics replace one small record per hook owner, stay outside repositories and
   agent context, and cannot establish current delivery from a previous handshake.
-
 - Installation offers to save Codex delivery consent even before a compatible local
   service/session is available. It leaves activation gated by the live verification.
 - Install and doctor report delivery policy, missing setup, current channel state and
@@ -20,20 +19,23 @@
   A connected MCP server and an active ACC transport do not verify that Claude admits
   inbound messages. Historical capture failures are no longer presented as current state.
 
-| Development artifact | Value |
+| Candidate artifact | Value |
 |---|---|
-| Built from | `34b084a3a9608df36f9ca2b7ab894370df97d17f` |
-| Tarball | `agents-can-communicate-0.4.1.tgz`, 340,538 bytes, 255 files |
-| sha256 | `be2c9c8a8b9a105cbcd1b0ad4af2b9ca67162601c1775783babc78bdde99dc36` |
+| Built from | `1a3249d2602a80d362cfcce412afeb548f378f51` |
+| Tarball | `agents-can-communicate-0.4.2.tgz`, 340,886 bytes, 255 files |
+| sha256 | `d509cd6a43c92e6fc0a5227a1a5499dfde0636385ede910f289a5c81c059a555` |
 
-This unpublished development build retains the 0.4.1 manifest version. Its archive passed
-installed-package verification and all 255 files match the recorded source commit.
-On macOS arm64 with Node 24, all 1,949 executed tests passed (2 skipped). Syntax checks
-passed for 474 files. Installed hooks, per-session doctor results and SessionEnd cleanup
-were exercised; delayed diagnostic I/O and nearly expired hook budgets retain normal output.
-The offer-rejection fixture deliberately expires its old startup budget before closing
-through the current service, so suite load cannot substitute a timeout for its assertion.
-No new client capability is certified by these diagnostics.
+This unpublished candidate passed exact installed-package verification and the managed
+upgrade from published 0.4.1 through `acc update`. All 255 source, archive, installed and
+active managed files match. Existing workspace bytes, client settings, delivery consent
+and update preferences were preserved. The upgraded hooks produce per-session diagnostics
+in both doctor text and JSON. All 23 managed-update checks and eight focused ownership
+checks passed on macOS arm64 / Node 24. Syntax checks passed for 474 files.
+
+The complete suite runs after the evidence commit, including the mandatory pre-push gate;
+its result is reported with the PR. No new client capability is certified. See the
+[candidate evidence](docs/release-evidence/v0.4.2.md) for mutations, native-client limits
+and the verified upgrade procedure.
 
 ## 0.4.1 — release candidate
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ experimental, off by default, and can spend model tokens. On Apple Silicon Macs,
 Claude Code 2.1.258 or newer requires zsh and shows its development-channel warning at
 startup. Messages arriving mid-turn wait for the turn to finish. The receiving session's
 opt-in policy and current reachability determine whether delivery can proceed.
+`acc install` reports each client's delivery state and can save Codex consent before its
+service is available. `acc doctor` distinguishes a disabled policy from an unavailable
+service or a missing live channel in the current project.
 
 A Codex thread retained by LocalDaemon can receive opted-in messages after its terminal
 exits. Turning ACC delivery off prevents new native offers; already accepted queue entries

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Run `acc doctor` from the project if a peer is missing. A directory containing A
 state, commonly your home directory, cannot be used as a workspace; start the client in a
 project directory. See [Troubleshooting](docs/TROUBLESHOOTING.md).
 
-Already using ACC? Follow the [upgrade guide](docs/UPGRADING.md), including the 0.4.0 →
-0.4.1 update and the data-format boundary when moving from 0.3.1.
+Already using ACC? Follow the [upgrade guide](docs/UPGRADING.md), including the 0.4.0/0.4.1 →
+0.4.2 update and the data-format boundary when moving from 0.3.1.
 
 ## When messages arrive
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,10 @@ alone does not verify inbound delivery. Messages arriving mid-turn wait for the 
 finish. The receiving session's
 opt-in policy and current reachability determine whether delivery can proceed.
 `acc install` reports each client's delivery state and can save Codex consent before its
-service is available. `acc doctor` distinguishes a disabled policy from an unavailable
-service or a missing live channel in the current project.
+service is available. `acc doctor` also names each session’s last native binding result,
+including missing launch consent, an unidentified client process or a failed handshake.
+It distinguishes a disabled policy from an unavailable service or a missing live channel
+in the current project.
 
 A Codex thread retained by LocalDaemon can receive opted-in messages after its terminal
 exits. Turning ACC delivery off prevents new native offers; already accepted queue entries

--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ mutations. It adds no automatic peer-message injection or idle delivery. A reloc
 **Optional live delivery can start a turn in an idle Codex or Claude Code session.** It is
 experimental, off by default, and can spend model tokens. On Apple Silicon Macs, Codex
 0.152.1 or newer requires an already-running LocalDaemon and a verified session;
-Claude Code 2.1.258 or newer requires zsh and shows its development-channel warning at
-startup. Messages arriving mid-turn wait for the turn to finish. The receiving session's
+Claude Code 2.1.258 or newer requires zsh and client-side Channels activation; check its
+startup notice for ACC and accept the development warning when shown. An MCP connection
+alone does not verify inbound delivery. Messages arriving mid-turn wait for the turn to
+finish. The receiving session's
 opt-in policy and current reachability determine whether delivery can proceed.
 `acc install` reports each client's delivery state and can save Codex consent before its
 service is available. `acc doctor` distinguishes a disabled policy from an unavailable

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,7 +68,13 @@ livePolicy · opaqueEndpointRef · leaseUntil
 
 Core validates identity and expiry but never interprets the opaque endpoint. That remains
 inside the owning adapter. `acc status` reports available modes, policy, reachability, and
-lease without exposing the endpoint.
+lease without exposing the endpoint. The hook runner also replaces one optional native
+attempt diagnostic beside its session-owner file: closed policy/process/handshake
+metadata with a timestamp, never vendor output. Doctor joins it only to the current open
+generation and reports it separately from transport and receipt facts. It is not journalled
+or projected into agent context; session restart replaces it and SessionEnd attempts bounded
+cleanup. Doctor ignores closed or superseded generations even if cleanup could not finish. Diagnostic disk I/O runs in an
+unreferenced worker, so a stalled write cannot hold the hook process open.
 
 ## Certified capability versus current reachability
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -261,6 +261,13 @@ recorded setup (or `not_required` for a pre-existing service). `policy` is the i
 choice; `sessionPolicy` describes a native binding when one is visible. Existing Claude
 sessions can retain their launch policy after a different choice is installed for new
 sessions; Codex checks current recorded consent before new offers.
+`nativeDelivery.sessions` lists each current session's identity, present transport state
+and `lastAttempt`: timestamp, startup/turn event, effective policy and its source, whether
+that policy was missing/invalid/off, whether a client process was identified, and the closed
+handshake result/reason. `lastAttempt: null` means no usable attempt was observed for this
+generation; it does not prove hooks are disabled. A past successful handshake is separate
+from current transport reachability. ACC replaces this small diagnostic beside the
+hook-owner file outside the repository; it never adds attempt history to agent context.
 See [delivery consent](CONFIGURATION.md#keep-delivery-consent-user-owned).
 
 An initial `acc install` enables automatic updates. Reinstalling preserves an explicit

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -253,6 +253,9 @@ starts or stops the vendor daemon. The install summary names each client's reque
 activation state and verified fallback. `doctor` separates protocol readiness, recorded
 consent and a live channel in the current workspace, with a next step for missing activation.
 A supported version or an installed plugin alone is not an active delivery channel.
+`runtime: active` means ACC has a reachable local transport binding. Claude can still
+block inbound Channels messages while its MCP server and tools remain connected;
+doctor therefore also names the client-side startup check.
 In doctor JSON, `nativeDelivery.activation` distinguishes missing launch setup from a
 recorded setup (or `not_required` for a pre-existing service). `policy` is the installed
 choice; `sessionPolicy` describes a native binding when one is visible. Existing Claude

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -239,8 +239,9 @@ external AI client. An addressed handoff requires acknowledgement; a room handof
 `--delivery off|actionable|all` is a per-client recipient policy request, not a capability
 switch, and the default is `off`. `--adapter` is repeatable to name several clients. An
 explicit `--delivery` applies uniformly and never prompts; omitting it on an interactive
-terminal asks one default-No question per eligible client, and on a non-interactive run or a
-`--dry-run` it keeps fresh clients off. A recorded opt-in is kept on upgrade. If the detected
+terminal asks one default-No question per supported client. Codex can save consent while
+its local service is unavailable or has no loaded session; this does not activate delivery.
+A non-interactive run or a `--dry-run` keeps fresh clients off. A recorded opt-in is kept on upgrade. If the detected
 client cannot receive native delivery - unsupported, below the captured minimum, a
 prerelease, known-bad, a wrong platform, or an unsupported shell - installation keeps the
 effective policy off and prints the reason. Claude Code shell activation writes an owned
@@ -248,7 +249,16 @@ zsh PATH block and a shim that `exec`s the real client; `ACC_BYPASS=1` bypasses 
 activation. Codex LocalDaemon delivery uses recorded installation consent without changing
 ordinary launch arguments. Its opt-in remains active when shim variables are absent or
 bypassed; `acc install --adapter codex --delivery off` disables new native offers. ACC never
-starts or stops the vendor daemon. See [delivery consent](CONFIGURATION.md#keep-delivery-consent-user-owned).
+starts or stops the vendor daemon. The install summary names each client's requested policy,
+activation state and verified fallback. `doctor` separates protocol readiness, recorded
+consent and a live channel in the current workspace, with a next step for missing activation.
+A supported version or an installed plugin alone is not an active delivery channel.
+In doctor JSON, `nativeDelivery.activation` distinguishes missing launch setup from a
+recorded setup (or `not_required` for a pre-existing service). `policy` is the installed
+choice; `sessionPolicy` describes a native binding when one is visible. Existing Claude
+sessions can retain their launch policy after a different choice is installed for new
+sessions; Codex checks current recorded consent before new offers.
+See [delivery consent](CONFIGURATION.md#keep-delivery-consent-user-owned).
 
 An initial `acc install` enables automatic updates. Reinstalling preserves an explicit
 `acc update --auto off` choice. A full uninstall pauses updates; reinstalling restores

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -15,7 +15,7 @@ pair or session-bound ACC MCP tools. See [CLI ownership](CLI.md#coordinate-from-
 
 ACC requires macOS or Linux and Node.js 24 or newer.
 
-Already using ACC? Follow the [upgrade guide](UPGRADING.md) for the 0.4.0 → 0.4.1
+Already using ACC? Follow the [upgrade guide](UPGRADING.md) for the 0.4.0/0.4.1 → 0.4.2
 update or the data-format boundary when upgrading from 0.3.1.
 
 ```bash

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -44,6 +44,11 @@ state directory is in `sandbox_workspace_write.writable_roots` in the config it 
 ACC keeps those user settings unchanged. Installed files alone do not establish that hooks
 are active; `acc doctor` leaves current readiness unverified and directs you to Codex.
 
+Read the delivery summary for each client. Live delivery needs an explicit opt-in and a
+verified channel in the current session. Codex can save your choice even when its local
+service is not running yet. Declining uses the reported fallback: `acc inbox`, or next-turn
+hooks only where the exact client version and platform are certified.
+
 If you opt into Claude Code's experimental idle delivery, Claude also shows its own
 development-channel warning at every startup. The feature is off by default, can spend
 model tokens, and currently requires Apple Silicon macOS, zsh, and Claude Code 2.1.258 or

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -49,8 +49,11 @@ verified channel in the current session. Codex can save your choice even when it
 service is not running yet. Declining uses the reported fallback: `acc inbox`, or next-turn
 hooks only where the exact client version and platform are certified.
 
-If you opt into Claude Code's experimental idle delivery, Claude also shows its own
-development-channel warning at every startup. The feature is off by default, can spend
+If you opt into Claude Code's experimental idle delivery, check Claude's Channels startup
+notice for ACC and accept its development-channel warning when shown. If it reports Channels
+unavailable or blocked, a connected MCP server does not make inbound delivery work;
+see [troubleshooting](TROUBLESHOOTING.md#i-enabled-live-delivery-but-got-fallback).
+The feature is off by default, can spend
 model tokens, and currently requires Apple Silicon macOS, zsh, and Claude Code 2.1.258 or
 newer. You do not need it for durable messages or supported next-turn delivery.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,7 +1,7 @@
 # Releasing
 
 Use this procedure to build one auditable npm artifact, verify that exact tarball, and keep
-its evidence tied to the commit that supplied its bytes. The package is currently `0.4.1`;
+its evidence tied to the commit that supplied its bytes. The package is currently `0.4.2`;
 the commands derive the version from `package.json` so the filename cannot drift.
 
 ```mermaid

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -94,8 +94,20 @@ For Codex, use your ordinary launch command with 0.152.1 or newer on Apple Silic
 macOS. Its LocalDaemon must already be running, and trusted hooks must establish
 the receiver's exact thread and workspace. Embedded sessions, an absent socket,
 ambiguous recipients or failed identity checks retain durable inbox access.
-`acc doctor` reports current eligibility. ACC preserves requested consent through
-a temporary daemon outage and does not start the daemon for you.
+`acc doctor` reports readiness, consent and the current workspace's live channel separately.
+`native_endpoint_unavailable` means the local service endpoint is missing or is not a safe socket;
+`native_session_unavailable` means the service answered but has no loaded thread to probe.
+An interactive install can save consent in either case. ACC preserves it through a temporary
+outage and does not start the daemon for you.
+
+Check `acc doctor --json` and `acc status --json` while both clients are open. If policy is
+`off`, opt in with `acc install --adapter codex --delivery actionable` (or select another
+adapter). This can spend model tokens. If policy is enabled but runtime is `waiting` and
+`deliveryBindings` is empty, no live channel is bound in this workspace. Start a new client
+session, check its integration prompts and re-run doctor. A healthy store, online peers,
+or a connected MCP server does not by itself establish automatic delivery. `lifecycle:
+manual` can also mean the current version has no certified session-end hook; it does not
+prove that no hooks ran.
 
 For Claude Code, open a fresh interactive zsh after installation so its launcher
 is on PATH, and accept its visible development-channel warning. A failed channel

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -110,9 +110,26 @@ manual` can also mean the current version has no certified session-end hook; it 
 prove that no hooks ran.
 
 For Claude Code, open a fresh interactive zsh after installation so its launcher
-is on PATH, and accept its visible development-channel warning. A failed channel
-connection may remain in Claude's `~/.claude/mcp-needs-auth-cache.json` for about
-fifteen minutes; remove only the `acc` entry and restart if that is the cause.
+is on PATH. Check Claude's **Channels startup notice for ACC**, and accept the
+development-channel warning when it appears. A successful bootstrap cache means the
+executable passed ACC's compatibility probe. `/mcp` showing `connected` and two tools
+means the MCP server connected. Even `runtime: active` in ACC's doctor JSON describes
+the local transport; none of these proves that Claude enabled inbound channel messages.
+
+If Claude says `--dangerously-load-development-channels ignored` or `Channels are not
+currently available`, it has not enabled that delivery path. On a fresh 2.1.266 test
+profile, the first launch showed those messages and the next launch showed the development
+warning; restarting once can recheck availability, but is not a guaranteed fix. If it
+remains unavailable, follow Claude's notice. Organization policy can also block Channels;
+an administrator must enable them where required. ACC does not override that policy.
+See [Claude's Channels documentation](https://code.claude.com/docs/en/channels).
+
+If `deliveryBindings` is empty, ACC has not bound a local transport either. Check the
+same running session's `ACC_NATIVE_DELIVERY_POLICY` (normally `actionable` after opting
+in), hook activation and workspace identity. A previously successful bootstrap cache
+does not establish the environment of the current launch. If Claude explicitly reports
+a cached MCP connection failure, reconnect the ACC server through `/mcp` and restart
+the session if needed.
 
 Closing a Codex terminal can leave its daemon thread loaded and eligible. Use
 `acc install --adapter codex --delivery off` to stop new ACC native offers.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -124,12 +124,21 @@ remains unavailable, follow Claude's notice. Organization policy can also block 
 an administrator must enable them where required. ACC does not override that policy.
 See [Claude's Channels documentation](https://code.claude.com/docs/en/channels).
 
-If `deliveryBindings` is empty, ACC has not bound a local transport either. Check the
-same running session's `ACC_NATIVE_DELIVERY_POLICY` (normally `actionable` after opting
-in), hook activation and workspace identity. A previously successful bootstrap cache
-does not establish the environment of the current launch. If Claude explicitly reports
-a cached MCP connection failure, reconnect the ACC server through `/mcp` and restart
-the session if needed.
+If `deliveryBindings` is empty, ACC has not bound a local transport either. Read the
+per-session lines in `acc doctor`, or `nativeDelivery.sessions[].lastAttempt` in JSON:
+
+- An absent launch policy means that hook did not receive delivery consent, even if an
+  earlier bootstrap probe succeeded. For Claude, open a new terminal and client through
+  the installed launcher.
+- `client_process_unknown` means ACC could not identify the client process. A new client
+  session repeats that lookup.
+- `handshake_failed` or `handshake_timeout` means the session could not bind the local
+  channel. Check the client's integration/channel setup; the next ordinary turn retries.
+- No attempt observed can mean no native hook ran, an older runtime wrote the owner, or
+  diagnostic persistence failed. Check hook activation and the runtime versions in doctor.
+
+The timestamp describes the last attempt for that exact generation. A past successful
+handshake does not establish a currently reachable channel or client-side admission.
 
 Closing a Codex terminal can leave its daemon thread loaded and eligible. Use
 `acc install --adapter codex --delivery off` to stop new ACC native offers.

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,12 +1,13 @@
-# Upgrading to 0.4.1
+# Upgrading to 0.4.2
 
-## From 0.4.0
+## From 0.4.1 or 0.4.0
 
-This patch keeps the existing workspace data format. It fixes Grok CLI ownership,
-relocated Grok profiles, automatic-update preferences after reinstall, and the warning
-when a client starts in a directory containing ACC's own state.
+This patch keeps the existing workspace data format. It makes installation and delivery
+diagnostics clearer, records the last native binding attempt per session, and restores
+hook participation after detaching a solo session without restarting the conversation.
+It also includes the 0.4.1 Grok, reinstall-preference and workspace-warning fixes.
 
-Close the participating clients and persistent ACC MCP processes, then run:
+Close participating clients and persistent ACC MCP processes, then run:
 
 ```bash
 acc update
@@ -14,17 +15,28 @@ acc version
 acc doctor
 ```
 
-After publication, `acc version` should report 0.4.1. A managed update refreshes the
-installed integrations and skills. Restart the clients and complete any hook/trust
-review they request. Existing managed installations activate the selected runtime
-through `acc update`; use the npm install steps below for pre-0.4 or unmanaged
-installations. When pinned to 0.4.0, select 0.4.1 or clear the pin first.
+After publication, `acc version` should report 0.4.2. If a pin keeps an older version,
+select 0.4.2 or clear it first. A managed update refreshes installed integrations and
+skills; use the npm instructions below for unmanaged or pre-0.4 installations. Start
+clients again and complete any hook/trust review they request.
 
-In Grok, the refreshed skill runs public status through the terminal before its first
-owned command. The hook reminder after that result supplies the session's own CLI
-arguments. Grok still reads peer messages explicitly through inbox; this patch does not
-add external wake or certify guards. Start clients in a project directory, rather than
-in a home directory containing ACC state.
+Run `acc doctor` in the project after the new clients have started (or submitted a normal
+turn). Its per-session lines now explain missing launch consent, an unidentified client
+process and a failed or timed-out handshake. `nativeDelivery.sessions[].lastAttempt` in
+`acc doctor --json` provides the same closed metadata and timestamp. Existing owners may
+have no attempt record until a new hook runs; missing metadata does not prove hooks are
+disabled. A previous successful handshake and a connected MCP server do not prove that
+Claude admitted inbound Channels messages. See [delivery troubleshooting](TROUBLESHOOTING.md#i-enabled-live-delivery-but-got-fallback).
+
+Upgrading preserves delivery consent. If doctor reports native delivery off and you want
+automatic peer requests, use `acc install --adapter codex --delivery actionable` (or the
+relevant adapter); this can spend model tokens. Codex can save that consent before its
+local service/session becomes available. ACC does not start the vendor daemon, and it
+keeps durable inbox access when no verified live channel is bound.
+
+In Grok, public status supplies the session's own CLI arguments through the next tool
+hook. Grok still uses explicit inbox reads; this patch adds no external wake or guards.
+Start clients in a project directory, rather than a home directory containing ACC state.
 
 ## From 0.3.1
 
@@ -47,7 +59,7 @@ restores access; deleting or editing the record is not a remedy.
 2. Install the released package, then refresh the client integrations:
 
    ```bash
-   npm install --global agents-can-communicate@0.4.1
+   npm install --global agents-can-communicate@0.4.2
    acc version
    acc install
    ```
@@ -97,7 +109,7 @@ acc update                    # download and apply, or report what is keeping it
 acc update --check            # check without installing or changing update settings
 acc update --auto off         # disable background updates
 acc update --auto on          # enable them again
-acc update --pin 0.4.1        # stay on this exact stable version
+acc update --pin 0.4.2        # stay on this exact stable version
 acc update --pin none         # follow stable releases again
 ```
 

--- a/docs/release-evidence/v0.4.2.md
+++ b/docs/release-evidence/v0.4.2.md
@@ -6,7 +6,7 @@ on the next genuine prompt after a solo detach removes its ephemeral owner.
 
 | Measurement | Value |
 |---|---|
-| Source commit A | `c3fde79aa26d462ddf99e3476e5a60656d2701fa` |
+| Source commit A | `3f46045e390f153cb36e8a47981f2f7c1964401c` |
 | Archive | `agents-can-communicate-0.4.2.tgz` |
 | SHA-256 | `d509cd6a43c92e6fc0a5227a1a5499dfde0636385ede910f289a5c81c059a555` |
 | Size / files | 340,886 bytes / 255 files |
@@ -75,6 +75,15 @@ nine seconds; a near-expired hook budget skips optional I/O. These checks protec
 hook's fail-open behavior. An existing offer-rejection fixture now deliberately expires
 its old startup budget and closes through the current hook service, so it reaches the
 receipt assertion instead of failing under suite load before exercising it.
+
+Linux CI then exposed an old assertion expecting the phrase “native delivery is off”.
+The actual output correctly distinguished saved consent from an inactive, unverified
+channel. That scenario now runs on every host by making only its disposable CLI process
+report an uncaptured architecture. It verifies saved actionable consent and the absence
+of native activation, channel configuration and launch shim. The old expectation failed
+locally; the corrected check passed, failed when the platform explanation was removed,
+and passed after restoration. All three Claude native-delivery process tests now execute
+on macOS. Repacking after this test-only correction again produced the identical archive.
 
 ## Native-client limits
 

--- a/docs/release-evidence/v0.4.2.md
+++ b/docs/release-evidence/v0.4.2.md
@@ -6,7 +6,7 @@ on the next genuine prompt after a solo detach removes its ephemeral owner.
 
 | Measurement | Value |
 |---|---|
-| Source commit A | `3f46045e390f153cb36e8a47981f2f7c1964401c` |
+| Source commit A | `7b082884f55e6ccc86d9e292c4dd647a6696352e` |
 | Archive | `agents-can-communicate-0.4.2.tgz` |
 | SHA-256 | `d509cd6a43c92e6fc0a5227a1a5499dfde0636385ede910f289a5c81c059a555` |
 | Size / files | 340,886 bytes / 255 files |
@@ -84,6 +84,21 @@ of native activation, channel configuration and launch shim. The old expectation
 locally; the corrected check passed, failed when the platform explanation was removed,
 and passed after restoration. All three Claude native-delivery process tests now execute
 on macOS. Repacking after this test-only correction again produced the identical archive.
+
+A later macOS run exposed two timing-sensitive fixtures. The near-deadline diagnostic
+check used a real 1,750ms delay within a 2,000ms budget, leaving only 250ms for normal hook
+work. Normalization exceeding that budget reproduced its misleading diagnostic-I/O
+assertion. The revised fixture freezes logical budget time with 749ms remaining and
+checks that no diagnostic worker starts; removing the allocation guard fails that check.
+The separate real nine-second delayed-write subprocess and three-second exit bound remain.
+
+The generated Codex data-home fixture unnecessarily enabled host Git in its PATH. An
+isolated delayed Git reproduced exit zero, no binding and a fail-open message after five
+seconds. Keeping the helper's isolated PATH passed; restoring the host PATH reproduced
+the failure. Hook streams, duration and scenario identity now accompany any failed
+binding assertion. The original CI streams were discarded, so Git is not claimed as its
+confirmed cause. Both data-home cases remain checked, without retries or changed product
+deadlines. Independent review found no blocker; the final repack remains byte-identical.
 
 ## Native-client limits
 

--- a/docs/release-evidence/v0.4.2.md
+++ b/docs/release-evidence/v0.4.2.md
@@ -1,0 +1,97 @@
+# ACC 0.4.2 candidate evidence
+
+This patch is prepared for maintainer review. It has not been tagged or published.
+It improves delivery setup and per-session diagnostics, and restores ACC participation
+on the next genuine prompt after a solo detach removes its ephemeral owner.
+
+| Measurement | Value |
+|---|---|
+| Source commit A | `1a3249d2602a80d362cfcce412afeb548f378f51` |
+| Archive | `agents-can-communicate-0.4.2.tgz` |
+| SHA-256 | `d509cd6a43c92e6fc0a5227a1a5499dfde0636385ede910f289a5c81c059a555` |
+| Size / files | 340,886 bytes / 255 files |
+| Platform / Node | macOS arm64 / 24.4.0 |
+| Clean-source pack / exact-package verifier | passed |
+| Source / archive / installed / active managed files | 255/255 identical |
+
+Root, all 14 bundled package manifests, lock entries and the embedded Gemini extension
+are aligned to 0.4.2. The exact archive passed installation into a clean consumer,
+doctor, a non-Git workspace, integration installation/removal, shipped fixture checks
+and documentation-link validation. No runtime dependencies were added.
+
+## Published 0.4.1 upgrade
+
+The preflight downloaded published 0.4.1 and verified its registry SHA-1 and SHA-512
+integrity. It installed Claude Code, Codex, Gemini CLI and Grok in an isolated home,
+with native delivery off and an explicit automatic-update opt-out. It created intents,
+a claim, requests, a reply, and queued and acknowledged obligations.
+
+The old hook was exercised, then ended before updating, as the upgrade guide requires.
+The published CLI ran `acc update` against a loopback registry serving the unchanged
+candidate archive above. Its existing launcher subsequently reported 0.4.2 and selected
+the new managed generation. Workspace bytes and the complete public snapshot were
+preserved. User settings, foreign hooks, all four integrations, delivery consent and the
+automatic-update opt-out were preserved. All installed and active managed files matched
+the archive byte for byte.
+
+New hook processes launched through the old installed entry point then recorded two
+separate outcomes: missing launch policy and an unidentified client process despite
+explicit actionable policy. Both `acc doctor` text and `acc doctor --json` reported the
+correct outcome per session with a timestamp. Public diagnostics contained neither
+generation credentials nor the fixture prompt. SessionEnd removed both diagnostic owners;
+the continuity participants and claim were also closed after verification.
+
+An earlier preflight left an unidentified hook owner present and observed
+activation held with `processes_active`. The final run follows the documented close,
+update, reopen sequence; it does not weaken that protection. Client executables in this
+automated upgrade check only reported versions. This is installed-product and upgrade
+evidence, not a native model-delivery capture.
+
+## Regression evidence
+
+The solo-detach failure was reproduced with the installed package for both Claude and
+Codex before changing production code. After detach, a tool hook still cannot revive the
+owner. The next genuine prompt now issues a fresh session and generation, retains the
+participant address, rejects the old credentials and preserves the new owner on later
+turns. SessionEnd removes it. Both new installed scenarios failed on the original code
+and passed with the fix.
+
+The focused owner-race test opens a replacement during client probing. It passed with
+the generation recheck, failed when that exact recheck was disabled, and passed again
+after restoration. Eight focused ownership tests passed on the final source.
+
+Earlier focused fixes in this branch also passed their RED/GREEN checks and targeted
+mutations: missing Codex consent prompts, delivery fallback and launch guidance,
+current-generation diagnostic attribution, and bounded diagnostic I/O. The actual hook
+subprocess retains normal output and exits promptly when a diagnostic write is delayed
+nine seconds; a near-expired hook budget skips optional I/O. These checks protect the
+hook's fail-open behavior. An existing offer-rejection fixture now deliberately expires
+its old startup budget and closes through the current hook service, so it reaches the
+receipt assertion instead of failing under suite load before exercising it.
+
+## Native-client limits
+
+The earlier branch investigation used real Claude Code 2.1.266 on macOS arm64 with a
+disposable profile, dummy API key and unreachable model endpoint. The generated launch
+shim, client hooks, MCP connection and local ACC binding were observed. One launch showed
+Channels unavailable; a later launch showed the development-channel warning. MCP
+initialization did not provide confirmation of inbound Channels admission. No model
+delivery was captured. See [Claude compatibility](../../packages/adapter-claude-code/COMPATIBILITY.md).
+That investigation preceded the final 0.4.2 artifact; the real client was not rerun on it.
+
+The other computer is unavailable. Its precise Claude delivery failure remains
+unconfirmed. The new diagnostics expose missing policy, missing process identity and
+handshake failure/timeout without collecting transcripts or injecting history into agent
+context. A previous successful handshake establishes no present delivery fact, and a
+connected Claude MCP server does not establish Channels admission. No capability flags
+were raised. Codex still requires recorded consent and a reachable verified local service;
+ACC does not start its daemon. Durable inbox access remains the fallback.
+
+## Gates and review
+
+`npm ci` passed; syntax checking covered 474 modules. All 23 managed installation/update
+acceptance checks passed. Independent read-only reviews found no blocker in the ownership
+fix or the version/documentation changes. Following [Releasing](../RELEASING.md), the
+complete suite runs after this evidence commit and through the mandatory pre-push gate.
+The PR reports the completed result and CI status. Publication and merge are separate;
+the maintainer performs the merge.

--- a/docs/release-evidence/v0.4.2.md
+++ b/docs/release-evidence/v0.4.2.md
@@ -6,7 +6,7 @@ on the next genuine prompt after a solo detach removes its ephemeral owner.
 
 | Measurement | Value |
 |---|---|
-| Source commit A | `1a3249d2602a80d362cfcce412afeb548f378f51` |
+| Source commit A | `c3fde79aa26d462ddf99e3476e5a60656d2701fa` |
 | Archive | `agents-can-communicate-0.4.2.tgz` |
 | SHA-256 | `d509cd6a43c92e6fc0a5227a1a5499dfde0636385ede910f289a5c81c059a555` |
 | Size / files | 340,886 bytes / 255 files |
@@ -58,7 +58,14 @@ and passed with the fix.
 
 The focused owner-race test opens a replacement during client probing. It passed with
 the generation recheck, failed when that exact recheck was disabled, and passed again
-after restoration. Eight focused ownership tests passed on the final source.
+after restoration. Eight focused ownership tests passed. The first full suite then caught two existing
+checks that still required no owner after a genuine turn found a missing record. Those
+checks now require a fresh, usable pair and reject the pending pair; tool hooks and
+mismatched existing generations still cannot create or expose ownership. All 17 installed
+crash/lifecycle checks passed, failed under an exact reversion of missing-owner recovery,
+and passed again after restoration. The two test files are not packed. Repacking from
+the final source above produced bytes identical to the archive already verified in the
+published-version upgrade, so that installed evidence applies unchanged.
 
 Earlier focused fixes in this branch also passed their RED/GREEN checks and targeted
 mutations: missing Codex consent prompts, delivery fallback and launch guidance,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -114,59 +114,59 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.4.1"
+      "version": "0.4.2"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.4.1"
+      "version": "0.4.2"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.4.1"
+      "version": "0.4.2"
     },
     "packages/adapter-grok": {
       "name": "@agents-can-communicate/adapter-grok",
-      "version": "0.4.1"
+      "version": "0.4.2"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.4.1"
+      "version": "0.4.2"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.4.1"
+      "version": "0.4.2"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.4.1"
+      "version": "0.4.2"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.4.1"
+      "version": "0.4.2"
     },
     "packages/delivery-router": {
       "name": "@agents-can-communicate/delivery-router",
-      "version": "0.4.1"
+      "version": "0.4.2"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.4.1"
+      "version": "0.4.2"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.4.1"
+      "version": "0.4.2"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.4.1"
+      "version": "0.4.2"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.4.1"
+      "version": "0.4.2"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.4.1"
+      "version": "0.4.2"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "description": "Local-first coordination for independently opened AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/COMPATIBILITY.md
+++ b/packages/adapter-claude-code/COMPATIBILITY.md
@@ -705,3 +705,29 @@ tool results reported errors; their text was not retained, so their causes canno
 be classified from this capture. The final outcome and independent checks passed.
 No ACC runtime, maintained test or capability changed; delivery stayed off. Only
 Claude ran natively in this capture, and no native Codex settings were changed.
+## Startup admission check, 2026-09-09 (no model delivery capture)
+
+Claude Code 2.1.266 on darwin-arm64 was launched through the ordinary ACC-generated
+shim in a disposable profile. ACC was installed from the development archive built
+from `5503e2a867f23215c7e8fc8aa072ab4efd9b725f`, SHA-256
+`04ce871d1a79f47f4bac14795a7c26d9bfe627df08b57bd300534fe97990d064`.
+The profile used a dummy API key and an unreachable localhost model endpoint; this
+exercise did not authenticate to a model or demonstrate a model receiving a message.
+
+On the first completed startup, bootstrap reported `supported: true`, `/mcp` showed
+the ACC Channel connected with two tools, and ACC published an `actionable` binding
+for the actual Claude PID. Claude nevertheless reported that it ignored the development
+flag because Channels were not currently available. On the next launch of that same
+profile, Claude displayed its development-channel warning. The cause of that change
+in vendor availability was not established; restarting is not a guaranteed remedy.
+
+A metadata-only witness on the second launch observed `actionable` in the MCP child
+and subsequent prompt hook. MCP initialization used protocol `2025-11-25`, client
+version `2.1.266`, roots/listChanged and elicitation capabilities; it did not report
+whether Claude admitted inbound Channel notifications. No raw conversation content
+was retained as evidence, and no capability certification is added by this check.
+
+This exposes a diagnostic limit: ACC's native binding verifies its local endpoint,
+not the vendor's inbound Channel gate. Install/doctor now name the separate client-side
+check, and doctor calls the observed state a local active transport. The remote report
+of an empty binding list remains unconfirmed; it was not reproduced by this local run.

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-claude-code/src/adapter.mjs
+++ b/packages/adapter-claude-code/src/adapter.mjs
@@ -11,9 +11,9 @@ import { bindNativeSession, offerMessage, planNativeActivation, probeNativeDeliv
 export const CLAUDE_CODE_VERSION = "2.1.233";
 export const CLAUDE_CHANNEL_MINIMUM = "2.1.258";
 export const CLAUDE_DELIVERY_FALLBACK = Object.freeze({
-  diagnostic: "Claude Code native delivery is off: the 2.1.252 capture stopped at the "
-    + "development-channel security warning before the ACC MCP child started; messages "
-    + "stay durable for certified next-turn delivery or acc inbox",
+  diagnostic: "Claude Code native delivery requires client-side Channels activation; "
+    + "a successful bootstrap or connected ACC MCP server does not prove inbound delivery "
+    + "is enabled. Messages remain durable for certified next-turn delivery or acc inbox",
 });
 
 /**

--- a/packages/adapter-claude-code/src/install.mjs
+++ b/packages/adapter-claude-code/src/install.mjs
@@ -1,6 +1,9 @@
 import { cp, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
+// Kept together above 300 lines: source and cache publication, vendor registry
+// merges and their exact uninstall share one ownership transaction and helpers.
+
 import { AccError, EXIT } from "@agents-can-communicate/protocol";
 import { fileURLToPath } from "node:url";
 
@@ -19,6 +22,9 @@ const manifest = fileURLToPath(new URL("../plugin/.claude-plugin/plugin.json",
 const PLUGIN_NAME = "agents-can-communicate";
 const MARKETPLACE = "acc-local";
 const QUALIFIED = `${PLUGIN_NAME}@${MARKETPLACE}`;
+const CHANNEL_ACTIVATION_CHECK = "Check Claude's Channels startup notice for ACC; "
+  + "an MCP connection does not verify inbound delivery. If Channels are unavailable "
+  + "or blocked, resolve that client warning before expecting live messages.";
 
 /**
  * How this client actually installs a plugin.
@@ -244,6 +250,7 @@ export async function installClaudePlugin({ configDir, runner, cli, preserveVers
     changes: [source, cached, marketplaceFile(configDir),
       knownMarketplacesPath(configDir), installedPluginsPath(configDir), file,
       ...(live ? [mcpPath(source), mcpPath(cached)] : [])],
+    needsAction: live ? [CHANNEL_ACTIVATION_CHECK] : [],
     diagnostics: live
       ? ["native channel wired; Claude's experimental development-channel warning still applies"]
       : [] };
@@ -290,7 +297,10 @@ export async function detectClaude({ configDir }) {
   const registered = Object.hasOwn(
     (await readJson(installedPluginsPath(configDir), { plugins: {} })).plugins ?? {},
     QUALIFIED);
+  const channelConfigured = enabled && registered
+    && (await readJson(mcpPath(sourceDir(configDir)), null))?.mcpServers?.["acc-channel"] != null;
   return { ok: true, changes: [],
+    needsAction: channelConfigured ? [CHANNEL_ACTIVATION_CHECK] : [],
     diagnostics: [enabled && registered
       ? "acc plugin registered and enabled"
       : "acc plugin not registered"] };

--- a/packages/adapter-claude-code/test/adapter.test.mjs
+++ b/packages/adapter-claude-code/test/adapter.test.mjs
@@ -245,10 +245,10 @@ test("doctor states that the handoff is not written at SessionEnd", async t => {
   // summarise anything. Saying so in doctor keeps the limitation visible.
   assert.match(report.diagnostics.join(" "), /while the model is active/);
   assert.match(report.diagnostics.join(" "), /captured/);
-  assert.match(report.diagnostics.join(" "), /2\.1\.252/,
-    "doctor hid which native-delivery capture failed");
-  assert.match(report.diagnostics.join(" "), /development-channel security warning/,
-    "doctor hid the client boundary that prevented native delivery");
+  assert.match(report.diagnostics.join(" "), /client-side Channels activation/,
+    "doctor hid the admission check that MCP connection cannot establish");
+  assert.doesNotMatch(report.diagnostics.join(" "), /native delivery is off/,
+    "a historical failed capture was reported as current delivery state");
   assert.match(report.diagnostics.join(" "), /next-turn.*acc inbox/,
     "doctor did not name the durable fallback");
 });

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/src/app-server-client.mjs
+++ b/packages/adapter-codex/src/app-server-client.mjs
@@ -65,7 +65,7 @@ export async function probeCodexQueue(peer, { threadId, minimum = MINIMUM_VERSIO
       const loaded = await pageAll(peer, "thread/loaded/list", {});
       threadId = loaded.find(id => typeof id === "string" && id !== "");
       if (threadId === undefined) return { supported: false, serverVersion,
-        reasonCode: "feature_probe_failed" };
+        reasonCode: "native_session_unavailable" };
     }
     queueEntries(await peer.request("thread/queue/list", { threadId }));
   } catch (error) {

--- a/packages/adapter-codex/src/native-delivery.mjs
+++ b/packages/adapter-codex/src/native-delivery.mjs
@@ -35,7 +35,7 @@ export async function probeNativeDelivery({ timeoutMs = 750, env = process.env,
   const unsupported = (reasonCode, clientVersion = null) => ({ supported: false, clientVersion,
     protocolContract: PROTOCOL_CONTRACT, executableFingerprint: null, modes: [], reasonCode });
   const socketPath = controlSocketPath(env);
-  if (!await socketIsReady(socketPath)) return unsupported("feature_probe_failed");
+  if (!await socketIsReady(socketPath)) return unsupported("native_endpoint_unavailable");
   try {
     return await usingPeer(socketPath, timeoutMs, open, async peer => {
       const probe = await probeCodexQueue(peer);

--- a/packages/adapter-codex/test/native-delivery.test.mjs
+++ b/packages/adapter-codex/test/native-delivery.test.mjs
@@ -18,7 +18,10 @@ test("a live queue probe succeeds without rewriting the vendor invocation", asyn
   assert.deepEqual(probe.modes, ["livePush", "idleWake", "busyQueue"]);
   assert.equal(probe.clientVersion, "0.152.1");
   h.state.loaded = [];
-  assert.equal((await native.probeNativeDelivery(h)).supported, false);
+  assert.equal((await native.probeNativeDelivery(h)).reasonCode, "native_session_unavailable");
+  const absent = await native.probeNativeDelivery({ env: { CODEX_HOME: path.join(h.root, "absent") } });
+  assert.equal(absent.reasonCode, "native_endpoint_unavailable");
+  assert.equal(absent.supported, false);
 });
 
 test("binding stores an opaque receiver address after checking the exact loaded thread", async t => {

--- a/packages/adapter-gemini-cli/extension/gemini-extension.json
+++ b/packages/adapter-gemini-cli/extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Coordinate this Gemini CLI session with other AI agent sessions working in the same workspace.",
   "contextFileName": "skills/acc/SKILL.md"
 }

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-grok/package.json
+++ b/packages/adapter-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-grok",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-sdk/src/index.mjs
+++ b/packages/adapter-sdk/src/index.mjs
@@ -23,3 +23,5 @@ export { formatJsonAs, jsonStyleOf, mergeOwnedConfig, mergeOwnedEntries, ownedEn
 export { clearSessionBinding, listSessionBindings, loadSessionBinding,
   storeSessionBinding }
   from "./session-binding.mjs";
+
+export { clearNativeAttempt, loadNativeAttempt, storeNativeAttempt } from "./native-attempt.mjs";

--- a/packages/adapter-sdk/src/native-attempt-writer.mjs
+++ b/packages/adapter-sdk/src/native-attempt-writer.mjs
@@ -1,0 +1,64 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { parentPort, workerData } from "node:worker_threads";
+
+import { assertPortableId } from "@agents-can-communicate/protocol";
+import { withWriterMutex } from "@agents-can-communicate/storage-filesystem";
+import { loadNativeAttempt, nativeAttemptFrom } from "./native-attempt.mjs";
+
+const keyFor = harnessSessionId => createHash("sha256").update(String(harnessSessionId))
+  .digest("hex").slice(0, 32);
+const fileFor = (runtimeDir, harnessSessionId) =>
+  path.join(runtimeDir, "native-attempts", `${keyFor(harnessSessionId)}.json`);
+const checkDeadline = deadline => {
+  if (Date.now() >= deadline) throw new Error("native diagnostic deadline expired");
+};
+
+// The caller stops waiting after 250 ms at most. An in-flight filesystem call
+// may complete later, so retain this SEPARATE mutex until its continuation is
+// finished. Unique staging names also isolate cleanup after stale-lock recovery.
+// No diagnostic operation can touch the authoritative hook-owner file.
+async function boundedWrite(input, operation) {
+  const deadline = input.deadlineAt;
+  try {
+    checkDeadline(deadline);
+    await withWriterMutex({ locks: path.join(input.runtimeDir, "native-attempt-locks",
+      keyFor(input.harnessSessionId)) }, { root: input.runtimeDir,
+      clock: { now: () => new Date().toISOString() }, deadlineAt: deadline },
+    () => operation(deadline));
+    return true;
+  } catch { return false; }
+}
+
+async function storeNativeAttempt(input) {
+  return boundedWrite(input, async deadline => {
+    const { runtimeDir, harnessSessionId, accSessionId, generation } = input;
+    assertPortableId(accSessionId, "native diagnostic session id");
+    assertPortableId(generation, "native diagnostic generation");
+    const attempt = nativeAttemptFrom(input.nativeAttempt);
+    if (attempt === null) return;
+    const file = fileFor(runtimeDir, harnessSessionId);
+    const temporary = `${file}.${randomUUID()}.tmp`;
+    checkDeadline(deadline);
+    await mkdir(path.dirname(file), { recursive: true });
+    try {
+      checkDeadline(deadline);
+      await writeFile(temporary, JSON.stringify({ schemaVersion: 1, accSessionId, generation,
+        attempt }) + "\n", "utf8");
+      checkDeadline(deadline);
+      await rename(temporary, file);
+    } finally { await rm(temporary, { force: true }).catch(() => {}); }
+  });
+}
+
+async function clearNativeAttempt(input) {
+  return boundedWrite(input, async deadline => {
+    if (await loadNativeAttempt(input) === null) return;
+    checkDeadline(deadline);
+    await rm(fileFor(input.runtimeDir, input.harnessSessionId), { force: true });
+  });
+}
+
+const operation = workerData.operation === "clear" ? clearNativeAttempt : storeNativeAttempt;
+parentPort.postMessage(await operation(workerData.input));

--- a/packages/adapter-sdk/src/native-attempt.mjs
+++ b/packages/adapter-sdk/src/native-attempt.mjs
@@ -1,0 +1,65 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { Worker } from "node:worker_threads";
+
+import { NATIVE_REASON_CODES, TIMESTAMP } from "./native-vocabulary.mjs";
+
+// Optional diagnostic metadata beside the hook-owner file, never an event
+// history or injected context. Copy only closed values: vendor errors, prompts,
+// endpoints and extra properties must not survive persistence or doctor reads.
+export function nativeAttemptFrom(value) {
+  if (!value || typeof value.at !== "string" || !TIMESTAMP.test(value.at)
+    || !Number.isFinite(Date.parse(value.at))
+    || !["sessionStart", "beforeTurn"].includes(value.event)
+    || !["active", "off", "degraded", "unsupported"].includes(value.state)
+    || !(value.reasonCode === null || NATIVE_REASON_CODES.includes(value.reasonCode))
+    || !["off", "actionable", "all"].includes(value.policy)
+    || !["bootstrap-environment", "installation-record"].includes(value.policySource)
+    || !["enabled", "off", "missing", "invalid", "unavailable"].includes(value.policyStatus)
+    || !["identified", "unknown"].includes(value.clientProcess)) return null;
+  return { at: value.at, event: value.event, state: value.state, reasonCode: value.reasonCode,
+    policy: value.policy, policySource: value.policySource, policyStatus: value.policyStatus,
+    clientProcess: value.clientProcess };
+}
+
+const keyFor = harnessSessionId => createHash("sha256").update(String(harnessSessionId))
+  .digest("hex").slice(0, 32);
+const fileFor = (runtimeDir, harnessSessionId) =>
+  path.join(runtimeDir, "native-attempts", `${keyFor(harnessSessionId)}.json`);
+export async function loadNativeAttempt({ runtimeDir, harnessSessionId, accSessionId, generation }) {
+  try {
+    const record = JSON.parse(await readFile(fileFor(runtimeDir, harnessSessionId), "utf8"));
+    return record.schemaVersion === 1 && record.accSessionId === accSessionId
+      && record.generation === generation ? nativeAttemptFrom(record.attempt) : null;
+  } catch { return null; }
+}
+
+// Isolate filesystem requests as well as JS waiting: even a stuck fs request
+// must not keep the vendor's short-lived hook process alive after its output.
+// The unreferenced worker owns its mutex through any late I/O continuation.
+async function writeDiagnostic(operation, input) {
+  const deadlineAt = Math.min(input.deadlineAt ?? Infinity, Date.now() + 250);
+  if (Date.now() >= deadlineAt) return false;
+  let worker;
+  let timer;
+  try {
+    worker = new Worker(new URL("./native-attempt-writer.mjs", import.meta.url), {
+      workerData: { operation, input: { runtimeDir: input.runtimeDir,
+        harnessSessionId: input.harnessSessionId, accSessionId: input.accSessionId,
+        generation: input.generation, nativeAttempt: nativeAttemptFrom(input.nativeAttempt), deadlineAt } },
+    });
+    const result = new Promise(resolve => {
+      worker.once("message", value => resolve(value === true));
+      worker.once("error", () => resolve(false));
+      worker.once("exit", () => resolve(false));
+      timer = setTimeout(() => resolve(false), Math.max(0, deadlineAt - Date.now()));
+    });
+    worker.unref();
+    return await result;
+  } catch { return false; }
+  finally { clearTimeout(timer); }
+}
+
+export const storeNativeAttempt = input => writeDiagnostic("store", input);
+export const clearNativeAttempt = input => writeDiagnostic("clear", input);

--- a/packages/adapter-sdk/src/native-vocabulary.mjs
+++ b/packages/adapter-sdk/src/native-vocabulary.mjs
@@ -23,6 +23,7 @@ export const NATIVE_REASON_CODES = Object.freeze([
   "native_delivery_unsupported", "platform_not_captured", "version_unavailable",
   "prerelease_not_captured", "below_minimum_version", "known_bad_version",
   "feature_probe_failed", "probe_timeout", "probe_version_mismatch", "protocol_mismatch",
+  "native_endpoint_unavailable", "native_session_unavailable",
   "handshake_failed", "handshake_timeout", "handshake_version_mismatch",
   "session_generation_stale", "client_process_unknown", "unsupported_shell",
   // The current session's canonical workspace identity could not be verified.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/src/doctor-command.mjs
+++ b/packages/cli/src/doctor-command.mjs
@@ -266,7 +266,8 @@ export async function runDoctor({ options, context, runtime }) {
   // eligibility, the recorded policy, and the live runtime state. It never
   // claims that "active" means a model read anything.
   ...adapters.filter(adapter => adapter.present)
-    .map(adapter => `  ${adapter.displayName} live delivery: ${describeNative(adapter.nativeDelivery)}; `
+    .map(adapter => `  ${adapter.displayName} live delivery: `
+      + `${describeNative(adapter.nativeDelivery, { clientVersion: adapter.version })}; `
       + `fallback: ${describeDeliveryFallback(adapter)}`),
   ...(manager === null ? [] : [`  automatic updates ${manager.auto ? "on" : "off"}; ACC ${manager.active.version}`
     + (manager.pin ? `; pinned to ${manager.pin}` : ""), ...(manager.notice ? [`  ${manager.notice}`] : [])]),

--- a/packages/cli/src/doctor-command.mjs
+++ b/packages/cli/src/doctor-command.mjs
@@ -9,6 +9,8 @@ import { AccError, EXIT } from "@agents-can-communicate/protocol";
 import { describeNative, nativeRemediation, nativeState, updateNativeRuntime } from "./native-delivery-status.mjs";
 export { describeNative } from "./native-delivery-status.mjs";
 
+import { nativeSessionLines, updateNativeSessions } from "./native-session-diagnostics.mjs";
+
 import { ALL_ADAPTERS, clientContext, probeTimeout } from "./install-command.mjs";
 import { describePresence } from "./main.mjs";
 import { platformPaths } from "./platform-paths.mjs";
@@ -231,6 +233,7 @@ export async function runDoctor({ options, context, runtime }) {
   const service = context.service ?? await context.openService();
   const status = await service.collectStatus({});
   updateNativeRuntime(adapters, status.deliveryBindings);
+  await updateNativeSessions(adapters, { service, status, root, now: clock.now() });
   for (const adapter of adapters) {
     adapter.remediation.push(...nativeRemediation(adapter));
   }
@@ -269,6 +272,7 @@ export async function runDoctor({ options, context, runtime }) {
     .map(adapter => `  ${adapter.displayName} live delivery: `
       + `${describeNative(adapter.nativeDelivery, { clientVersion: adapter.version })}; `
       + `fallback: ${describeDeliveryFallback(adapter)}`),
+  ...nativeSessionLines(adapters),
   ...(manager === null ? [] : [`  automatic updates ${manager.auto ? "on" : "off"}; ACC ${manager.active.version}`
     + (manager.pin ? `; pinned to ${manager.pin}` : ""), ...(manager.notice ? [`  ${manager.notice}`] : [])]),
   ...data.remediation.map(line => `  ${line}`),

--- a/packages/cli/src/doctor-command.mjs
+++ b/packages/cli/src/doctor-command.mjs
@@ -2,9 +2,12 @@ import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 
-import { detectInstallation, livePolicyOf, loadOwnership, shellOf, verifyOwned }
+import { describeDeliveryFallback, detectInstallation, livePolicyOf, loadOwnership, shellOf, verifyOwned }
   from "@agents-can-communicate/installer";
 import { AccError, EXIT } from "@agents-can-communicate/protocol";
+
+import { describeNative, nativeRemediation, nativeState, updateNativeRuntime } from "./native-delivery-status.mjs";
+export { describeNative } from "./native-delivery-status.mjs";
 
 import { ALL_ADAPTERS, clientContext, probeTimeout } from "./install-command.mjs";
 import { describePresence } from "./main.mjs";
@@ -66,21 +69,6 @@ export function staleInstall({ recorded, running }) {
   return recorded === running ? null : { recorded, running };
 }
 
-const RUNTIME_LABEL = Object.freeze({ active: "active", waiting: "waiting for a live session",
-  inactive: "not enabled", degraded: "degraded", unsupported: "unsupported" });
-
-/** One human clause for a native-delivery state, next-action implied, never overclaiming. */
-export function describeNative(native) {
-  if (native.eligibility === "unsupported") {
-    return `unsupported${native.reasonCode ? ` (${native.reasonCode})` : ""}`;
-  }
-  const enabled = native.configured ? `enabled (${native.policy})` : "eligible, not enabled";
-  const runtime = RUNTIME_LABEL[native.runtime] ?? native.runtime;
-  const degraded = native.eligibility === "degraded" && native.reasonCode
-    ? ` - ${native.reasonCode}` : "";
-  return `${native.eligibility} - ${enabled} - ${runtime}${degraded}`;
-}
-
 /**
  * The runner version behind whatever ACC wrote for one client.
  *
@@ -115,25 +103,6 @@ async function findShims(root, depth) {
     else if (entry.name.endsWith(".sh")) found.push(target);
   }
   return found;
-}
-
-// One closed native-delivery report per adapter, built only from detection,
-// ownership, and later the live binding facts - never inferred from a
-// configured shim alone. eligibility is what the client could do; configured is
-// whether a policy was recorded; policy is that recorded policy; runtime is
-// filled in from current bindings; modes and reasonCode carry the closed
-// detail. runtime "active" never means the model read anything.
-function nativeState(detected, recordedPolicy) {
-  const native = detected ?? { state: "unsupported", reasonCode: "native_delivery_unsupported" };
-  const eligibility = native.state === "eligible" ? "eligible"
-    : native.state === "degraded" ? "degraded" : "unsupported";
-  const policy = recordedPolicy ?? "off";
-  const configured = policy !== "off";
-  const modes = native.state === "eligible" && Array.isArray(native.probe?.modes)
-    ? [...native.probe.modes] : [];
-  const runtime = eligibility === "unsupported" ? "unsupported"
-    : !configured ? "inactive" : "waiting";
-  return { eligibility, configured, policy, runtime, modes, reasonCode: native.reasonCode ?? null };
 }
 
 export async function diagnoseAdapters({ options, runtime, detect = detectInstallation }) {
@@ -203,7 +172,9 @@ export async function diagnoseAdapters({ options, runtime, detect = detectInstal
     // divergence legible rather than hidden behind a single reassuring number.
     return { ...entry, stale, wired, bundleVersion, owned: { modified: owned.modified,
       missing: owned.missing, intact: owned.intact.length },
-      nativeDelivery: nativeState(entry.nativeDelivery, livePolicyOf(installed)), remediation };
+      nativeDelivery: nativeState(entry.nativeDelivery, livePolicyOf(installed), {
+        contract: adapters.find(adapter => adapter.id === entry.adapterId)?.nativeDelivery,
+        activation: installed?.nativeActivation }), remediation };
   }));
 }
 
@@ -259,22 +230,9 @@ export async function runDoctor({ options, context, runtime }) {
   // front.
   const service = context.service ?? await context.openService();
   const status = await service.collectStatus({});
-  // The runtime column is the only part that needs a live read: a current
-  // reachable binding for this adapter is "active", an expired one "degraded".
-  const bindingsByAdapter = new Map();
-  for (const binding of status.deliveryBindings ?? []) {
-    const existing = bindingsByAdapter.get(binding.adapterId);
-    if (existing === undefined || binding.reachable) bindingsByAdapter.set(binding.adapterId, binding);
-  }
+  updateNativeRuntime(adapters, status.deliveryBindings);
   for (const adapter of adapters) {
-    const native = adapter.nativeDelivery;
-    if (native.eligibility === "unsupported") continue;
-    const binding = bindingsByAdapter.get(adapter.adapterId);
-    native.runtime = binding === undefined ? (native.configured ? "waiting" : "inactive")
-      : binding.reachable ? "active" : "degraded";
-    if (binding !== undefined && Array.isArray(binding.availableModes)) {
-      native.modes = binding.availableModes.filter(mode => mode !== "nextTurn");
-    }
+    adapter.remediation.push(...nativeRemediation(adapter));
   }
 
   const data = {
@@ -301,13 +259,15 @@ export async function runDoctor({ options, context, runtime }) {
   const text = [`store healthy; ${describePresence(status.counts)}; `
     + `protection ${status.protection}; ${installed} of ${adapters.length} adapter(s) installed`,
   ...adapters.filter(adapter => (adapter.present || adapter.installed)
+    && adapter.nativeDelivery.reasonCode === "native_delivery_unsupported"
     && typeof adapter.deliveryDiagnostic === "string")
     .map(adapter => `  ${adapter.deliveryDiagnostic}`),
   // One concise native-delivery line per detected client, distinguishing
   // eligibility, the recorded policy, and the live runtime state. It never
   // claims that "active" means a model read anything.
   ...adapters.filter(adapter => adapter.present)
-    .map(adapter => `  ${adapter.displayName} native delivery: ${describeNative(adapter.nativeDelivery)}`),
+    .map(adapter => `  ${adapter.displayName} live delivery: ${describeNative(adapter.nativeDelivery)}; `
+      + `fallback: ${describeDeliveryFallback(adapter)}`),
   ...(manager === null ? [] : [`  automatic updates ${manager.auto ? "on" : "off"}; ACC ${manager.active.version}`
     + (manager.pin ? `; pinned to ${manager.pin}` : ""), ...(manager.notice ? [`  ${manager.notice}`] : [])]),
   ...data.remediation.map(line => `  ${line}`),

--- a/packages/cli/src/install-command.mjs
+++ b/packages/cli/src/install-command.mjs
@@ -148,8 +148,8 @@ export function describeOutcome({ action, acted, failed = [], skipped = [],
   ...operations.filter(operation => operation.applied)
     .flatMap(operation => describeChanges(operation, home)),
   ...operations.filter(operation => operation.applied
-    && typeof operation.deliveryDiagnostic === "string")
-    .map(operation => `  ${operation.deliveryDiagnostic}`),
+    && typeof (operation.deliverySummary ?? operation.deliveryDiagnostic) === "string")
+    .map(operation => `  ${operation.deliverySummary ?? operation.deliveryDiagnostic}`),
   ...operations.filter(operation => operation.applied)
     .flatMap(operation => (operation.needsAction ?? [])
       .map(step => `  ${operation.adapterId}: ${step}`)),
@@ -203,42 +203,21 @@ export function actedOn(result) {
 const isInteractive = runtime => typeof runtime.isInteractive === "function"
   && runtime.isInteractive() === true;
 
-/**
- * One default-No question per eligible client, asked only after detection has
- * finished and only when a person is at both ends of the terminal.
- *
- * Written for someone who has never heard of this project. It used to open with
- * "Enable native live delivery" over a list of internal artefact names, which
- * told a first-time reader neither what they would gain nor what it would cost -
- * and left out the part that matters most: saying yes makes their own `claude`
- * start with the vendor's `--dangerously-load-development-channels` flag. A
- * consent prompt that hides the loudest consequence is not consent.
- *
- * So the order is the reader's, not the installer's: what changes for them,
- * what it costs, what it touches, and that "no" costs them nothing.
- */
-function questionFor(entry, context, { onlyEligible = false } = {}) {
-  const bootstrap = entry.nativeDelivery.activationPlan.mechanisms
+// One default-No question per supported client. Disclose token use and any
+// repeated channel prompt; declining only promises a verified fallback.
+function questionFor(entry) {
+  const bootstrap = entry.nativeDelivery.activationPlan?.mechanisms
     .find(mechanism => mechanism.kind === "shell-bootstrap") ?? null;
-  // The presence of a flag is what makes this worth asking about at all: it is
-  // why the client will warn at every start from now on. Which flag it is, and
-  // that a shim adds it, are answers to a question nobody is asking here - the
-  // shim `exec`s and is gone, so nothing runs "through" acc afterwards either.
-  const flags = (bootstrap?.prefixArgs ?? []).filter(argument => argument.startsWith("--"));
-  void context;
-  // Why the default is No, and why only one client is being asked about, are
-  // the two questions the bare prompt provokes and never answered: a `[y/N]`
-  // reads as "not recommended" on its own, and a single question among four
-  // installed clients reads as an omission. Both have the same short answer.
-  const aside = ["experimental", ...(onlyEligible ? [`${entry.displayName} only`] : [])]
-    .join("; ");
+  const warns = (bootstrap?.prefixArgs ?? []).some(argument => argument.startsWith("--"));
   return [
-    `Let idle agents answer each other while you are away?  (${aside})`,
-    ...(flags.length === 0 || bootstrap === null
-      ? ["  Yes: they reply without waiting for you."]
-      : [`  Yes: they reply without waiting for you, and ${entry.displayName} asks you`,
-        "       to allow development channels every time it starts."]),
-    "  No:  messages still arrive, at the session's next turn.",
+    `Let ${entry.displayName} answer peer requests while idle? (experimental)`,
+    "  Yes: automatic turns can spend tokens without waiting for you.",
+    ...(warns ? ["       Allow development channels each time the client starts."] : []),
+    ...(entry.nativeDelivery.state !== "eligible"
+      ? ["       Save consent now; delivery waits for an available client service."] : []),
+    entry.capabilities?.delivery?.nextTurn === true
+      ? "  No:  use next-turn hooks (when enabled) or acc inbox."
+      : "  No:  read messages with acc inbox; automatic next-turn delivery is unavailable.",
   ].join("\n");
 }
 
@@ -250,22 +229,18 @@ function questionFor(entry, context, { onlyEligible = false } = {}) {
  * client is off unless a person answers yes here, and a dry run or a
  * non-interactive stdin/stdout makes no interactive choice at all.
  */
-export async function decideDelivery({ options, detected, recorded, runtime, dryRun, context }) {
+export async function decideDelivery({ options, detected, recorded, runtime, dryRun }) {
   const explicit = options.delivery;
   if (explicit !== undefined && !LIVE_POLICIES.includes(explicit)) {
     throw new AccError(EXIT.USAGE, `unknown delivery policy: ${explicit}`, { delivery: explicit });
   }
   const recordedById = new Map(recorded.map(install => [install.adapterId, install]));
-  // Whether this client is the only one that could be asked at all. When it is,
-  // the question says so, because otherwise being asked about one of four
-  // installed clients looks like the other three were forgotten.
-  const onlyEligible = detected
-    .filter(candidate => candidate.nativeDelivery?.state === "eligible").length === 1;
   const deliveryByAdapter = {};
   const asked = [];
   let withheld = 0;
   for (const entry of detected) {
-    const eligible = entry.nativeDelivery?.state === "eligible";
+    const eligible = entry.nativeDelivery?.state === "eligible"
+      || entry.nativeDelivery?.consentAvailable === true;
     const previous = livePolicyOf(recordedById.get(entry.adapterId));
     if (explicit !== undefined) {
       deliveryByAdapter[entry.adapterId] = explicit;
@@ -275,7 +250,7 @@ export async function decideDelivery({ options, detected, recorded, runtime, dry
       deliveryByAdapter[entry.adapterId] = "off";
       if (eligible) withheld += 1;
     } else {
-      const yes = await runtime.confirm(questionFor(entry, context, { onlyEligible }),
+      const yes = await runtime.confirm(questionFor(entry),
         { input: runtime.input, output: runtime.output }) === true;
       deliveryByAdapter[entry.adapterId] = yes ? "actionable" : "off";
       asked.push(entry.adapterId);
@@ -333,7 +308,7 @@ export async function runInstallCommand({ options, runtime, action = "install" }
   // Decided only after detection, from the operator's explicit answer, the
   // recorded consent, or a default of off; never from inference.
   const decided = action === "install"
-    ? await decideDelivery({ options, detected, recorded, runtime, dryRun, context })
+    ? await decideDelivery({ options, detected, recorded, runtime, dryRun })
     : { deliveryByAdapter: {}, asked: [], notes: [] };
   const plan = planInstallation({ adapters, detected, context, action, recorded,
     accVersion, allowDowngrade: options.downgrade === true, requested,

--- a/packages/cli/src/install-command.mjs
+++ b/packages/cli/src/install-command.mjs
@@ -212,7 +212,7 @@ function questionFor(entry) {
   return [
     `Let ${entry.displayName} answer peer requests while idle? (experimental)`,
     "  Yes: automatic turns can spend tokens without waiting for you.",
-    ...(warns ? ["       Allow development channels each time the client starts."] : []),
+    ...(warns ? ["       Allow development channels when prompted; check the client's startup notice."] : []),
     ...(entry.nativeDelivery.state !== "eligible"
       ? ["       Save consent now; delivery waits for an available client service."] : []),
     entry.capabilities?.delivery?.nextTurn === true

--- a/packages/cli/src/native-delivery-status.mjs
+++ b/packages/cli/src/native-delivery-status.mjs
@@ -1,0 +1,87 @@
+import { describeNativeReason } from "@agents-can-communicate/installer";
+
+export function describeNative(native) {
+  const differs = native.runtime === "active" && native.sessionPolicy
+    && native.sessionPolicy !== native.policy;
+  const enabled = (native.configured ? `enabled (${native.policy})` : "off")
+    + (differs ? " for new sessions" : "");
+  const availability = native.eligibility === "eligible" ? "available"
+    : `${native.eligibility === "unsupported" ? "unavailable" : "readiness unverified"}: `
+      + describeNativeReason(native.reasonCode);
+  const runtime = native.runtime === "active"
+    ? `active${differs ? ` (session policy: ${native.sessionPolicy})` : ""}`
+    : native.runtime === "degraded" ? "channel unreachable"
+      : native.configured && native.runtime === "waiting"
+        ? "no live channel bound in this workspace" : null;
+  return [availability, enabled, ...(runtime ? [runtime] : [])].join("; ");
+}
+
+export function nativeRemediation(entry) {
+  const native = entry.nativeDelivery;
+  if (!(entry.present || entry.installed) || native.eligibility === "unsupported") return [];
+  const steps = [];
+  if (!native.configured && native.runtime !== "active") {
+    steps.push(`acc install --adapter ${entry.adapterId} --delivery actionable`
+      + "  # opt in to automatic peer requests; may spend tokens");
+  } else if (native.configured && native.activation === "missing") {
+    steps.push(`acc install --adapter ${entry.adapterId}`
+      + "  # complete the missing native launch setup from a supported shell");
+  } else if (native.configured && native.runtime !== "active") {
+    steps.push(`${entry.displayName}: no verified live channel in this workspace; `
+      + "open a new terminal, start a new client session and check its integration/channel prompts; "
+      + "then run acc doctor here");
+  }
+  if (native.reasonCode === "native_endpoint_unavailable") {
+    steps.push(`${entry.displayName}: check the client's local delivery service setup; `
+      + "ACC does not start or restart that service");
+  } else if (native.reasonCode === "native_session_unavailable") {
+    steps.push(`${entry.displayName}: open a session connected to the client's local delivery service`);
+  }
+  return steps;
+}
+
+// One closed native-delivery report per adapter, built only from detection,
+// ownership, and later the live binding facts - never inferred from a
+// configured shim alone. eligibility is what the client could do; configured is
+// whether a policy was recorded; policy is that recorded policy; runtime is
+// filled in from current bindings; modes and reasonCode carry the closed
+// detail. runtime "active" never means the model read anything.
+export function nativeState(detected, recordedPolicy, { contract, activation } = {}) {
+  const native = detected ?? { state: "unsupported", reasonCode: "native_delivery_unsupported" };
+  const eligibility = native.state === "eligible" ? "eligible"
+    : native.state === "degraded" ? "degraded" : "unsupported";
+  const policy = recordedPolicy ?? "off";
+  const configured = policy !== "off";
+  const modes = native.state === "eligible" && Array.isArray(native.probe?.modes)
+    ? [...native.probe.modes] : [];
+  const runtime = eligibility === "unsupported" ? "unsupported"
+    : !configured ? "inactive" : "waiting";
+  const setupRequired = contract?.activationKinds?.some(kind => kind !== "native-service") === true;
+  return { eligibility, configured, policy, runtime, modes, reasonCode: native.reasonCode ?? null,
+    policySource: contract?.policySource ?? null,
+    activation: !setupRequired ? "not_required"
+      : activation?.mechanisms?.length > 0 ? "recorded" : "missing", sessionPolicy: null };
+}
+
+// Native runtime is workspace-specific. A hook-only binding cannot prove it;
+// legacy launch policies may outlive the policy selected for future launches.
+export function updateNativeRuntime(adapters, bindings) {
+  const byAdapter = new Map();
+  for (const binding of bindings ?? []) {
+    if (!binding.availableModes?.includes("livePush")) continue;
+    const previous = byAdapter.get(binding.adapterId);
+    if (previous === undefined || binding.reachable) byAdapter.set(binding.adapterId, binding);
+  }
+  for (const entry of adapters) {
+    const native = entry.nativeDelivery;
+    if (native.eligibility === "unsupported") continue;
+    const binding = byAdapter.get(entry.adapterId);
+    const disabled = native.policySource === "installation-record" && !native.configured;
+    native.runtime = disabled ? "inactive"
+      : binding === undefined ? (native.configured ? "waiting" : "inactive")
+        : binding.reachable ? "active" : "degraded";
+    native.sessionPolicy = disabled || !binding ? null
+      : native.policySource === "installation-record" ? native.policy : binding.livePolicy;
+    if (binding) native.modes = binding.availableModes.filter(mode => mode !== "nextTurn");
+  }
+}

--- a/packages/cli/src/native-delivery-status.mjs
+++ b/packages/cli/src/native-delivery-status.mjs
@@ -1,13 +1,13 @@
 import { describeNativeReason } from "@agents-can-communicate/installer";
 
-export function describeNative(native) {
+export function describeNative(native, { clientVersion } = {}) {
   const differs = native.runtime === "active" && native.sessionPolicy
     && native.sessionPolicy !== native.policy;
   const enabled = (native.configured ? `enabled (${native.policy})` : "off")
     + (differs ? " for new sessions" : "");
   const availability = native.eligibility === "eligible" ? "available"
     : `${native.eligibility === "unsupported" ? "unavailable" : "readiness unverified"}: `
-      + describeNativeReason(native.reasonCode);
+      + describeNativeReason(native.reasonCode, { clientVersion, minimumVersion: native.minimumVersion });
   const runtime = native.runtime === "active"
     ? `active${differs ? ` (session policy: ${native.sessionPolicy})` : ""}`
     : native.runtime === "degraded" ? "channel unreachable"
@@ -58,6 +58,7 @@ export function nativeState(detected, recordedPolicy, { contract, activation } =
     : !configured ? "inactive" : "waiting";
   const setupRequired = contract?.activationKinds?.some(kind => kind !== "native-service") === true;
   return { eligibility, configured, policy, runtime, modes, reasonCode: native.reasonCode ?? null,
+    minimumVersion: native.eligibility?.minimumVersion ?? null,
     policySource: contract?.policySource ?? null,
     activation: !setupRequired ? "not_required"
       : activation?.mechanisms?.length > 0 ? "recorded" : "missing", sessionPolicy: null };

--- a/packages/cli/src/native-delivery-status.mjs
+++ b/packages/cli/src/native-delivery-status.mjs
@@ -9,7 +9,7 @@ export function describeNative(native, { clientVersion } = {}) {
     : `${native.eligibility === "unsupported" ? "unavailable" : "readiness unverified"}: `
       + describeNativeReason(native.reasonCode, { clientVersion, minimumVersion: native.minimumVersion });
   const runtime = native.runtime === "active"
-    ? `active${differs ? ` (session policy: ${native.sessionPolicy})` : ""}`
+    ? `local transport active${differs ? ` (session policy: ${native.sessionPolicy})` : ""}`
     : native.runtime === "degraded" ? "channel unreachable"
       : native.configured && native.runtime === "waiting"
         ? "no live channel bound in this workspace" : null;

--- a/packages/cli/src/native-session-diagnostics.mjs
+++ b/packages/cli/src/native-session-diagnostics.mjs
@@ -1,0 +1,64 @@
+import { listSessionBindings, loadNativeAttempt } from "@agents-can-communicate/adapter-sdk";
+import { describeNativeReason } from "@agents-can-communicate/installer";
+
+// Session diagnostics are read only here, never projected into agent context.
+// Verify the owner generation against core before attributing any last attempt.
+export async function updateNativeSessions(adapters, { service, status, root, now }) {
+  const owners = await listSessionBindings({ runtimeDir: root }).catch(() => []);
+  const transports = new Map();
+  for (const entry of adapters) {
+    const native = entry.nativeDelivery;
+    native.sessions = [];
+    if (native.reasonCode === "native_delivery_unsupported") continue;
+    for (const peer of status.participants.filter(p => p.harness === entry.adapterId)) {
+      const current = (await service.locateSession(peer.sessionId))?.record;
+      if (current?.state !== "open") continue;
+      const matches = owners.filter(owner => owner.accSessionId === peer.sessionId
+        && owner.generation === current.generation);
+      const owner = matches.length === 1 ? matches[0] : null;
+      if (!transports.has(peer.participantId)) {
+        transports.set(peer.participantId, await service.listDeliveryBindings({
+          participantId: peer.participantId, now, includeExpired: true }));
+      }
+      const binding = transports.get(peer.participantId).find(b => b.sessionId === peer.sessionId
+        && b.generation === current.generation && b.adapterId === entry.adapterId
+        && b.availableModes.includes("livePush"));
+      const runtime = native.policySource === "installation-record" && !native.configured
+        ? "inactive" : !binding ? "unbound"
+          : Date.parse(binding.leaseUntil) > Date.parse(now) ? "active" : "degraded";
+      native.sessions.push({ sessionId: peer.sessionId, participantId: peer.participantId,
+        presence: peer.presence, runtime,
+        lastAttempt: owner === null ? null : await loadNativeAttempt({ runtimeDir: root, ...owner }) });
+    }
+  }
+}
+
+const failures = {
+  client_process_unknown: "the client process could not be identified; start a new client session",
+  handshake_failed: "the session handshake failed; check the client's integration/channel setup",
+  handshake_timeout: "the session handshake timed out; check the local channel and retry on the next turn",
+  handshake_version_mismatch: "the session and CLI versions differ; start a new client session",
+  session_generation_stale: "the session was replaced during the handshake",
+};
+
+function describeAttempt(attempt) {
+  if (attempt === null) return "no native binding attempt observed for this generation; "
+    + "check client hooks; an older hook runtime or a failed diagnostic write can also leave no record";
+  let detail;
+  if (attempt.state === "off") {
+    const source = attempt.policySource === "bootstrap-environment" ? "launch" : "installation";
+    detail = attempt.policyStatus === "missing" ? `${source} delivery policy was absent`
+      : attempt.policyStatus === "invalid" ? `${source} delivery policy was invalid`
+        : attempt.policyStatus === "unavailable" ? `${source} delivery policy could not be read`
+          : `${source} delivery policy was off`;
+  } else if (attempt.state === "active") detail = "local handshake succeeded";
+  else detail = failures[attempt.reasonCode] ?? describeNativeReason(attempt.reasonCode);
+  return `last attempt ${attempt.at}: ${detail}`;
+}
+
+export function nativeSessionLines(adapters) {
+  return adapters.flatMap(entry => (entry.nativeDelivery.sessions ?? []).map(session =>
+    `  ${entry.displayName} session ${session.participantId} (${session.sessionId}): `
+    + `${session.runtime === "active" ? "local transport active" : session.runtime}; `
+    + describeAttempt(session.lastAttempt)));
+}

--- a/packages/cli/test/install-command.test.mjs
+++ b/packages/cli/test/install-command.test.mjs
@@ -303,7 +303,7 @@ test("an interactive install asks one default-No question per eligible client", 
     "each choice must identify its recipient");
   assert.match(first, /experimental/);
   assert.match(first, /automatic turns can spend tokens/);
-  assert.match(first, /Allow development channels each time the client starts/);
+  assert.match(first, /Allow development channels when prompted/);
   assert.match(first, /No:.*acc inbox/);
   assert.doesNotMatch(first, /messages still arrive, at the session.s next turn/);
   assert.doesNotMatch(first, /--captured|PATH|shim|launcher|plugin entry|\.zshrc/);

--- a/packages/cli/test/install-command.test.mjs
+++ b/packages/cli/test/install-command.test.mjs
@@ -298,55 +298,20 @@ test("an interactive install asks one default-No question per eligible client", 
   assert.equal(questions.length, 2, "the ineligible client is reported, not asked");
   const [first, io] = questions[0];
 
-  // Written for someone who has never heard of this project. The old wording
-  // opened with "Enable native live delivery" over a list of internal artefact
-  // names, which told a first-time reader neither what they gained nor what it
-  // cost. Each assertion below is one thing such a reader has to be told.
-  // A person deciding needs three things: why they would want it, what happens
-  // if they agree, and what happens if they do not. Not an inventory of files,
-  // and not how to undo something they have not done yet. The prompt this
-  // replaced listed artefact names and omitted the flag entirely.
-  assert.match(first, /^Let idle agents answer each other while you are away\?/,
-    "the question has to say what the reader gets, not what the installer does");
-  assert.match(first, /Yes: they reply without waiting for you/,
-    "agreeing has to name the gain");
-
-  // A bare [y/N] reads as "not recommended", and one question among several
-  // installed clients reads as an oversight. Both are answered in the same
-  // breath, because both are questions the prompt itself provokes.
-  // Two clients are eligible here, so the "only" half would be a lie and is
-  // absent; the experimental half is why the default is No either way.
-  assert.match(first, /\(experimental\)/,
-    "a bare [y/N] reads as not recommended, and nothing here says why");
-  assert.doesNotMatch(first, /only\)/,
-    "claiming it is the only eligible client while asking about a second one");
-
-  // The reason this is asked at all: from now on the client stops to ask at
-  // every start. That is the cost the reader lives with, so it is the cost they
-  // are shown - not the flag behind it, which is ours to know.
-  assert.match(first, /Claude Code asks you\n\s+to allow development channels every time it starts\./,
-    "the repeated prompt is the whole reason for asking; hiding it hides the cost");
-  assert.doesNotMatch(first, /--captured|through acc/,
-    "the flag, and how it is added, are not what the reader is agreeing to");
-  assert.match(first, /No:  messages still arrive, at the session's next turn\./,
-    "declining has to name what still works, or no is not a real option");
-
-  assert.doesNotMatch(first, /PATH|shim|launcher|plugin entry|\.zshrc/,
-    "what it writes belongs in --dry-run, not in front of someone deciding");
-  assert.doesNotMatch(first, /Undo|uninstall|--delivery off/,
-    "how to reverse it is a question for the moment they want to reverse it");
-
-  const lines = first.split("\n");
-  assert.ok(lines.length <= 4, `the question grew to ${lines.length} lines`);
-  const longest = Math.max(...lines.map(line => line.length));
-  assert.ok(longest <= 88, `a line reached ${longest} characters and will wrap`);
+  assert.match(first, /^Let Claude Code answer peer requests while idle/);
+  assert.match(questions[1][0], /^Let Codex answer peer requests while idle/,
+    "each choice must identify its recipient");
+  assert.match(first, /experimental/);
+  assert.match(first, /automatic turns can spend tokens/);
+  assert.match(first, /Allow development channels each time the client starts/);
+  assert.match(first, /No:.*acc inbox/);
+  assert.doesNotMatch(first, /messages still arrive, at the session.s next turn/);
+  assert.doesNotMatch(first, /--captured|PATH|shim|launcher|plugin entry|\.zshrc/);
+  assert.ok(first.split("\n").length <= 4);
   assert.deepEqual(io, { input: "in", output: "out" });
 });
 
-// Being asked about one client while three others are installed looks like the
-// other three were forgotten. When it really is the only one that can do this,
-// the question says so instead of leaving the reader to wonder.
-test("the question says when this is the only client that can do it", async () => {
+test("the question names its recipient even when only one client is supported", async () => {
   const questions = [];
   const detected = DETECTED.filter(entry => entry.adapterId !== "codex");
   await decideDelivery({ options: {}, detected, recorded: [], dryRun: false, context: CONTEXT,
@@ -354,7 +319,7 @@ test("the question says when this is the only client that can do it", async () =
       confirm: async question => { questions.push(question); return false; } } });
 
   assert.equal(questions.length, 1);
-  assert.match(questions[0], /\(experimental; Claude Code only\)/);
+  assert.match(questions[0], /^Let Claude Code answer/);
 });
 
 test("a recorded opt-in is kept on upgrade without a new question", async () => {

--- a/packages/cli/test/native-delivery-doctor.test.mjs
+++ b/packages/cli/test/native-delivery-doctor.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { describeNative } from "../src/doctor-command.mjs";
+import { updateNativeRuntime } from "../src/native-delivery-status.mjs";
 
 // The closed native-delivery state model doctor reports, exercised directly so
 // every combination is held to one shape without a client on the machine.
@@ -9,22 +10,55 @@ const state = overrides => ({ eligibility: "eligible", configured: false, policy
   runtime: "inactive", modes: [], reasonCode: null, ...overrides });
 
 test("eligibility, configuration, policy, and runtime are reported as distinct facts", () => {
-  assert.equal(describeNative(state()), "eligible - eligible, not enabled - not enabled");
+  assert.equal(describeNative(state()), "available; off");
   assert.equal(describeNative(state({ configured: true, policy: "actionable", runtime: "waiting" })),
-    "eligible - enabled (actionable) - waiting for a live session");
+    "available; enabled (actionable); no live channel bound in this workspace");
   assert.equal(describeNative(state({ configured: true, policy: "all", runtime: "active",
-    modes: ["livePush", "replyRoute"] })), "eligible - enabled (all) - active");
+    modes: ["livePush", "replyRoute"] })), "available; enabled (all); active");
 });
 
 test("an unsupported or degraded client names its closed reason and never claims a session", () => {
   assert.equal(describeNative(state({ eligibility: "unsupported",
-    reasonCode: "below_minimum_version" })), "unsupported (below_minimum_version)");
+    reasonCode: "below_minimum_version" })), "unavailable: the client is below the native delivery minimum version; off");
   assert.equal(describeNative(state({ eligibility: "unsupported",
-    reasonCode: "native_delivery_unsupported" })), "unsupported (native_delivery_unsupported)");
+    reasonCode: "native_delivery_unsupported" })), "unavailable: this adapter has no native delivery channel; off");
   assert.equal(describeNative(state({ eligibility: "degraded", configured: true,
     policy: "actionable", runtime: "degraded", reasonCode: "unsupported_shell" })),
-  "degraded - enabled (actionable) - degraded - unsupported_shell");
+  "readiness unverified: automatic launch setup requires zsh; enabled (actionable); channel unreachable");
   assert.equal(describeNative(state({ eligibility: "eligible", configured: true,
     policy: "actionable", runtime: "active" })).includes("read"), false,
   "the line must never suggest a model read the message");
+});
+
+
+test("native runtime ignores next-turn bindings and separates installed from running consent", () => {
+  const entry = (policySource, policy = "actionable") => ({ adapterId: "fixture",
+    nativeDelivery: state({ configured: policy !== "off", policy, policySource, runtime: "waiting" }) });
+  const binding = { adapterId: "fixture", reachable: true,
+    availableModes: ["nextTurn"], livePolicy: "actionable" };
+  const recipient = entry("installation-record");
+  updateNativeRuntime([recipient], [binding]);
+  assert.equal(recipient.nativeDelivery.runtime, "waiting",
+    "a hook-only binding was advertised as an active native channel");
+  const live = { ...binding, availableModes: ["livePush", "idleWake"] };
+  updateNativeRuntime([recipient], [live]);
+  assert.equal(recipient.nativeDelivery.runtime, "active");
+  assert.equal(recipient.nativeDelivery.sessionPolicy, "actionable");
+
+  for (const [installed, bound] of [["actionable", "all"], ["all", "actionable"]]) {
+    const changed = entry("installation-record", installed);
+    updateNativeRuntime([changed], [{ ...live, livePolicy: bound }]);
+    assert.equal(changed.nativeDelivery.sessionPolicy, installed,
+      "stored consent applies to every new offer, including existing sessions");
+    assert.doesNotMatch(describeNative(changed.nativeDelivery), /for new sessions/);
+  }
+  const disabled = entry("installation-record", "off");
+  updateNativeRuntime([disabled], [live]);
+  assert.equal(disabled.nativeDelivery.runtime, "inactive",
+    "the recorded policy blocks native offers even while an old binding remains");
+  const running = entry("bootstrap-environment", "off");
+  updateNativeRuntime([running], [live]);
+  assert.equal(running.nativeDelivery.runtime, "active");
+  assert.match(describeNative(running.nativeDelivery), /off for new sessions/);
+  assert.match(describeNative(running.nativeDelivery), /active.*session policy: actionable/);
 });

--- a/packages/cli/test/native-delivery-doctor.test.mjs
+++ b/packages/cli/test/native-delivery-doctor.test.mjs
@@ -14,7 +14,7 @@ test("eligibility, configuration, policy, and runtime are reported as distinct f
   assert.equal(describeNative(state({ configured: true, policy: "actionable", runtime: "waiting" })),
     "available; enabled (actionable); no live channel bound in this workspace");
   assert.equal(describeNative(state({ configured: true, policy: "all", runtime: "active",
-    modes: ["livePush", "replyRoute"] })), "available; enabled (all); active");
+    modes: ["livePush", "replyRoute"] })), "available; enabled (all); local transport active");
 });
 
 test("an unsupported or degraded client names its closed reason and never claims a session", () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/delivery-router/package.json
+++ b/packages/delivery-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/delivery-router",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/src/native-attempt.mjs
+++ b/packages/hook-runner/src/native-attempt.mjs
@@ -1,0 +1,43 @@
+import { storeNativeAttempt } from "@agents-can-communicate/adapter-sdk";
+import { readInstalledLivePolicyState } from "@agents-can-communicate/installer";
+
+import { establishNativeBinding, LIVE_POLICIES, livePolicyFrom } from "./native-binding.mjs";
+
+// Reserve time for turn projection, status and output before optional disk I/O.
+export function nativeDiagnosticDeadline(hookDeadline) {
+  const now = Date.now();
+  return hookDeadline - now >= 750 ? now + 250 : null;
+}
+
+// The diagnostic has its own bounded writer; it never rewrites hook ownership.
+// A failed or slow disk leaves the functional hook result intact.
+export async function bindNative({ adapter, event, hookBinding, clientVersion, platform,
+  context, paths, deadline }) {
+  const assertBudget = () => {
+    if (Date.now() >= deadline) throw new Error("hook deadline expired");
+  };
+  assertBudget();
+  const policySource = adapter?.nativeDelivery?.policySource === "installation-record"
+    ? "installation-record" : "bootstrap-environment";
+  const raw = context.env?.ACC_NATIVE_DELIVERY_POLICY;
+  const { policy, policyStatus } = policySource === "installation-record"
+    ? await readInstalledLivePolicyState({ dataHome: context.dataHome, adapterId: adapter.id })
+    : { policy: livePolicyFrom(context.env), policyStatus: raw === undefined ? "missing"
+      : !LIVE_POLICIES.includes(raw) ? "invalid" : raw === "off" ? "off" : "enabled" };
+  assertBudget();
+  const result = await establishNativeBinding({ adapter, event, hookBinding, clientVersion, platform,
+    livePolicy: policy, service: context.service, runtimeDir: paths.root,
+    clock: context.service.clock, env: context.env,
+    timeoutMs: Math.max(1, Math.min(750, deadline - Date.now())) });
+  const diagnosticDeadline = nativeDiagnosticDeadline(deadline);
+  if (adapter.nativeDelivery && diagnosticDeadline !== null) {
+    await storeNativeAttempt({ runtimeDir: paths.root, harnessSessionId: event.sessionId,
+      accSessionId: hookBinding.accSessionId, generation: hookBinding.generation, deadlineAt: diagnosticDeadline, nativeAttempt: {
+        at: context.service.clock.now(), event: event.kind, state: result.state,
+        reasonCode: result.reasonCode, policy, policySource, policyStatus,
+        clientProcess: Number.isInteger(hookBinding.clientPid) && hookBinding.clientPid > 0
+          ? "identified" : "unknown",
+      } }).catch(() => {});
+  }
+  return result;
+}

--- a/packages/hook-runner/src/runner.mjs
+++ b/packages/hook-runner/src/runner.mjs
@@ -3,10 +3,9 @@ import { createHash, randomBytes } from "node:crypto";
 import { realpath } from "node:fs/promises";
 import path from "node:path";
 
-import { clearSessionBinding, effectiveCapabilities, loadSessionBinding, storeSessionBinding }
+import { clearNativeAttempt, clearSessionBinding, effectiveCapabilities, loadSessionBinding, storeSessionBinding }
   from "@agents-can-communicate/adapter-sdk";
 import { createCoordinationService } from "@agents-can-communicate/core";
-import { readInstalledLivePolicy } from "@agents-can-communicate/installer";
 import { AccError, createId } from "@agents-can-communicate/protocol";
 import { openFilesystemStore } from "@agents-can-communicate/storage-filesystem";
 import { createGitProbe, discoverWorkspace, platformDataHome, runtimePaths }
@@ -14,7 +13,7 @@ import { createGitProbe, discoverWorkspace, platformDataHome, runtimePaths }
 
 import { resolveClientPid } from "./client-pid.mjs";
 import { probeClientVersion as defaultProbeClientVersion } from "./client-version.mjs";
-import { establishNativeBinding, livePolicyFrom } from "./native-binding.mjs";
+import { bindNative, nativeDiagnosticDeadline } from "./native-attempt.mjs";
 import { readProcessTable as defaultReadProcessTable } from "./process-table.mjs";
 import { withSessionLifecycle } from "./session-lifecycle.mjs";
 import { appendToolOwner, ownerHeader, ownerOnlyOutcome } from "./owner-context.mjs";
@@ -305,22 +304,6 @@ async function projectTurn({ binding, context, adapter, adapterId }) {
     offerInputs: writableOffers };
 }
 
-// One bounded, fail-open native handshake for this exact session generation.
-// New adapters read durable consent from their installation record; legacy
-// adapters keep the environment exported by an owned shell bootstrap.
-async function bindNative({ adapter, event, hookBinding, clientVersion, platform, context, paths,
-  deadline }) {
-  assertHookBudget(deadline);
-  const livePolicy = adapter?.nativeDelivery?.policySource === "installation-record"
-    ? await readInstalledLivePolicy({ dataHome: context.dataHome, adapterId: adapter.id })
-    : livePolicyFrom(context.env);
-  assertHookBudget(deadline);
-  return establishNativeBinding({ adapter, event, hookBinding, clientVersion, platform,
-    livePolicy, service: context.service, runtimeDir: paths.root,
-    clock: context.service.clock, env: context.env,
-    timeoutMs: Math.max(1, Math.min(750, deadline - Date.now())) });
-}
-
 const HANDLERS = {
   async sessionStart({ event, context, adapter, adapterId, binding, paths,
     readProcessTable, probeClientVersion, platform, deadline }) {
@@ -432,6 +415,11 @@ const HANDLERS = {
       await context.service.clearDeliveryBinding(owner);
     }
     await clearSessionBinding({ runtimeDir: paths.root, deadlineAt: deadline, harnessSessionId: event.sessionId });
+    const diagnosticDeadline = nativeDiagnosticDeadline(deadline);
+    if (diagnosticDeadline !== null) {
+      await clearNativeAttempt({ runtimeDir: paths.root, harnessSessionId: event.sessionId,
+        ...binding, deadlineAt: diagnosticDeadline });
+    }
     return {};
   },
 

--- a/packages/hook-runner/src/runner.mjs
+++ b/packages/hook-runner/src/runner.mjs
@@ -339,12 +339,12 @@ const HANDLERS = {
       branch: context.descriptor.git?.branch ?? null,
     };
     if (event.kind === "beforeTurn" && binding !== null) {
-      // A real prompt may continue after finish closed this native owner's
-      // record. Recheck after the probes: a CLI replacement can run outside
-      // the native lifecycle lock. Never adopt that replacement's identity.
+      // A genuine prompt can resume after an ephemeral removal or a durable
+      // close. Recheck after probes: a CLI replacement can run outside the
+      // native lifecycle lock. Never adopt that replacement's identity.
       const previous = await context.service.locateSession(binding.accSessionId);
-      if (previous?.record.state !== "closed"
-        || previous.record.generation !== binding.generation) {
+      if (previous !== null && (previous.record.state !== "closed"
+        || previous.record.generation !== binding.generation)) {
         throw new Error("the completed hook owner changed during turn registration");
       }
     }
@@ -438,9 +438,11 @@ const HANDLERS = {
       return { ...turn, nativeBinding: started.nativeBinding };
     }
     const current = await context.service.locateSession(binding.accSessionId);
-    if (current?.record.state === "closed" && current.record.generation === binding.generation) {
-      // finish ends an ACC incarnation, not the native conversation. Only a
-      // genuine new user turn can start another one; tool hooks cannot. Reuse
+    if (current === null
+      || current.record.state === "closed" && current.record.generation === binding.generation) {
+      // A solo detach removes its ephemeral record; a durable close retains it.
+      // Both end the ACC incarnation while the native conversation may continue.
+      // Only a genuine user turn can start another one; tool hooks cannot. Reuse
       // the crash-safe opening path, retaining its full published client facts
       // and its single native handshake rather than binding a second time.
       const started = await HANDLERS.sessionStart(input);

--- a/packages/hook-runner/test/native-attempt-doctor.test.mjs
+++ b/packages/hook-runner/test/native-attempt-doctor.test.mjs
@@ -193,22 +193,36 @@ test("slow diagnostic I/O cannot hold the hook process open or replace its owner
     import { runHook } from ${JSON.stringify(new URL("../src/runner.mjs", import.meta.url).href)};
     import { createClaudeCodeAdapter } from ${JSON.stringify(new URL(
       "../../adapter-claude-code/src/adapter.mjs", import.meta.url).href)};
+    import workers from "node:worker_threads";
+    import { syncBuiltinESMExports } from "node:module";
+    const Worker = workers.Worker;
+    let diagnosticWorkers = 0;
+    workers.Worker = class extends Worker {
+      constructor(...args) { diagnosticWorkers += 1; super(...args); }
+    };
+    syncBuiltinESMExports();
+    // Freeze logical budget time after normalization. CI scheduling must not
+    // turn ordinary hook work into a false accusation against optional I/O.
+    let budgetNow = Date.now();
+    Date.now = () => budgetNow;
     const original = createClaudeCodeAdapter();
-    const adapter = { ...original, normalizeHook: async payload => {
-      await new Promise(r => setTimeout(r, 1750));
+    const adapter = { ...original, normalizeHook: payload => {
+      budgetNow += 4251; // 749ms remain: below the diagnostic allocation threshold.
       return original.normalizeHook(payload);
     } };
     const result = await runHook({ adapterId: adapter.id, adapters: { [adapter.id]: adapter },
-      budgetMs: 2000, dataHome: process.env.ACC_DATA_HOME, env: process.env,
+      budgetMs: 5000, dataHome: process.env.ACC_DATA_HOME, env: process.env,
       payload: { hook_event_name: "UserPromptSubmit", session_id: "slow", cwd: process.cwd() } });
     process.stdout.write(JSON.stringify({ timedOut: result.timedOut, failed: result.failed,
-      stdout: result.stdout }));
+      diagnosticWorkers, stdout: result.stdout }));
   `);
   const nearDeadline = JSON.parse((await exec(process.execPath, ["--import", preload, driver], {
     cwd: path.join(m.home, "project"), timeout: 3000,
     env: { HOME: m.home, ACC_DATA_HOME: m.dataHome, ACC_NO_UPDATE_CHECK: "1", PATH: "",
       ACC_NATIVE_DELIVERY_POLICY: "off", GIT_DIR: "", GIT_WORK_TREE: "" },
   })).stdout);
+  assert.equal(nearDeadline.diagnosticWorkers, 0,
+    "optional diagnostic work was started without its reserved budget");
   assert.equal(nearDeadline.timedOut, undefined,
     "optional diagnostics consumed the remaining functional hook budget");
   assert.equal(nearDeadline.failed, undefined);

--- a/packages/hook-runner/test/native-attempt-doctor.test.mjs
+++ b/packages/hook-runner/test/native-attempt-doctor.test.mjs
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import { createClaudeCodeAdapter } from "@agents-can-communicate/adapter-claude-code";
+import { recordInstall } from "@agents-can-communicate/installer";
+import { runHook } from "../src/runner.mjs";
+
+const exec = promisify(execFile);
+const binary = path.resolve(import.meta.dirname, "../../../bin/acc.mjs");
+const claudeCodeAdapter = createClaudeCodeAdapter();
+const consent = { ACC_NATIVE_DELIVERY_POLICY: "actionable" };
+
+async function machine(t) {
+  const home = await realpath(await mkdtemp(path.join(tmpdir(), "acc-attempt-")));
+  const project = path.join(home, "project");
+  const dataHome = path.join(home, "data");
+  await mkdir(project);
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const env = { HOME: home, ACC_DATA_HOME: dataHome, ACC_NO_UPDATE_CHECK: "1", PATH: "",
+    GIT_DIR: "", GIT_WORK_TREE: "" };
+  const doctor = async (json = true) => {
+    const { stdout } = await exec(process.execPath,
+      [binary, "doctor", "--cwd", project, ...(json ? ["--json"] : [])], { env });
+    return json ? JSON.parse(stdout).data.adapters.find(a => a.adapterId === "claude_code")
+      .nativeDelivery.sessions : stdout;
+  };
+  const hook = async (name, { kind = "SessionStart", policy = consent, pid = true,
+    bindNativeSession, policySource } = {}) => {
+    const adapter = { ...claudeCodeAdapter,
+      nativeDelivery: { ...claudeCodeAdapter.nativeDelivery,
+        ...(policySource ? { policySource } : {}) },
+      ...(bindNativeSession ? { bindNativeSession } : {}) };
+    const result = await runHook({ adapterId: adapter.id, adapters: { [adapter.id]: adapter },
+      payload: { hook_event_name: kind, session_id: name, cwd: project,
+        prompt: "secret-prompt-must-not-be-recorded" }, dataHome, env: { ...env, ...policy },
+      readProcessTable: async () => pid
+        ? new Map([[process.pid, { ppid: 1, comm: "claude" }]]) : new Map(),
+      probeClientVersion: async () => "2.1.266", platform: "darwin-arm64" });
+    assert.equal(result.failed, undefined, result.reason);
+    assert.equal(result.timedOut, undefined);
+    return result;
+  };
+  const bindingFile = async name => {
+    const entries = await readdir(dataHome, { recursive: true });
+    for (const entry of entries.filter(file => file.endsWith(".json") && file.includes("bindings"))) {
+      const file = path.join(dataHome, entry);
+      const record = JSON.parse(await readFile(file, "utf8"));
+      if (record.harnessSessionId === name) return { file, record };
+    }
+    throw new Error(`missing hook owner ${name}`);
+  };
+  const attemptFile = async name => {
+    const { file, record: owner } = await bindingFile(name);
+    const target = path.join(path.dirname(path.dirname(file)), "native-attempts", path.basename(file));
+    return { file: target, record: JSON.parse(await readFile(target, "utf8")), owner };
+  };
+  return { home, dataHome, doctor, hook, bindingFile, attemptFile };
+}
+
+test("doctor preserves the hook's missing consent and PID failures per session", async t => {
+  const m = await machine(t);
+  const missing = await m.hook("missing", { policy: {} });
+  const unknown = await m.hook("unknown", { pid: false });
+  const sessions = await m.doctor();
+  assert.ok(Array.isArray(sessions), "doctor discarded the hook's native binding outcomes");
+  assert.equal(JSON.stringify(sessions).includes(unknown.generation), false,
+    "doctor leaked the session mutation credential");
+  const a = sessions.find(s => s.sessionId === missing.accSessionId);
+  const b = sessions.find(s => s.sessionId === unknown.accSessionId);
+  assert.equal(a.lastAttempt.policyStatus, "missing");
+  assert.equal(a.lastAttempt.state, "off");
+  assert.equal(b.lastAttempt.reasonCode, "client_process_unknown");
+  assert.equal(b.lastAttempt.policy, "actionable");
+  assert.equal(b.lastAttempt.clientProcess, "unknown");
+  assert.match(await m.doctor(false), /client process could not be identified/);
+  assert.match(await m.doctor(false), /delivery policy was absent/);
+  assert.doesNotMatch(JSON.stringify(sessions), /secret-prompt/);
+});
+
+test("a later turn replaces the failed attempt; old success never claims current delivery", async t => {
+  const m = await machine(t);
+  const failed = await m.hook("retry", { bindNativeSession: async () => {
+    throw new Error("secret-endpoint-and-vendor-error");
+  } });
+  let [session] = await m.doctor();
+  assert.equal(session?.lastAttempt?.reasonCode, "handshake_failed");
+  const active = await m.hook("retry", { kind: "UserPromptSubmit", bindNativeSession: async () => ({
+    supported: true, clientVersion: "2.1.266", protocolContract: "claude-code-channel-mcp-v1",
+    modes: ["livePush"], opaqueEndpointRef: "secret-endpoint-and-vendor-error",
+    leaseUntil: new Date(Date.now() + 60_000).toISOString(), reasonCode: null }) });
+  [session] = await m.doctor();
+  assert.equal(session.lastAttempt.state, "active");
+  assert.equal(session.sessionId, failed.accSessionId);
+  assert.equal(session.runtime, "active");
+  await active.service.clearDeliveryBinding({ sessionId: failed.accSessionId,
+    generation: active.generation ?? failed.generation });
+  [session] = await m.doctor();
+  assert.equal(session.lastAttempt.state, "active");
+  assert.equal(session.runtime, "unbound");
+  const { record } = await m.attemptFile("retry");
+  assert.equal(record.attempt.state, "active");
+  assert.equal(Array.isArray(record.attempt), false);
+  assert.doesNotMatch(JSON.stringify(record), /secret-/);
+});
+
+test("doctor ignores superseded or corrupt attempts and closed sessions", async t => {
+  const m = await machine(t);
+  const started = await m.hook("restart", { pid: false });
+  const { file, record } = await m.attemptFile("restart");
+  assert.equal(record.attempt?.reasonCode, "client_process_unknown");
+  await writeFile(file, JSON.stringify({ ...record, generation: "generation_obsolete" }));
+  assert.equal((await m.doctor())[0].lastAttempt, null);
+  await writeFile(file, JSON.stringify({ ...record,
+    attempt: { ...record.attempt, reasonCode: "secret-vendor-output" } }));
+  assert.equal((await m.doctor())[0].lastAttempt, null);
+  await writeFile(file, JSON.stringify({ ...record, attempt: {
+    ...record.attempt, prompt: "secret-extra-property" } }));
+  assert.doesNotMatch(JSON.stringify(await m.doctor()), /secret-extra-property/);
+  await writeFile(file, JSON.stringify(record));
+  await started.service.closeSession({ sessionId: started.accSessionId, generation: started.generation });
+  assert.deepEqual(await m.doctor(), []);
+  const fresh = await m.hook("restart", { policy: { ACC_NATIVE_DELIVERY_POLICY: "off" } });
+  const [session] = await m.doctor();
+  assert.notEqual(session.sessionId, started.accSessionId);
+  assert.equal(session.sessionId, fresh.sessions[0].sessionId);
+  assert.equal(session.lastAttempt.policyStatus, "off");
+  assert.equal(session.lastAttempt.reasonCode, null);
+});
+
+test("handshake timeout and recorded consent survive into doctor without vendor output", async t => {
+  const m = await machine(t);
+  await recordInstall({ dataHome: m.dataHome, adapterId: "claude_code", version: "2.1.266",
+    artifacts: [], deliveryPolicy: "all" });
+  await m.hook("timeout", { policySource: "installation-record", policy: {},
+    bindNativeSession: async () => new Promise(() => {}) });
+  const [session] = await m.doctor();
+  assert.equal(session?.lastAttempt?.reasonCode, "handshake_timeout");
+  assert.equal(session.lastAttempt.policy, "all");
+  assert.equal(session.lastAttempt.policySource, "installation-record");
+});
+
+
+test("diagnostic write failure cannot discard an otherwise successful hook", async t => {
+  const m = await machine(t);
+  await m.hook("write-failure", { bindNativeSession: async () => {
+    const { file } = await m.bindingFile("write-failure");
+    await writeFile(path.join(path.dirname(path.dirname(file)), "native-attempts"), "blocked");
+    throw new Error("private-handshake-failure");
+  } });
+  const [session] = await m.doctor();
+  assert.equal(session.lastAttempt, null);
+  assert.equal(session.runtime, "unbound");
+  assert.match(await m.doctor(false), /no native binding attempt observed/);
+  assert.doesNotMatch(await m.doctor(false), /private-handshake-failure/);
+});
+
+test("slow diagnostic I/O cannot hold the hook process open or replace its owner", async t => {
+  const m = await machine(t);
+  await m.hook("slow", { pid: false });
+  const before = await m.bindingFile("slow");
+  const preload = path.join(m.home, "slow-diagnostic.mjs");
+  await writeFile(preload, `
+    import fs from "node:fs/promises";
+    import { syncBuiltinESMExports } from "node:module";
+    const write = fs.writeFile;
+    fs.writeFile = async (file, ...args) => {
+      if (String(file).includes("native-attempts")) await new Promise(r => setTimeout(r, 9000));
+      return write(file, ...args);
+    };
+    syncBuiltinESMExports();
+  `);
+  const child = exec(process.execPath, ["--import", preload,
+    path.resolve(import.meta.dirname, "../../../bin/acc-hook.mjs"), "claude_code"], {
+    cwd: path.join(m.home, "project"), timeout: 3000,
+    env: { HOME: m.home, ACC_DATA_HOME: m.dataHome, ACC_NO_UPDATE_CHECK: "1", PATH: "",
+      ACC_NATIVE_DELIVERY_POLICY: "off", GIT_DIR: "", GIT_WORK_TREE: "" },
+  });
+  child.child.stdin.end(JSON.stringify({ hook_event_name: "UserPromptSubmit", session_id: "slow",
+    cwd: path.join(m.home, "project"), prompt: "continue" }));
+  const { stdout } = await child;
+  assert.match(stdout, /ACC|acc/);
+  assert.deepEqual((await m.bindingFile("slow")).record, before.record,
+    "optional diagnostic I/O rewrote functional hook ownership");
+  assert.equal((await m.doctor())[0].lastAttempt.reasonCode, "client_process_unknown",
+    "an abandoned diagnostic was published after its deadline");
+  const driver = path.join(m.home, "near-deadline.mjs");
+  await writeFile(driver, `
+    import { runHook } from ${JSON.stringify(new URL("../src/runner.mjs", import.meta.url).href)};
+    import { createClaudeCodeAdapter } from ${JSON.stringify(new URL(
+      "../../adapter-claude-code/src/adapter.mjs", import.meta.url).href)};
+    const original = createClaudeCodeAdapter();
+    const adapter = { ...original, normalizeHook: async payload => {
+      await new Promise(r => setTimeout(r, 1750));
+      return original.normalizeHook(payload);
+    } };
+    const result = await runHook({ adapterId: adapter.id, adapters: { [adapter.id]: adapter },
+      budgetMs: 2000, dataHome: process.env.ACC_DATA_HOME, env: process.env,
+      payload: { hook_event_name: "UserPromptSubmit", session_id: "slow", cwd: process.cwd() } });
+    process.stdout.write(JSON.stringify({ timedOut: result.timedOut, failed: result.failed,
+      stdout: result.stdout }));
+  `);
+  const nearDeadline = JSON.parse((await exec(process.execPath, ["--import", preload, driver], {
+    cwd: path.join(m.home, "project"), timeout: 3000,
+    env: { HOME: m.home, ACC_DATA_HOME: m.dataHome, ACC_NO_UPDATE_CHECK: "1", PATH: "",
+      ACC_NATIVE_DELIVERY_POLICY: "off", GIT_DIR: "", GIT_WORK_TREE: "" },
+  })).stdout);
+  assert.equal(nearDeadline.timedOut, undefined,
+    "optional diagnostics consumed the remaining functional hook budget");
+  assert.equal(nearDeadline.failed, undefined);
+  assert.match(nearDeadline.stdout, /ACC|acc/);
+  await m.hook("slow", { policy: { ACC_NATIVE_DELIVERY_POLICY: "off" } });
+  assert.equal((await m.doctor())[0].lastAttempt.policyStatus, "off",
+    "a dead diagnostic writer prevented a subsequent session from recording its result");
+});

--- a/packages/hook-runner/test/tool-owner-context.test.mjs
+++ b/packages/hook-runner/test/tool-owner-context.test.mjs
@@ -62,3 +62,27 @@ test("an owner formatter failure remains a failed-open hook", async t => {
   assert.equal(result.decision, "allow");
   assert.equal(result.stdout, "");
 });
+
+test("a vanished owner cannot adopt a replacement created while the next turn probes", async t => {
+  const { hook, started } = await stage(t);
+  const service = started.service;
+  const participantId = started.sessions[0].participantId;
+  await service.closeSession({ sessionId: started.accSessionId, generation: started.generation });
+  assert.equal(await service.locateSession(started.accSessionId), null);
+  let replacement;
+  const result = await hook("user_prompt_submit", "native-owner", {
+    probeClientVersion: async () => {
+      replacement = await service.openSession({ workspaceId: service.store.workspaceId,
+        sessionId: started.accSessionId, generation: "generation_replacement", participantId,
+        harness: "grok", heartbeatCadenceMs: 60_000 });
+      return "1.0.24";
+    },
+  });
+  assert.ok(replacement, "the fixture did not replace the absent owner during the probe");
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.failed, true);
+  assert.equal(result.stdout, "");
+  const status = await service.collectStatus({});
+  assert.equal(status.counts.live, 1, "the stale hook registered another session beside its replacement");
+  assert.deepEqual((await service.locateSession(started.accSessionId)).record, replacement);
+});

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/src/delivery-diagnostics.mjs
+++ b/packages/installer/src/delivery-diagnostics.mjs
@@ -1,0 +1,30 @@
+// Shared presentation of observed delivery facts. Vendor probes provide closed
+// reasons; installation and doctor must not turn a version floor into readiness.
+const REASONS = Object.freeze({
+  native_delivery_unsupported: "this adapter has no native delivery channel",
+  platform_not_captured: "native delivery is not verified on this platform",
+  version_unavailable: "the client version could not be verified",
+  prerelease_not_captured: "this client version is not a verified stable release",
+  below_minimum_version: "the client is below the native delivery minimum version",
+  known_bad_version: "this client version has a known native delivery failure",
+  native_endpoint_unavailable: "the client's local delivery service is unavailable",
+  native_session_unavailable: "the local delivery service has no loaded client session",
+  feature_probe_failed: "the native protocol probe did not succeed",
+  probe_timeout: "the native protocol probe timed out",
+  probe_version_mismatch: "the local service and CLI versions differ",
+  protocol_mismatch: "the local service did not confirm the required protocol",
+  unsupported_shell: "automatic launch setup requires zsh",
+});
+
+export const describeNativeReason = reason => REASONS[reason] ?? reason ?? "readiness is unverified";
+export const describeDeliveryFallback = entry => entry.capabilities?.delivery?.nextTurn === true
+  ? "next-turn hooks (when enabled) or acc inbox" : "acc inbox";
+
+export function describeInstallDelivery(entry, policy, effectivePolicy) {
+  const state = policy === "off" ? "off" : effectivePolicy === "off"
+    ? `consent saved (${policy}); not active` : `enabled (${policy}); waiting for a verified session`;
+  const reason = entry.nativeDelivery?.reasonCode;
+  return `${entry.displayName ?? entry.adapterId} live delivery: ${state}`
+    + (reason ? `; ${describeNativeReason(reason)}` : "")
+    + `; fallback: ${describeDeliveryFallback(entry)}`;
+}

--- a/packages/installer/src/delivery-diagnostics.mjs
+++ b/packages/installer/src/delivery-diagnostics.mjs
@@ -16,7 +16,12 @@ const REASONS = Object.freeze({
   unsupported_shell: "automatic launch setup requires zsh",
 });
 
-export const describeNativeReason = reason => REASONS[reason] ?? reason ?? "readiness is unverified";
+export function describeNativeReason(reason, { clientVersion, minimumVersion } = {}) {
+  if (reason === "below_minimum_version" && clientVersion && minimumVersion) {
+    return `client ${clientVersion} needs version ${minimumVersion} or newer for native delivery`;
+  }
+  return REASONS[reason] ?? reason ?? "readiness is unverified";
+}
 export const describeDeliveryFallback = entry => entry.capabilities?.delivery?.nextTurn === true
   ? "next-turn hooks (when enabled) or acc inbox" : "acc inbox";
 
@@ -25,6 +30,7 @@ export function describeInstallDelivery(entry, policy, effectivePolicy) {
     ? `consent saved (${policy}); not active` : `enabled (${policy}); waiting for a verified session`;
   const reason = entry.nativeDelivery?.reasonCode;
   return `${entry.displayName ?? entry.adapterId} live delivery: ${state}`
-    + (reason ? `; ${describeNativeReason(reason)}` : "")
+    + (reason ? `; ${describeNativeReason(reason, { clientVersion: entry.version,
+      minimumVersion: entry.nativeDelivery?.eligibility?.minimumVersion })}` : "")
     + `; fallback: ${describeDeliveryFallback(entry)}`;
 }

--- a/packages/installer/src/detect.mjs
+++ b/packages/installer/src/detect.mjs
@@ -6,6 +6,8 @@ import { effectiveCapabilities, evaluateNativeEligibility, validateNativeActivat
 
 import { resolveExecutable, shellOf, shimDirFor } from "./native-activation.mjs";
 
+import { describeDeliveryFallback, describeNativeReason } from "./delivery-diagnostics.mjs";
+
 const run = promisify(execFile);
 
 // Reasons the client itself will not change within an install: unsupported,
@@ -79,8 +81,14 @@ async function detectNative(adapter, entry, { context, platform, probeTimeoutMs,
     }
     if (facts.eligibility.eligible !== true) {
       const reasonCode = facts.eligibility.reasonCode ?? "feature_probe_failed";
+      // A stored policy can be consented to before a service/session exists.
+      // No activation is planned until the full probe passes; bootstrap-based
+      // clients still need their verified plan to disclose launch changes.
+      const consentAvailable = adapter.nativeDelivery.policySource === "installation-record"
+        && ["native_endpoint_unavailable", "native_session_unavailable"].includes(reasonCode);
       return STATIC_REASONS.has(reasonCode)
-        ? { ...unsupported(reasonCode), ...facts } : degraded(reasonCode, facts);
+        ? { ...unsupported(reasonCode), ...facts }
+        : { ...degraded(reasonCode, facts), consentAvailable };
     }
     let activationPlan;
     try {
@@ -151,15 +159,19 @@ export async function detectInstallation({ adapters, context, probe = spawnProbe
       } catch (error) {
         entry.error = entry.error ?? error.message;
       }
-      if (entry.nativeDelivery.state !== "eligible"
-        && typeof adapter.deliveryFallback?.diagnostic === "string") {
-        const nextTurnDowngraded = adapter.capabilities?.delivery?.nextTurn === true
-          && entry.capabilities?.delivery?.nextTurn !== true;
-        entry.deliveryDiagnostic = nextTurnDowngraded
-          ? `${adapter.displayName} ${entry.version ?? "unknown version"} has no certified `
-            + `next-turn delivery on ${platform}; ${adapter.deliveryFallback.diagnostic}`
-          : adapter.deliveryFallback.diagnostic;
-        entry.diagnostics.push(entry.deliveryDiagnostic);
+      if (entry.nativeDelivery.state !== "eligible") {
+        if (adapter.nativeDelivery !== undefined) {
+          entry.deliveryDiagnostic = `${adapter.displayName} native delivery: `
+            + `${describeNativeReason(entry.nativeDelivery.reasonCode)}; `
+            + `fallback: ${describeDeliveryFallback(entry)}`;
+        } else if (typeof adapter.deliveryFallback?.diagnostic === "string") {
+          const downgraded = adapter.capabilities?.delivery?.nextTurn === true
+            && entry.capabilities?.delivery?.nextTurn !== true;
+          entry.deliveryDiagnostic = (downgraded
+            ? `${adapter.displayName} ${entry.version ?? "unknown version"} has no certified `
+              + `next-turn delivery on ${platform}; ` : "") + adapter.deliveryFallback.diagnostic;
+        }
+        if (entry.deliveryDiagnostic !== null) entry.diagnostics.push(entry.deliveryDiagnostic);
       }
       return entry;
     }));

--- a/packages/installer/src/detect.mjs
+++ b/packages/installer/src/detect.mjs
@@ -162,7 +162,8 @@ export async function detectInstallation({ adapters, context, probe = spawnProbe
       if (entry.nativeDelivery.state !== "eligible") {
         if (adapter.nativeDelivery !== undefined) {
           entry.deliveryDiagnostic = `${adapter.displayName} native delivery: `
-            + `${describeNativeReason(entry.nativeDelivery.reasonCode)}; `
+            + `${describeNativeReason(entry.nativeDelivery.reasonCode, { clientVersion: entry.version,
+              minimumVersion: entry.nativeDelivery.eligibility?.minimumVersion })}; `
             + `fallback: ${describeDeliveryFallback(entry)}`;
         } else if (typeof adapter.deliveryFallback?.diagnostic === "string") {
           const downgraded = adapter.capabilities?.delivery?.nextTurn === true

--- a/packages/installer/src/index.mjs
+++ b/packages/installer/src/index.mjs
@@ -13,3 +13,5 @@ export { BLOCK_BEGIN, BLOCK_END, SHIM_MARKER, SHIM_POLICIES, SUPPORTED_SHELLS,
 export { LIVE_POLICIES, describeActivation, describeDeactivation, livePolicyOf, rcFileFor,
   resolveExecutable, shellOf, shimDirFor } from "./native-activation.mjs";
 export { readInstalledLivePolicy } from "./live-policy.mjs";
+export { describeDeliveryFallback, describeInstallDelivery, describeNativeReason }
+  from "./delivery-diagnostics.mjs";

--- a/packages/installer/src/index.mjs
+++ b/packages/installer/src/index.mjs
@@ -12,6 +12,6 @@ export { BLOCK_BEGIN, BLOCK_END, SHIM_MARKER, SHIM_POLICIES, SUPPORTED_SHELLS,
   shellLiteral, uninstallShellBootstrap, validateShimEntry } from "./shell-bootstrap.mjs";
 export { LIVE_POLICIES, describeActivation, describeDeactivation, livePolicyOf, rcFileFor,
   resolveExecutable, shellOf, shimDirFor } from "./native-activation.mjs";
-export { readInstalledLivePolicy } from "./live-policy.mjs";
+export { readInstalledLivePolicy, readInstalledLivePolicyState } from "./live-policy.mjs";
 export { describeDeliveryFallback, describeInstallDelivery, describeNativeReason }
   from "./delivery-diagnostics.mjs";

--- a/packages/installer/src/live-policy.mjs
+++ b/packages/installer/src/live-policy.mjs
@@ -10,12 +10,19 @@ export const livePolicyOf = install => {
     ? install.nativeActivation.livePolicy : "off";
 };
 
-export async function readInstalledLivePolicy({ dataHome, adapterId }) {
+export async function readInstalledLivePolicy(input) {
+  return (await readInstalledLivePolicyState(input)).policy;
+}
+
+export async function readInstalledLivePolicyState({ dataHome, adapterId }) {
   try {
     const record = await loadOwnership({ dataHome });
     const install = record.installs.find(entry => entry.adapterId === adapterId);
-    return livePolicyOf(install);
+    const raw = Object.hasOwn(install ?? {}, "deliveryPolicy")
+      ? install.deliveryPolicy : install?.nativeActivation?.livePolicy;
+    return { policy: livePolicyOf(install), policyStatus: raw === undefined ? "missing"
+      : !LIVE_POLICIES.includes(raw) ? "invalid" : raw === "off" ? "off" : "enabled" };
   } catch {
-    return "off";
+    return { policy: "off", policyStatus: "unavailable" };
   }
 }

--- a/packages/installer/src/plan.mjs
+++ b/packages/installer/src/plan.mjs
@@ -1,3 +1,5 @@
+import { describeInstallDelivery } from "./delivery-diagnostics.mjs";
+
 import { AccError, EXIT } from "@agents-can-communicate/protocol";
 
 import { LIVE_POLICIES, describeActivation, describeDeactivation, planActivationRetirements, rcFileFor, shimDirFor }
@@ -112,6 +114,8 @@ export function planInstallation({ adapters, detected, context, action = "instal
         ?? `${adapter.displayName ?? adapter.id} cannot receive native delivery `
           + `(${native?.reasonCode ?? "native_delivery_unsupported"}); durable fallback remains active`
       : null;
+    const deliverySummary = action === "install"
+      ? describeInstallDelivery(entry, delivery, effectiveLivePolicy) : null;
     const installContext = { ...context, requestedLivePolicy: delivery,
       livePolicy: effectiveLivePolicy };
     // A consented activation that this run keeps, activates, or takes back.
@@ -143,6 +147,7 @@ export function planInstallation({ adapters, detected, context, action = "instal
       livePolicy: delivery,
       effectiveLivePolicy,
       ...(deliveryDiagnostic === null ? {} : { deliveryDiagnostic }),
+      ...(deliverySummary === null ? {} : { deliverySummary }),
       ...(nativeActivation === null ? {} : { nativeActivation }),
       ...(deactivation === null ? {} : { deactivation }),
       artifacts,
@@ -151,7 +156,7 @@ export function planInstallation({ adapters, detected, context, action = "instal
       summary: [
         ...(entry.present ? [] : [`${adapter.displayName ?? adapter.id} is no longer on `
           + "this machine; removing what ACC recorded writing"]),
-        ...(deliveryDiagnostic === null ? [] : [deliveryDiagnostic]),
+        ...(deliverySummary === null ? [] : [deliverySummary]),
         ...artifacts.filter(a => a.kind === "tree")
           .map(a => `${action === "install" ? "create" : "remove"} ${a.path}`),
         ...artifacts.filter(a => a.kind === "merge")

--- a/packages/installer/test/live-policy.test.mjs
+++ b/packages/installer/test/live-policy.test.mjs
@@ -6,7 +6,7 @@ import test from "node:test";
 
 import { applyPlan } from "../src/apply.mjs";
 import { loadOwnership, recordInstall } from "../src/ownership.mjs";
-import { livePolicyOf, readInstalledLivePolicy } from "../src/live-policy.mjs";
+import { livePolicyOf, readInstalledLivePolicy, readInstalledLivePolicyState } from "../src/live-policy.mjs";
 
 async function dataHome(t, name = "acc-live-policy-") {
   const root = await realpath(await mkdtemp(path.join(tmpdir(), name)));
@@ -53,6 +53,8 @@ test("apply records requested consent even when effective activation is off", as
 test("missing and unknown installation records read off", async t => {
   const missing = await dataHome(t, "acc-live-policy-missing-");
   assert.equal(await readInstalledLivePolicy({ dataHome: missing, adapterId: "codex" }), "off");
+  assert.deepEqual(await readInstalledLivePolicyState({ dataHome: missing, adapterId: "codex" }),
+    { policy: "off", policyStatus: "missing" });
 
   const unknown = await dataHome(t, "acc-live-policy-unknown-");
   const file = path.join(unknown, "acc", "installs.json");
@@ -69,5 +71,7 @@ test("a corrupt installation record reads off without changing its bytes", async
   await writeFile(file, bytes);
 
   assert.equal(await readInstalledLivePolicy({ dataHome: root, adapterId: "codex" }), "off");
+  assert.deepEqual(await readInstalledLivePolicyState({ dataHome: root, adapterId: "codex" }),
+    { policy: "off", policyStatus: "unavailable" });
   assert.deepEqual(await readFile(file), bytes);
 });

--- a/packages/installer/test/native-activation.test.mjs
+++ b/packages/installer/test/native-activation.test.mjs
@@ -109,7 +109,7 @@ test("policies are explicit per adapter, and an ineligible client cannot be acti
       deliveryByAdapter: { other: "all" } });
     const otherOp = forced.operations.find(op => op.adapterId === "other");
     assert.equal(otherOp.effectiveLivePolicy, "off");
-    assert.match(otherOp.deliveryDiagnostic, /version_unavailable/);
+    assert.match(otherOp.deliveryDiagnostic, /client version could not be verified/);
   });
 
 test("apply activates, records owned bytes, and a second policy regenerates only the shim",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/tests/acceptance/delivery-setup-packed.test.mjs
+++ b/tests/acceptance/delivery-setup-packed.test.mjs
@@ -31,7 +31,7 @@ test("installed delivery setup preserves opt-in before a Codex service exists an
     const questions = [];
     const result = await runInstallCommand({ options: { adapter: "codex" },
       runtime: { env: process.env, cwd: process.cwd(), platform: process.platform,
-        packageRoot: ${JSON.stringify(p.installed)}, version: async () => "0.4.1",
+        packageRoot: ${JSON.stringify(p.installed)}, version: async () => ${JSON.stringify(p.manifest.version)},
         isInteractive: () => true, confirm: async question => {
           questions.push(question); return true;
         } } });

--- a/tests/acceptance/delivery-setup-packed.test.mjs
+++ b/tests/acceptance/delivery-setup-packed.test.mjs
@@ -112,4 +112,22 @@ test("doctor asks to complete missing launch setup before asking for a new sessi
   assert.equal(after.nativeDelivery.activation, "recorded");
   assert.equal(after.nativeDelivery.runtime, "waiting");
   assert.ok(after.remediation.some(line => /new terminal/.test(line)));
+
+  // Execute the shipped hook in separate processes. No vendor process is in
+  // their ancestry, so enabled consent must explain the missing PID, while an
+  // ordinary environment reports its absent launch policy independently.
+  const payload = name => ({ hook_event_name: "SessionStart", session_id: name, cwd: p.project });
+  delete p.env.ACC_NATIVE_DELIVERY_POLICY;
+  await p.hook("claude_code", payload("no-consent"), { ACC_PARTICIPANT: "no-consent" });
+  await p.hook("claude_code", payload("no-client-pid"), {
+    ACC_PARTICIPANT: "no-client-pid", ACC_NATIVE_DELIVERY_POLICY: "actionable" });
+  const sessions = (await p.acc(["doctor"])).adapters.find(a => a.adapterId === "claude_code")
+    .nativeDelivery.sessions;
+  assert.equal(sessions.find(s => s.participantId === "no-consent").lastAttempt.policyStatus, "missing");
+  assert.equal(sessions.find(s => s.participantId === "no-client-pid").lastAttempt.reasonCode,
+    "client_process_unknown");
+  assert.match((await human(p, ["doctor"])).stdout, /client process could not be identified/);
+  await p.hook("claude_code", { ...payload("no-client-pid"), hook_event_name: "SessionEnd" });
+  assert.equal((await p.acc(["doctor"])).adapters.find(a => a.adapterId === "claude_code")
+    .nativeDelivery.sessions.length, 1);
 });

--- a/tests/acceptance/delivery-setup-packed.test.mjs
+++ b/tests/acceptance/delivery-setup-packed.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { pathToFileURL } from "node:url";
+import test from "node:test";
+
+import { createPackedAcc } from "../helpers/packed-acc.mjs";
+
+const run = promisify(execFile);
+const captured = process.platform === "darwin" && process.arch === "arm64";
+const human = (p, args) => run(process.execPath, [p.accBin, ...args],
+  { cwd: p.project, env: p.env });
+
+test("installed delivery setup preserves opt-in before a Codex service exists and explains fallback", async t => {
+  const p = await createPackedAcc(t);
+  p.env.CODEX_HOME = path.join(p.clientHome, ".codex");
+  p.env.SHELL = "/bin/zsh";
+  await p.setClientVersions({ codex: "0.153.4" });
+  const preview = await human(p, ["install", "--adapter", "codex", "--dry-run"]);
+  assert.match(preview.stdout, /live delivery: off/);
+  await assert.rejects(readFile(path.join(p.clientHome, ".codex", "config.toml")), { code: "ENOENT" });
+  // Use the shipped command and actual detection/planning/application. Only the
+  // terminal answer is supplied by a port; no detection result is invented.
+  const entry = pathToFileURL(path.join(p.installed, "node_modules",
+    "@agents-can-communicate/cli/src/install-command.mjs")).href;
+  const driver = path.join(p.root, "interactive-install.mjs");
+  await writeFile(driver, `
+    import { runInstallCommand } from ${JSON.stringify(entry)};
+    const questions = [];
+    const result = await runInstallCommand({ options: { adapter: "codex" },
+      runtime: { env: process.env, cwd: process.cwd(), platform: process.platform,
+        packageRoot: ${JSON.stringify(p.installed)}, version: async () => "0.4.1",
+        isInteractive: () => true, confirm: async question => {
+          questions.push(question); return true;
+        } } });
+    if (result.error) throw result.error;
+    process.stdout.write(JSON.stringify({ ...result, questions }));
+  `);
+  const result = JSON.parse((await run(process.execPath, [driver],
+    { cwd: p.project, env: p.env })).stdout);
+  assert.equal(result.questions.length, captured ? 1 : 0,
+    "a supported client with no running service must still offer to save consent");
+  if (captured) {
+    assert.match(preview.stdout, /interactive choices were not made/);
+    assert.match(result.questions[0], /Codex CLI/);
+    assert.match(result.questions[0], /tokens/);
+    assert.match(result.questions[0], /acc inbox/);
+    assert.doesNotMatch(result.questions[0], /messages still arrive|use next-turn hooks/);
+  }
+  const expectedPolicy = captured ? "actionable" : "off";
+  const operation = result.data.operations[0];
+  assert.equal(operation.livePolicy, expectedPolicy);
+  assert.equal(operation.effectiveLivePolicy, "off");
+  assert.equal(operation.nativeActivation, undefined);
+  const ownership = JSON.parse(await readFile(path.join(p.dataHome, "acc", "installs.json")));
+  assert.equal(ownership.installs[0].deliveryPolicy, expectedPolicy);
+  await assert.rejects(readFile(path.join(p.env.CODEX_HOME,
+    "app-server-control", "app-server-control.sock")), { code: "ENOENT" });
+  assert.match(result.text, /Codex CLI.*live delivery/);
+  assert.match(result.text, /fallback: acc inbox/);
+  const doctor = await p.acc(["doctor"]);
+  const native = doctor.adapters.find(a => a.adapterId === "codex").nativeDelivery;
+  assert.equal(native.policy, expectedPolicy);
+  assert.notEqual(native.runtime, "active");
+  if (captured) {
+    assert.equal(native.reasonCode, "native_endpoint_unavailable");
+    assert.match((await human(p, ["doctor"])).stdout, /local delivery service is unavailable/);
+  }
+
+  await p.acc(["install", "--adapter", "codex", "--delivery", "off"]);
+  const off = await human(p, ["install", "--adapter", "codex"]);
+  assert.match(off.stdout, /Codex CLI.*live delivery: off/);
+  assert.match(off.stdout, /fallback: acc inbox/);
+  const after = await p.acc(["doctor"]);
+  assert.equal(after.adapters.find(a => a.adapterId === "codex").nativeDelivery.policy, "off");
+  if (captured) assert.ok(after.remediation.some(line =>
+    line.includes("acc install --adapter codex --delivery actionable")));
+
+  // A missing service is retryable; a version below the native minimum is not.
+  await p.setClientVersions({ codex: "0.147.0" });
+  const older = JSON.parse((await run(process.execPath, [driver],
+    { cwd: p.project, env: p.env })).stdout);
+  assert.equal(older.questions.length, 0);
+  assert.equal(older.data.operations[0].livePolicy, "off");
+  if (captured) assert.match(older.text, /fallback: next-turn hooks \(when enabled\) or acc inbox/);
+});
+
+
+test("doctor asks to complete missing launch setup before asking for a new session", async t => {
+  const p = await createPackedAcc(t);
+  p.env.CODEX_HOME = path.join(p.clientHome, ".codex");
+  await p.setClientVersions({ claude: "2.1.266" });
+  const executable = path.join(p.clientBin, "claude");
+  await writeFile(executable, '#!/bin/sh\n# notifications/claude/channel\nprintf "2.1.266 (Claude Code)\\n"\n');
+  p.env.SHELL = "/bin/bash";
+  await p.acc(["install", "--adapter", "claude_code", "--delivery", "actionable"]);
+  p.env.SHELL = "/bin/zsh";
+  const before = (await p.acc(["doctor"])).adapters.find(a => a.adapterId === "claude_code");
+  assert.equal(before.nativeDelivery.policy, "actionable");
+  if (!captured) {
+    assert.equal(before.nativeDelivery.eligibility, "unsupported");
+    return;
+  }
+  assert.equal(before.nativeDelivery.eligibility, "eligible");
+  assert.equal(before.nativeDelivery.activation, "missing");
+  assert.ok(before.remediation.some(line => line.startsWith("acc install --adapter claude_code")),
+    "a restart cannot create the missing launch shim or Channel configuration");
+  await p.acc(["install", "--adapter", "claude_code"]);
+  const after = (await p.acc(["doctor"])).adapters.find(a => a.adapterId === "claude_code");
+  assert.equal(after.nativeDelivery.activation, "recorded");
+  assert.equal(after.nativeDelivery.runtime, "waiting");
+  assert.ok(after.remediation.some(line => /new terminal/.test(line)));
+});

--- a/tests/acceptance/hook-after-finish-packed.test.mjs
+++ b/tests/acceptance/hook-after-finish-packed.test.mjs
@@ -70,3 +70,45 @@ for (const adapterId of ["claude_code", "codex"]) {
     assert.equal(afterEnd.sessions.length, 3);
   });
 }
+
+for (const adapterId of ["claude_code", "codex"]) {
+  test(`${adapterId} resumes a detached solo conversation whose ephemeral owner is absent`, async t => {
+    const packed = await createPackedAcc(t);
+    const payload = { session_id: "solo-conversation", cwd: packed.project };
+    const hook = name => packed.hook(adapterId, { ...payload, hook_event_name: name,
+      prompt: "Continue after detach" });
+    await hook("SessionStart");
+    const first = ownerFlags((await hook("UserPromptSubmit")).stdout, adapterId);
+    const before = await packed.acc(["status"]);
+    assert.equal(before.materialised, false);
+    assert.equal(before.counts.live, 1);
+    const participantId = before.participants[0].participantId;
+
+    await packed.acc(["detach", ...first]);
+    const detached = await packed.acc(["status"]);
+    assert.equal(detached.materialised, false);
+    assert.deepEqual(detached.participants, []);
+    const oldBinding = await packed.findBinding(payload.session_id);
+    assert.equal(oldBinding.accSessionId, first[1]);
+    await packed.hook(adapterId, { ...payload, hook_event_name: "PreToolUse",
+      tool_name: "Bash", tool_input: { command: "true" } });
+    assert.deepEqual((await packed.acc(["status"])).participants, [],
+      "a tool hook revived a completed owner without a genuine user turn");
+    assert.deepEqual(await packed.findBinding(payload.session_id), oldBinding);
+
+    const fresh = ownerFlags((await hook("UserPromptSubmit")).stdout, adapterId);
+    assert.notEqual(fresh[1], first[1]);
+    assert.notEqual(fresh[3], first[3]);
+    const after = await packed.acc(["status"]);
+    assert.equal(after.materialised, false);
+    assert.equal(after.counts.live, 1);
+    assert.equal(after.participants[0].sessionId, fresh[1]);
+    assert.equal(after.participants[0].participantId, participantId);
+    await packed.acc(["work", ...fresh, "--summary", "continued with fresh ownership"]);
+    assert.equal((await packed.accError(["heartbeat", ...first]))?.code, 5);
+    assert.deepEqual(ownerFlags((await hook("UserPromptSubmit")).stdout, adapterId), fresh);
+    await hook("SessionEnd");
+    assert.equal(await packed.findBinding(payload.session_id), null);
+    assert.deepEqual((await packed.acc(["status"])).participants, []);
+  });
+}

--- a/tests/acceptance/hook-crash-recovery-packed.test.mjs
+++ b/tests/acceptance/hook-crash-recovery-packed.test.mjs
@@ -53,14 +53,27 @@ test("installed hook crash recovery preserves one exact owner", async t => {
     const id = "before-open";
     await crashHook(packed, { boundary: "before-open", payload: startPayload(id), participantId: id });
     const pending = await packed.findBinding(id);
-    // A header naming a session that never opened sends every subsequent CLI call to exit 5.
-    const turn = await packed.beforeTurn({ adapterId: "claude_code", harnessSessionId: id });
-    assert.doesNotMatch(turn.stdout, /ACC CLI|--generation/);
-    await start(id);
+    assert.ok(pending, "the crash did not retain the unpublished owner pair");
+    assert.deepEqual((await packed.acc(["status"])).participants, []);
+    const tool = await packed.hook("claude_code", { ...startPayload(id),
+      hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: { command: "true" } });
+    assert.doesNotMatch(tool.stdout, /ACC CLI|--generation/);
+    assert.deepEqual(await packed.findBinding(id), pending);
+    assert.deepEqual((await packed.acc(["status"])).participants, []);
+    // A genuine prompt can recover, but may expose only a newly opened pair.
+    const turn = await packed.hook("claude_code", { ...startPayload(id),
+      hook_event_name: "UserPromptSubmit", prompt: "continue" }, { ACC_PARTICIPANT: id });
     const current = await packed.findBinding(id);
     assert.ok(current);
-    if (pending !== null) assert.notEqual(current.generation, pending.generation);
+    assert.notEqual(current.accSessionId, pending.accSessionId);
+    assert.notEqual(current.generation, pending.generation);
+    assert.ok(turn.stdout.includes(current.accSessionId));
+    assert.ok(turn.stdout.includes(current.generation));
+    assert.equal(turn.stdout.includes(pending.generation), false);
     await packed.acc(["heartbeat", ...flags(current)]);
+    assert.equal((await packed.accError(["heartbeat", ...flags(pending)]))?.code, 5);
+    await start(id);
+    assert.deepEqual(flags(await packed.findBinding(id)), flags(current));
     assert.equal((await packed.acc(["status"])).participants.filter(p => p.participantId === id).length, 1);
     await end(id);
   });

--- a/tests/acceptance/hook-turn-lifecycle-packed.test.mjs
+++ b/tests/acceptance/hook-turn-lifecycle-packed.test.mjs
@@ -104,7 +104,7 @@ test("a genuine turn with no binding establishes its own fresh owner", async t =
   assert.equal(after.sessions.find(s => s.sessionId === binding.accSessionId).state, "open");
 });
 
-test("stale bindings and heartbeats cannot allocate owners", async t => {
+test("missing owners recover while stale generations and heartbeats cannot allocate owners", async t => {
   const f = await fixture(t);
   const { start, owner } = await f.prepare("closed");
   const runtimeDir = start.service.store.root;
@@ -120,6 +120,24 @@ test("stale bindings and heartbeats cannot allocate owners", async t => {
     const result = await f.invoke(state === "heartbeat" ? "heartbeat" : "beforeTurn", state,
       { probeClientVersion: async () => { probes += 1; return "1.0.0"; } });
     assert.equal(result.exitCode, 0);
+    if (state === "missing") {
+      const fresh = await f.packed.findBinding(state);
+      assert.equal(result.failed, undefined, result.reason);
+      assert.equal(probes, 1);
+      assert.notEqual(fresh.accSessionId, "session_not_created");
+      assert.notEqual(fresh.generation, "generation_stale");
+      assert.ok(result.stdout.includes(fresh.accSessionId));
+      assert.ok(result.stdout.includes(fresh.generation));
+      assert.equal(result.stdout.includes("generation_stale"), false);
+      await f.packed.acc(["heartbeat", "--session", fresh.accSessionId,
+        "--generation", fresh.generation]);
+      assert.equal((await f.packed.accError(["heartbeat", "--session", "session_not_created",
+        "--generation", "generation_stale"]))?.code, 5);
+      assert.deepEqual((await f.snapshot()).sessions.filter(s => s.sessionId !== fresh.accSessionId),
+        before.sessions);
+      await f.invoke("sessionEnd", state);
+      continue;
+    }
     assert.equal(result.stdout, "");
     assert.equal(probes, 0);
     assert.deepEqual((await f.snapshot()).sessions, before.sessions);

--- a/tests/acceptance/managed-codex-data-home-packed.test.mjs
+++ b/tests/acceptance/managed-codex-data-home-packed.test.mjs
@@ -34,18 +34,22 @@ test("managed refresh keeps generated Codex hooks and skills in the enrolled dat
   const skill = await readFile(path.join(plugin, "skills", "acc", "SKILL.md"), "utf8");
   const statusCommand = skill.match(/`([^`\n]+ status --json)`/)[1];
   for (const inherited of [undefined, path.join(f.root, "wrong-data")]) {
-    const env = { ...f.env, PATH: `${f.clientBin}:/usr/bin:/bin` };
+    // Shell and Node use absolute paths; keep unrelated host Git out of this
+    // non-Git data-home fixture and its finite hook budget.
+    const env = { ...f.env };
     delete env.ACC_DATA_HOME;
     delete env.XDG_DATA_HOME;
     if (inherited !== undefined) env.ACC_DATA_HOME = inherited;
     const wrongHome = inherited ?? platformDataHome({ platform: process.platform, env });
     const nativeId = `refresh-home-${inherited === undefined ? "absent" : "wrong"}`;
+    const startedAt = Date.now();
     const pending = run("/bin/sh", [shim, "session-start"], { cwd: f.project, env });
     pending.child.stdin.end(JSON.stringify({ hook_event_name: "SessionStart", session_id: nativeId,
       cwd: f.project, source: "startup" }));
-    await pending;
+    const output = await pending;
     const binding = await f.findBinding(nativeId);
-    assert.ok(binding, "regenerated hook must persist its binding in the enrolled data home");
+    assert.ok(binding, "regenerated hook must persist its binding in the enrolled data home: "
+      + JSON.stringify({ nativeId, elapsedMs: Date.now() - startedAt, ...output }));
     const status = JSON.parse((await run("/bin/sh", ["-c", statusCommand], { cwd: f.project, env })).stdout);
     assert.ok(status.data.participants.some(peer => peer.sessionId === binding.accSessionId),
       "regenerated skill must read the same hook workspace");

--- a/tests/process/claude-channel-install.test.mjs
+++ b/tests/process/claude-channel-install.test.mjs
@@ -10,6 +10,10 @@ import { promisify } from "node:util";
 const run = promisify(execFile);
 const repo = path.resolve(import.meta.dirname, "..", "..");
 const acc = path.join(repo, "bin", "acc.mjs");
+const capturedPlatform = process.platform === "darwin" && process.arch === "arm64";
+const assertNativeReason = text => assert.match(text, capturedPlatform
+  ? /2\.1\.252.*2\.1\.258/ : /not verified on this platform/);
+
 
 async function machine(t) {
   const home = await realpath(await mkdtemp(path.join(tmpdir(), "acc-claude-home-")));
@@ -54,14 +58,12 @@ for (const policy of ["actionable", "all"]) {
 
     assert.equal(operation.livePolicy, policy);
     assert.equal(operation.effectiveLivePolicy, "off");
-    assert.match(operation.deliveryDiagnostic, /2\.1\.252/);
-    assert.match(operation.deliveryDiagnostic, /development-channel security warning/);
-    assert.match(operation.deliveryDiagnostic, /next-turn.*acc inbox/);
+    assertNativeReason(operation.deliveryDiagnostic);
+    assert.match(operation.deliveryDiagnostic, /fallback: acc inbox/);
 
     const installed = await place.command("install", "--adapter", "claude_code",
       "--delivery", policy, "--home", place.home);
-    assert.match(installed.stdout, /development-channel security warning/,
-      "the human install report hid the native-delivery downgrade");
+    assertNativeReason(installed.stdout);
     for (const tree of await place.pluginTrees()) {
       await assert.rejects(readFile(path.join(tree, ".mcp.json")), { code: "ENOENT" });
       assert.equal((await readFile(path.join(tree, "hooks", "hooks.json"), "utf8"))
@@ -79,17 +81,16 @@ test("doctor names the failed native capture and the durable fallback", async t 
   await place.command("install", "--adapter", "claude_code", "--home", place.home);
 
   const human = (await place.command("doctor", "--home", place.home)).stdout;
-  assert.match(human, /2\.1\.252/);
-  assert.match(human, /development-channel security warning/);
-  assert.match(human, /next-turn.*acc inbox/);
+  assertNativeReason(human);
+  assert.match(human, /fallback: acc inbox/);
 
   const body = JSON.parse((await place.command("doctor", "--home", place.home,
     "--json")).stdout).data;
   const claude = body.adapters.find(adapter => adapter.adapterId === "claude_code");
   assert.equal(claude.capabilities.delivery.livePush, false);
   assert.equal(claude.capabilities.delivery.replyRoute, false);
-  assert.match(claude.deliveryDiagnostic, /development-channel security warning/);
-  assert.match(claude.diagnostics.join(" "), /next-turn.*acc inbox/);
+  assertNativeReason(claude.deliveryDiagnostic);
+  assert.match(claude.diagnostics.join(" "), /fallback: acc inbox/);
 });
 
 test("delivery off removes only legacy ACC channel opt-ins", async t => {

--- a/tests/process/claude-native-delivery.test.mjs
+++ b/tests/process/claude-native-delivery.test.mjs
@@ -41,7 +41,8 @@ async function machine(t) {
 
 const acc = path.join(repo, "bin", "acc.mjs");
 const run = (place, args) => import("node:child_process").then(({ execFile }) =>
-  new Promise((resolve, reject) => execFile(process.execPath, [acc, ...args, "--cwd", place.project],
+  new Promise((resolve, reject) => execFile(process.execPath, [
+    ...(place.preload ? ["--import", place.preload] : []), acc, ...args, "--cwd", place.project],
     { env: place.env }, (error, stdout, stderr) =>
       error ? reject(Object.assign(error, { stdout, stderr })) : resolve({ stdout, stderr }))));
 
@@ -51,10 +52,10 @@ const run = (place, args) => import("node:child_process").then(({ execFile }) =>
  * assumed a capture, it passed on the author's laptop and failed on Linux CI -
  * which is how it was found, after the release had already gone out.
  *
- * So it is two tests rather than a skip. Where there is a capture, the install
- * wires the channel. Where there is none, it must say so and wire nothing at
- * all, which is the rule that actually matters - an uncaptured platform must
- * never be promoted to a native path - and it is only checkable off darwin.
+ * The eligible case uses the actual host platform. The unsupported case makes
+ * only its CLI subprocess report an uncaptured architecture, so every host
+ * checks that saved consent cannot wire an unverified native path. This is a
+ * platform-gate fixture, not native-client or operating-system certification.
  */
 const CAPTURED_PLATFORM = process.platform === "darwin" && process.arch === "arm64";
 
@@ -94,10 +95,10 @@ test("an eligible live install writes a channel .mcp.json pointing at managed la
   await assert.rejects(readFile(source), { code: "ENOENT" });
 });
 
-test("a platform with no capture is told so, and no channel is wired", {
-  skip: CAPTURED_PLATFORM ? "this platform has a passing capture" : false,
-}, async t => {
+test("a platform with no capture is told so, and no channel is wired", async t => {
   const place = await machine(t);
+  place.preload = path.join(place.home, "uncaptured-architecture.mjs");
+  await writeFile(place.preload, 'Object.defineProperty(process, "arch", { value: "uncaptured-fixture" });\n');
   const installed = await run(place, ["install", "--adapter", "claude_code", "--delivery",
     "actionable", "--home", place.home]);
 
@@ -106,10 +107,16 @@ test("a platform with no capture is told so, and no channel is wired", {
   // machine actually gets.
   assert.doesNotMatch(installed.stdout, /native delivery is wired/i,
     "an uncaptured platform was told a native path had been wired");
-  assert.match(installed.stdout, /native delivery is off/i,
-    "the downgrade was applied without saying so");
-  assert.match(installed.stdout, /acc inbox|next-turn/i,
-    "the downgrade did not name what is left");
+  assert.match(installed.stdout, /consent saved \(actionable\); not active/i,
+    "saved consent was not distinguished from an active channel");
+  assert.match(installed.stdout, /native delivery is not verified on this platform/i,
+    "the unavailable native channel was not explained");
+  assert.match(installed.stdout, /fallback: acc inbox/i,
+    "the uncaptured platform did not name its durable fallback");
+  const ownership = JSON.parse(await readFile(path.join(place.dataHome, "acc", "installs.json")));
+  const record = ownership.installs.find(entry => entry.adapterId === "claude_code");
+  assert.equal(record.deliveryPolicy, "actionable");
+  assert.equal(record.nativeActivation, undefined);
 
   // The claim and the artefact have to agree. A channel wired here would be a
   // native path on a platform nobody captured, which is the exact thing the

--- a/tests/process/claude-native-delivery.test.mjs
+++ b/tests/process/claude-native-delivery.test.mjs
@@ -65,6 +65,12 @@ test("an eligible live install writes a channel .mcp.json pointing at managed la
   const installed = await run(place, ["install", "--adapter", "claude_code", "--delivery",
     "actionable", "--home", place.home]);
   assert.match(installed.stdout, /native delivery is wired/i);
+  assert.match(installed.stdout, /MCP connection does not verify inbound delivery/,
+    "install treated a configured Channel as proof Claude admitted its messages");
+  const doctor = await run(place, ["doctor", "--home", place.home]);
+  assert.match(doctor.stdout, /Channels.*startup/,
+    "doctor omitted the client-side Channel admission check");
+  assert.match(doctor.stdout, /MCP connection does not verify inbound delivery/);
   const source = path.join(place.home, ".claude", "plugins", "marketplaces", "acc-local",
     "agents-can-communicate", ".mcp.json");
   const versions = await readdir(path.join(place.home, ".claude", "plugins", "cache", "acc-local",

--- a/tests/process/codex-live-fallback.test.mjs
+++ b/tests/process/codex-live-fallback.test.mjs
@@ -95,14 +95,13 @@ for (const policy of ["actionable", "all"]) {
 
     assert.equal(operation.livePolicy, policy);
     assert.equal(operation.effectiveLivePolicy, "off");
-    assert.match(operation.deliveryDiagnostic, /0\.152\.1/);
-    assert.match(operation.deliveryDiagnostic, /recorded.*consent/i);
-    assert.match(operation.deliveryDiagnostic, /does not start, restart or stop.*daemon/i);
-    assert.match(operation.deliveryDiagnostic, /next-turn.*acc inbox/);
+    assert.match(operation.deliveryDiagnostic, capturedPlatform
+      ? /local delivery service is unavailable/ : /not verified on this platform/);
+    assert.match(operation.deliveryDiagnostic, /fallback: acc inbox/);
 
     const installed = await place.command("install", "--adapter", "codex",
       "--delivery", policy, "--home", place.home);
-    assert.match(installed.stdout, /recorded.*consent/i,
+    assert.match(installed.stdout, /consent saved.*not active/i,
       "the human install report hid the native-delivery downgrade");
     const [record] = (await loadOwnership({ dataHome: place.dataHome })).installs;
     assert.equal(record.deliveryPolicy, policy,
@@ -127,10 +126,13 @@ test("doctor names unavailable fallback without withdrawing captured live delive
   await place.command("install", "--adapter", "codex", "--home", place.home);
 
   const human = (await place.command("doctor", "--home", place.home)).stdout;
-  assert.match(human, /0\.152\.1/);
-  assert.match(human, /recorded.*consent/i);
-  assert.match(human, /does not start, restart or stop.*daemon/i);
-  assert.match(human, /next-turn.*acc inbox/);
+  assert.match(human, /Codex CLI live delivery:.*off/);
+  assert.match(human, /fallback: acc inbox/);
+  if (capturedPlatform) {
+    assert.match(human, /local delivery service is unavailable/);
+    assert.match(human, /acc install --adapter codex --delivery actionable/);
+    assert.match(human, /ACC does not start or restart that service/);
+  }
   await assertOnlyVersionProbes(place);
 
   const body = JSON.parse((await place.command("doctor", "--home", place.home,
@@ -139,8 +141,9 @@ test("doctor names unavailable fallback without withdrawing captured live delive
   assert.equal(codex.capabilities.delivery.nextTurn, false);
   assert.equal(codex.capabilities.delivery.livePush, capturedPlatform);
   assert.equal(codex.capabilities.delivery.replyRoute, false);
-  assert.match(codex.deliveryDiagnostic, /recorded.*consent/i);
-  assert.match(codex.diagnostics.join(" "), /next-turn.*acc inbox/);
+  assert.match(codex.deliveryDiagnostic, /fallback: acc inbox/);
+  assert.equal(codex.nativeDelivery.reasonCode, capturedPlatform
+    ? "native_endpoint_unavailable" : "platform_not_captured");
   await assertOnlyVersionProbes(place);
 });
 

--- a/tests/process/delivery-bindings.test.mjs
+++ b/tests/process/delivery-bindings.test.mjs
@@ -91,9 +91,8 @@ test("requested Codex consent stays off without an isolated LocalDaemon session"
   assert.equal(operation.livePolicy, "actionable");
   assert.equal(operation.effectiveLivePolicy, "off");
   assert.equal(operation.clientVersion, "0.153.4");
-  assert.match(operation.deliveryDiagnostic, /recorded.*consent/i);
-  assert.match(operation.deliveryDiagnostic, /does not start, restart or stop.*daemon/i);
-  assert.match(operation.deliveryDiagnostic, /next-turn.*acc inbox/i);
+  assert.match(operation.deliverySummary, /consent saved.*not active/);
+  assert.match(operation.deliveryDiagnostic, /fallback: acc inbox/);
   await assertOnlyVersionProbes(place);
   await assert.rejects(stat(path.join(place.codexHome, "app-server-control")), { code: "ENOENT" },
     "the dry run created a LocalDaemon control directory");

--- a/tests/process/offer-after-write.test.mjs
+++ b/tests/process/offer-after-write.test.mjs
@@ -143,8 +143,14 @@ test("committing the same prepared offers twice is idempotent", async t => {
 test("a rejected offer commit leaves that receipt queued", async t => {
   const { invoke, receipt, recipient } = await fixture(t);
   const result = await invoke("beforeTurn", "recipient-session");
-  await recipient.service.closeSession({ sessionId: recipient.accSessionId,
-    generation: recipient.generation });
+  // The startup hook's service is scoped to its five-second budget. Expire it
+  // deliberately: under suite load the old fixture accidentally exercised that
+  // timeout instead of closing the recipient and testing offer rejection.
+  t.mock.method(Date, "now", () => recipient.deadlineAt);
+  try {
+    await result.service.closeSession({ sessionId: recipient.accSessionId,
+      generation: recipient.generation });
+  } finally { t.mock.restoreAll(); }
 
   await assert.rejects(result.commitOffers, /target|generation|open session/);
 


### PR DESCRIPTION
ACC 0.4.1 could skip Codex delivery consent when its local service was unavailable, and `doctor` could leave an inbox-only session unexplained. This 0.4.2 patch separates eligibility, saved policy, launch setup and current transport state. It records the last binding attempt per session so doctor can explain missing policy, an unidentified client process, and handshake failures/timeouts.

- Preserve explicit delivery consent without claiming an unavailable channel is active. Claude guidance distinguishes an MCP connection from client-side Channels admission.
- Restore participation on the next genuine prompt after solo `acc detach`, using fresh ownership and rejecting concurrent replacements.
- Align all package versions and refresh README, onboarding, troubleshooting and the upgrade guide. Workspace data format and native capability claims stay unchanged.

Validation: npm ci and syntax checks passed; 23 installed managed-update checks, 8 focused ownership checks and 17 installed crash/lifecycle checks passed. The exact 0.4.2 archive passed package verification and an upgrade from published 0.4.1 through `acc update`. Existing state, user settings and delivery preferences survived; upgraded hooks produced the expected doctor text/JSON. All 255 source/archive/installed/active files match. The uncaptured-platform install check runs on every host and verifies saved consent without native activation or artifacts. Near-deadline diagnostics now have a deterministic worker-allocation gate, and the generated-hook data-home fixture excludes unrelated host Git. Regression checks were demonstrated failing on the original defects or targeted mutations.

Mandatory pre-push gate passed on Node 24/macOS arm64: 1,954 tests, 1,953 passed, 1 skipped, zero failures. Final GitHub CI passed on this head: the full suite and package checks on macOS and Linux, lint, and AI code review.

[Candidate evidence](https://github.com/automatis-tools/agents-can-communicate/blob/f7b042cf334500830e77dbea19a26fd810c12d27/docs/release-evidence/v0.4.2.md) records source commit `7b082884f55e6ccc86d9e292c4dd647a6696352e` and archive SHA-256 `d509cd6a43c92e6fc0a5227a1a5499dfde0636385ede910f289a5c81c059a555`. The remote Claude cause remains unconfirmed; this release adds actionable diagnostics without certifying new native delivery capabilities.

This PR prepares the release candidate. Merge belongs to the maintainer; tagging, npm publication and the GitHub release follow separately.
