### PR TITLE
fix: restore Codex live replies and prepare ACC 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.4.3 — release candidate
+
+- Live opt-in configures Codex outgoing socket access on macOS arm64 with Codex
+  0.153.4 or newer, including before its local daemon becomes available. Default
+  workspace permissions and ACC-only legacy roots are migrated; custom policies
+  remain untouched and visibly unverified.
+- Permission selection, proxy and local grants are owned and restored together.
+  Reinstall is stable; off/uninstall preserves edited components and dependent
+  settings without reparenting foreign TOML declarations.
+- Install previews and consent disclose the outgoing permission setup. Doctor reports
+  outgoing configuration separately from receiving-channel state and gives the
+  supported command for a missing Codex daemon.
+- EPERM/EACCES in either native transport remain `transport_permission_denied`
+  through router and durable offer events. CLI explains the sender-side block;
+  the recorded message remains queued. macOS channel paths no longer vary with TMPDIR.
+- README, onboarding, configuration, troubleshooting and upgrade documentation are updated.
+
+| Candidate artifact | Value |
+|---|---|
+| Built from | `7583e437651c93285650f6bcf983d677b850393f` |
+| Tarball | `agents-can-communicate-0.4.3.tgz`, 347,612 bytes, 259 files |
+| sha256 | `eeea525e9b15f25b09d5ec08e6754574b684e447bebe5798b264b088b9a2fa8d` |
+
+The exact archive passed installed-package verification, all 23 managed-update
+checks, and an upgrade from published 0.4.2. All 259 source, archive, installed and
+active managed files match. A fresh Claude 2.1.267 → Codex 0.154.0 → Claude live
+round trip passed with installer-generated permissions and two native offers.
+The real Codex sandbox allowed ACC sockets and denied unrelated Unix/TCP endpoints.
+See [candidate evidence](docs/release-evidence/v0.4.3.md) for setup and limitations.
+The full suite runs after this evidence commit through the mandatory pre-push gate.
+This candidate has not been tagged or published.
+
 ## 0.4.2 — release candidate
 
 - A genuine prompt restores ACC participation after detaching a solo session whose

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ then restart your clients from the project directory. In Codex, check `/plugins`
 review the current ACC definitions in `/hooks`; changed hooks may need fresh trust.
 [Getting started](docs/GETTING_STARTED.md) covers activation and preserved sandbox settings.
 
+For Codex live delivery on Apple Silicon macOS, installation also configures outgoing
+local socket access on Codex 0.153.4 or newer when using default workspace permissions.
+Custom policies are preserved. If its local service is missing, doctor gives the command
+`codex app-server daemon start`; then open a new Codex session. Doctor reports receiving
+channel state and outgoing permission configuration separately.
+
 Open two sessions and give them ordinary tasks, as above. Look for an agent discovering a
 peer, checking who is changing a file, asking about a shared dependency, or replying to a
 review request.
@@ -73,8 +79,8 @@ Run `acc doctor` from the project if a peer is missing. A directory containing A
 state, commonly your home directory, cannot be used as a workspace; start the client in a
 project directory. See [Troubleshooting](docs/TROUBLESHOOTING.md).
 
-Already using ACC? Follow the [upgrade guide](docs/UPGRADING.md), including the 0.4.0/0.4.1 →
-0.4.2 update and the data-format boundary when moving from 0.3.1.
+Already using ACC? Follow the [upgrade guide](docs/UPGRADING.md), including the 0.4.x →
+0.4.3 update and the data-format boundary when moving from 0.3.1.
 
 ## When messages arrive
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -144,6 +144,31 @@ consent from the installation record, not a shell-shim variable. Unavailable or 
 sessions retain durable inbox fallback. Use `acc install --adapter codex --delivery off`
 to stop new native offers; bypassing a shim does not disable that recorded opt-in.
 
+### Codex outgoing permissions
+
+Receiving a native message and sending from the agent's sandbox are separate operations.
+On Codex 0.153.4 or newer on macOS arm64, live opt-in also configures outgoing access
+for default workspace permissions. This happens even when the daemon is not yet available.
+Installation, its preview, and the interactive consent question disclose this change.
+
+ACC selects a permission profile named `acc-workspace`, extending `:workspace`. It grants
+write access to the ACC state directory and allows only the local ACC channel directory
+(`/tmp/acc-ch-<uid>`) and the Codex home control socket. The profile enables networking
+through `features.network_proxy = true`, with no external domains allowed. The proxy and
+socket grants must stay together: enabling networking without the proxy changes its scope.
+
+An existing legacy workspace-write configuration is migrated only when its sole writable
+root is ACC's state directory. Custom permission/configuration profiles, additional roots,
+inline settings and uncaptured clients are preserved and reported as unverified. ACC does
+not merge arbitrary security policies or verify overrides in an already running session.
+For a custom policy, grant the same state and socket access through the proxy in the
+client's effective workspace profile; do not combine it with legacy sandbox settings.
+
+Restart Codex after changing permissions. Explicit delivery `off` or uninstall restores
+the previous configuration only while every generated permission component is unchanged.
+If any component was edited or another setting depends on it, ACC preserves the entire
+bundle and reports it for review. Plugin registration can still be removed independently.
+
 ## Override local paths and identity
 
 Nothing in `acc.workspace.json` says where state is stored, and nothing there can — that is

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -15,7 +15,7 @@ pair or session-bound ACC MCP tools. See [CLI ownership](CLI.md#coordinate-from-
 
 ACC requires macOS or Linux and Node.js 24 or newer.
 
-Already using ACC? Follow the [upgrade guide](UPGRADING.md) for the 0.4.0/0.4.1 → 0.4.2
+Already using ACC? Follow the [upgrade guide](UPGRADING.md) for the 0.4.x → 0.4.3
 update or the data-format boundary when upgrading from 0.3.1.
 
 ```bash
@@ -39,8 +39,12 @@ printed by the installer. In Codex, use `/plugins` to check ACC is enabled, then
 to review each ACC hook and enable/trust its current definition if needed. Restart the
 session after that review; changed hook definitions may require trust again.
 
-If the installer preserved your existing Codex sandbox settings, verify the named ACC
-state directory is in `sandbox_workspace_write.writable_roots` in the config it identifies.
+For Codex live delivery, follow the outgoing-permission and local-service instructions
+from install/doctor, then start a new session. Default workspace permissions can be
+configured automatically on Codex 0.153.4 or newer on macOS arm64. Custom settings are
+preserved; see [outgoing permissions](CONFIGURATION.md#codex-outgoing-permissions).
+With legacy sandbox settings, the named ACC state directory must also be in
+`sandbox_workspace_write.writable_roots` in the config the installer identifies.
 ACC keeps those user settings unchanged. Installed files alone do not establish that hooks
 are active; `acc doctor` leaves current readiness unverified and directs you to Codex.
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -199,6 +199,10 @@ peer body into diagnostics.
 Receipt `offered` is committed only after the transport accepts bytes. A failed attempt
 leaves the receipt queued.
 
+`transport_permission_denied` means the sender's OS or sandbox refused local transport
+access (`EPERM` or `EACCES`). It is distinct from `recipient_unavailable` and remains a
+failed offer with a queued receipt; raw OS error strings are not persisted.
+
 ## Inbox, reply, and acknowledgement
 
 Without an id, public `inbox` lists bounded summary pages for unresolved messages owned

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,7 +1,7 @@
 # Releasing
 
 Use this procedure to build one auditable npm artifact, verify that exact tarball, and keep
-its evidence tied to the commit that supplied its bytes. The package is currently `0.4.2`;
+its evidence tied to the commit that supplied its bytes. The package is currently `0.4.3`;
 the commands derive the version from `package.json` so the filename cannot drift.
 
 ```mermaid

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -79,6 +79,13 @@ consent before offers. A loaded daemon thread can receive messages after its TUI
 exits. Delivery off and uninstall prevent new Codex submissions; a submission
 already accepted by the vendor queue cannot be withdrawn.
 
+On captured Codex/macOS configurations, live opt-in also grants outgoing access to ACC's
+state and local Unix sockets through a deny-by-default network proxy. Custom permission
+policies remain user-owned. Selection, proxy and grants are restored together only while
+unchanged; edited or newly referenced settings remain intact. See
+[Codex outgoing permissions](CONFIGURATION.md#codex-outgoing-permissions). Configuration
+readiness does not prove that an active session's overrides permit a live offer.
+
 ## Claims
 
 CLI claims default to advisory. Guarded enforcement must be requested explicitly and

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -100,6 +100,20 @@ ambiguous recipients or failed identity checks retain durable inbox access.
 An interactive install can save consent in either case. ACC preserves it through a temporary
 outage and does not start the daemon for you.
 
+On a supported Codex CLI, a missing daemon can be started with
+`codex app-server daemon start`; open a new Codex session afterward. Doctor includes this
+command when it detects the missing endpoint.
+
+If a reply stays queued with `transport_permission_denied`, the sender's permissions
+blocked local transport. This is distinct from an unavailable recipient. The message was
+recorded successfully; the error does not mean it was read or acknowledged.
+On Codex 0.153.4 or newer on macOS arm64, rerun `acc install --adapter codex` with existing
+live consent (or add `--delivery actionable` to opt in), then start a new session.
+Doctor's `outgoingDelivery` reports the installed permission configuration separately
+from `nativeDelivery.runtime`: an active receiving channel does not establish outgoing
+access. Custom policies and active-session overrides remain unverified; inspect the config
+path doctor names and follow [outgoing permissions](CONFIGURATION.md#codex-outgoing-permissions).
+
 Check `acc doctor --json` and `acc status --json` while both clients are open. If policy is
 `off`, opt in with `acc install --adapter codex --delivery actionable` (or select another
 adapter). This can spend model tokens. If policy is enabled but runtime is `waiting` and
@@ -153,8 +167,9 @@ definitions need review, and a trusted hook can still be disabled.
 
 `acc doctor` reports installed files separately from hook readiness, which it leaves
 unverified. A saved trust record cannot prove current activation. If installation preserved
-your own sandbox configuration, doctor also names the ACC state directory whose access
-you should check in `sandbox_workspace_write.writable_roots`.
+your own legacy sandbox configuration, doctor also names the ACC state directory whose
+access you should check in `sandbox_workspace_write.writable_roots`. Live delivery requires
+local socket permissions as well; a writable state directory alone is insufficient.
 
 ## Gemini does not guard a write
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,11 +1,11 @@
-# Upgrading to 0.4.2
+# Upgrading to 0.4.3
 
-## From 0.4.1 or 0.4.0
+## From 0.4.2, 0.4.1 or 0.4.0
 
-This patch keeps the existing workspace data format. It makes installation and delivery
-diagnostics clearer, records the last native binding attempt per session, and restores
-hook participation after detaching a solo session without restarting the conversation.
-It also includes the 0.4.1 Grok, reinstall-preference and workspace-warning fixes.
+This patch keeps the existing workspace data format. It fixes outgoing native delivery
+from Codex's sandbox, separates permission failures from unavailable recipients, and
+shows outgoing setup alongside receiving-channel state in doctor. It also includes the
+previous 0.4.x delivery diagnostics, session recovery and client integration fixes.
 
 Close participating clients and persistent ACC MCP processes, then run:
 
@@ -15,10 +15,15 @@ acc version
 acc doctor
 ```
 
-After publication, `acc version` should report 0.4.2. If a pin keeps an older version,
-select 0.4.2 or clear it first. A managed update refreshes installed integrations and
+After publication, `acc version` should report 0.4.3. If a pin keeps an older version,
+select 0.4.3 or clear it first. A managed update refreshes installed integrations and
 skills; use the npm instructions below for unmanaged or pre-0.4 installations. Start
-clients again and complete any hook/trust review they request.
+clients again and complete any hook/trust review they request. With existing live consent,
+Codex 0.153.4 or newer on macOS arm64 receives local socket permissions when its workspace
+policy is default or contains only ACC's legacy state root. Custom policies are preserved
+and reported as unverified. See [outgoing permissions](CONFIGURATION.md#codex-outgoing-permissions).
+If doctor names a missing local service, run `codex app-server daemon start` before opening
+the new session.
 
 Run `acc doctor` in the project after the new clients have started (or submitted a normal
 turn). Its per-session lines now explain missing launch consent, an unidentified client
@@ -59,7 +64,7 @@ restores access; deleting or editing the record is not a remedy.
 2. Install the released package, then refresh the client integrations:
 
    ```bash
-   npm install --global agents-can-communicate@0.4.2
+   npm install --global agents-can-communicate@0.4.3
    acc version
    acc install
    ```
@@ -109,7 +114,7 @@ acc update                    # download and apply, or report what is keeping it
 acc update --check            # check without installing or changing update settings
 acc update --auto off         # disable background updates
 acc update --auto on          # enable them again
-acc update --pin 0.4.2        # stay on this exact stable version
+acc update --pin 0.4.3        # stay on this exact stable version
 acc update --pin none         # follow stable releases again
 ```
 

--- a/docs/release-evidence/v0.4.3.md
+++ b/docs/release-evidence/v0.4.3.md
@@ -1,0 +1,90 @@
+# ACC 0.4.3 candidate evidence
+
+This patch is prepared for maintainer review. It has not been tagged or published.
+It fixes outgoing native delivery from Codex's sandbox and makes its configuration
+and permission failures visible in install, doctor and message commands.
+
+| Measurement | Value |
+|---|---|
+| Built from | `7583e437651c93285650f6bcf983d677b850393f` |
+| Archive | `agents-can-communicate-0.4.3.tgz`, 347,612 bytes, 259 files |
+| SHA-256 | `eeea525e9b15f25b09d5ec08e6754574b684e447bebe5798b264b088b9a2fa8d` |
+| Platform / Node | macOS arm64 / 24.4.0 |
+| Source / archive / installed / managed comparisons | 259/259 identical |
+
+The root, all 14 bundled package manifests, lock entries and embedded Gemini
+extension are aligned to 0.4.3. Syntax checks passed for 482 tracked modules.
+The exact archive passed `scripts/verify-package.mjs`, including a clean consumer,
+doctor, non-Git coordination, installation/removal and packed documentation links.
+No runtime dependency was added. The full suite runs after this evidence commit,
+including the mandatory pre-push gate.
+
+## Published-version upgrade
+
+Published 0.4.2 was downloaded and checked against its registry SHA-1 and SHA-512
+integrity. An isolated installation created participants, intents, a claim,
+requests, a reply, and queued and acknowledged obligations. The published CLI's
+`acc update` then consumed this unchanged candidate from a loopback registry.
+
+Workspace bytes and the public full-sync snapshot remained identical. User settings,
+foreign hooks, four installed integrations, delivery consent and the explicit
+automatic-update opt-out were preserved. The old launcher selected the new managed
+runtime. Its hooks and doctor retained per-session diagnostics. All 23 installed
+managed-update acceptance checks passed independently.
+
+## Regression checks
+
+Both EPERM and EACCES were reproduced through the real Claude transport, router
+and receipt writer before the fix: each was incorrectly reduced to
+`recipient_unavailable`. The Codex transport separately returned `transport_rejected`.
+Corrected checks require `transport_permission_denied`, a queued receipt and no raw
+OS error text in durable diagnostics.
+
+The new installer checks first failed on missing outgoing configuration and on
+version/platform facts lost between detection and application. Packed command checks
+also failed when the preview hid the proxy setup and when uninstall hid retained
+permissions. All passed after correction.
+
+Review reproduced unsafe teardown cases involving edited/missing pieces, modified
+restoration metadata, escaped profile references, configuration-profile overrides,
+and foreign assignments whose TOML scope changed after header restoration. Targeted
+checks failed on those cases before their fixes. The final configuration review
+found no remaining blockers; all 14 focused configuration checks passed.
+
+## Native round trip on the installed archive
+
+The final capture used Claude Code 2.1.267 and Codex CLI 0.154.0 on macOS arm64.
+Codex had updated since the earlier 0.153.4 investigation. The installer generated
+the outgoing permission profile; Codex used no remote or sandbox-bypass flags.
+
+Both were independent interactive terminal clients with isolated ACC state and
+plugin configuration. Codex used an isolated home and daemon. Claude used its normal
+account authentication with `--settings` and `--setting-sources` to select the test
+plugin configuration. Current hooks were reviewed and the development-channel
+notice accepted. These are explicit capture conditions, not proof of unattended
+client authentication or hook trust.
+
+After one initial instruction per client, Claude sent `LIVE043-FINAL`. The Codex
+native offer succeeded at 02:19:14.846 UTC on 2026-09-10. Codex created the authorized
+`CODEX_LIVE_043` marker and replied; the Claude native offer succeeded at
+02:19:32.698 UTC. Claude then created `CLAUDE_LIVE_043`. Exactly two messages and two
+successful native offers were recorded, with the reply linked to the request.
+No further model prompts or manual inbox reads were used. The request receipt was
+acknowledged by its reply; the answer receipt remained offered. Marker observation
+does not rewrite that delivery fact.
+
+Doctor reported both receiving channels active and Codex outgoing permissions
+configured. A separate real `codex sandbox` probe using the generated configuration
+connected to both ACC socket namespaces while unrelated Unix and localhost TCP
+connections failed with EPERM. This validates the local grants and retained boundary.
+
+An earlier isolated attempt launched its daemon with another installation's PATH
+and data environment; its reply stopped at `runtime unavailable`. The final run
+used matching environments and a fresh workspace. When deliberately overriding
+ACC's data home or PATH, the daemon must inherit that environment too.
+
+Raw client transcripts and credentials are excluded from retained evidence. Local
+evidence contains synthetic markers, hashes, closed events and public diagnostics.
+Custom permission policies, active-session overrides and other platforms remain
+unverified. This capture adds no exact-version hook certification or native replyRoute
+claim. Merge and publication remain the maintainer's actions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -114,59 +114,59 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.4.2"
+      "version": "0.4.3"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.4.2"
+      "version": "0.4.3"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.4.2"
+      "version": "0.4.3"
     },
     "packages/adapter-grok": {
       "name": "@agents-can-communicate/adapter-grok",
-      "version": "0.4.2"
+      "version": "0.4.3"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.4.2"
+      "version": "0.4.3"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.4.2"
+      "version": "0.4.3"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.4.2"
+      "version": "0.4.3"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.4.2"
+      "version": "0.4.3"
     },
     "packages/delivery-router": {
       "name": "@agents-can-communicate/delivery-router",
-      "version": "0.4.2"
+      "version": "0.4.3"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.4.2"
+      "version": "0.4.3"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.4.2"
+      "version": "0.4.3"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.4.2"
+      "version": "0.4.3"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.4.2"
+      "version": "0.4.3"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.4.2"
+      "version": "0.4.3"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "description": "Local-first coordination for independently opened AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-claude-code/src/channel.mjs
+++ b/packages/adapter-claude-code/src/channel.mjs
@@ -1,8 +1,8 @@
 import { randomBytes, timingSafeEqual } from "node:crypto";
 import { chmodSync, existsSync, mkdirSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import net from "node:net";
-import os from "node:os";
 import path from "node:path";
+import { channelSocketDirectory } from "@agents-can-communicate/adapter-sdk";
 
 // The production ACC Channel: a stdio MCP server Claude Code spawns, plus a
 // session-scoped Unix endpoint the delivery router reaches. One envelope on the
@@ -39,8 +39,6 @@ const shortId = () => `endpoint_${randomBytes(16).toString("hex")}`;
 // while the registration - discoverable by the hook-resolved pid - stays under
 // the workspace. The registration records the socket's absolute path, so the
 // two are decoupled.
-const defaultSocketDir = () => path.join(os.tmpdir(),
-  `acc-ch-${typeof process.getuid === "function" ? process.getuid() : "u"}`);
 
 /**
  * Compose a Channel over an endpoint directory and injected ACC callbacks.
@@ -49,7 +47,7 @@ const defaultSocketDir = () => path.join(os.tmpdir(),
  * ones backed by the real conversation service; a test supplies fakes. Neither
  * the socket path nor the nonce leaves through a return value or a log line.
  */
-export function createAccChannel({ endpointDir, socketDir = defaultSocketDir(), clientPid,
+export function createAccChannel({ endpointDir, socketDir = channelSocketDirectory(), clientPid,
   protocolContract = PROTOCOL_CONTRACT, modes = CHANNEL_MODES, leaseMs = 60_000, routeReply,
   routeAck, refreshBinding = null, observe = () => {},
   clock = () => new Date().toISOString(), write, now = Date.now }) {

--- a/packages/adapter-claude-code/src/native-delivery.mjs
+++ b/packages/adapter-claude-code/src/native-delivery.mjs
@@ -206,7 +206,9 @@ function sendEnvelope({ record, message, binding, connect, timeoutMs, rejected }
     const finish = value => { if (settled) return; settled = true; clearTimeout(timer);
       socket.destroy(); resolve(value); };
     const timer = setTimeout(() => finish(rejected("transport_error")), timeoutMs);
-    socket.once("error", () => finish(rejected("recipient_unavailable")));
+    socket.once("error", error => finish(rejected(
+      ["EPERM", "EACCES"].includes(error.code)
+        ? "transport_permission_denied" : "recipient_unavailable")));
     socket.once("connect", () => {
       socket.write(`${JSON.stringify(envelope)}\n`);
       let buffer = "";

--- a/packages/adapter-codex/COMPATIBILITY.md
+++ b/packages/adapter-codex/COMPATIBILITY.md
@@ -914,3 +914,25 @@ Delivery stayed off. This is one explicit continuation in a small fresh workspac
 not automatic client restart, unsaved-context recovery, arbitrary-history discovery or
 transfer of another participant's inbox. No ACC runtime, maintained test or capability
 changed. File samples do not exclude transient changes between observations.
+
+## Outgoing sandbox permissions, 2026-09-09
+
+On macOS arm64, ordinary Codex CLI 0.153.4 and Claude Code 2.1.267 sessions exposed
+an asymmetry in installed ACC 0.4.2: Claude's request reached Codex through the
+LocalDaemon queue, but Codex's shell reply could not connect to the Claude channel.
+The OS returned EPERM while both receiving bindings remained active. The former
+`recipient_unavailable` diagnosis concealed this sender-side permission failure.
+
+A workspace permission profile granting ACC state writes and its local Unix sockets,
+with the network proxy enabled and no external domains allowed, resolved that failure.
+A fresh ordinary Claude → Codex → Claude round trip then produced both synthetic
+markers and two successful native offers, without inbox polling or additional prompts.
+The same Codex sandbox allowed the ACC socket and denied an unrelated Unix socket and
+localhost TCP connection. Raw model transcripts were not retained.
+
+Automatic outgoing permission setup is limited to Codex 0.153.4 or newer on this
+platform. The installer preserves custom policies and reports them as unverified;
+configuration readiness never establishes an active session's effective permissions.
+This does not expand the certified hook versions or establish native replyRoute.
+The patch also uses a stable short macOS channel directory across different TMPDIR
+values and retains permission failures as a distinct safe offer code.

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/src/config-block.mjs
+++ b/packages/adapter-codex/src/config-block.mjs
@@ -3,10 +3,8 @@ import path from "node:path";
 import { BEGIN, END, renderBlock } from "@agents-can-communicate/adapter-sdk";
 import { AccError, EXIT } from "@agents-can-communicate/protocol";
 
-const unsafe = (reason = "unrecognized TOML declaration") => {
-  throw new AccError(EXIT.CONFLICT, `cannot safely edit Codex config: ${reason}; `
-    + "repair ambiguous TOML or ACC markers before retrying", { reason });
-};
+import { statements, declaration, unsafe } from "./toml-scan.mjs";
+
 const ROOT = "# ACC sandbox writable_roots created with: ";
 export const sandboxOwnership = root => `${ROOT}${JSON.stringify(root)}`;
 
@@ -15,88 +13,6 @@ const OWNED = new Map([
   [JSON.stringify(["plugins", "agents-can-communicate@acc-local"]), ["enabled"]],
   [JSON.stringify(["sandbox_workspace_write"]), ["writable_roots"]],
 ]);
-
-// A bounded lexical scan, not a TOML value parser. Newlines inside strings,
-// arrays and inline tables cannot introduce a header or a managed marker.
-function* statements(source) {
-  let start = 0, code = "", quote = null;
-  const stack = [];
-  for (let i = 0; i < source.length;) {
-    const char = source[i];
-    if (quote) {
-      if (quote[0] === '"' && char === "\\") {
-        code += source.slice(i, i + 2); i += 2; continue;
-      }
-      if (source.startsWith(quote, i)) {
-        let count = quote.length;
-        if (quote.length === 3) {
-          while (source[i + count] === quote[0]) count++;
-          if (count > 5) unsafe("unsupported string quote delimiter");
-        }
-        code += source.slice(i, i + count); i += count; quote = null; continue;
-      }
-      if (quote.length === 1 && /[\r\n]/.test(char)) unsafe("newline in single-line string");
-      code += char; i++; continue;
-    }
-    if (char === "#") {
-      while (i < source.length && source[i] !== "\n") i++;
-      continue;
-    }
-    if (char === '"' || char === "'") {
-      quote = source.startsWith(char.repeat(3), i) ? char.repeat(3) : char;
-      code += quote; i += quote.length; continue;
-    }
-    if (char === "[" || char === "{") stack.push(char);
-    if (char === "]" || char === "}") {
-      if (stack.pop() !== (char === "]" ? "[" : "{")) unsafe("mismatched collection delimiter");
-    }
-    code += char; i++;
-    if (char === "\n" && stack.length === 0) {
-      yield { raw: source.slice(start, i), code: code.trim() };
-      start = i; code = "";
-    }
-  }
-  if (quote || stack.length) unsafe(quote ? "unclosed string" : "unclosed collection");
-  if (start < source.length) yield { raw: source.slice(start), code: code.trim() };
-}
-
-function decodeKey(key) {
-  if (key[0] === "'") return key.slice(1, -1);
-  if (key[0] !== '"') return key;
-  return key.slice(1, -1).replace(/\\(U[\da-fA-F]{8}|u[\da-fA-F]{4}|[btnfr"\\])|\\./g,
-    (match, escape) => {
-      if (!escape) unsafe("unsupported quoted-key escape");
-      if (/^[uU]/.test(escape)) {
-        const point = Number.parseInt(escape.slice(1), 16);
-        if (point > 0x10ffff || (point >= 0xd800 && point <= 0xdfff)) {
-          unsafe("invalid quoted-key Unicode escape");
-        }
-        return String.fromCodePoint(point);
-      }
-      return ({ b: "\b", t: "\t", n: "\n", f: "\f", r: "\r", '"': '"', "\\": "\\" })[escape];
-    });
-}
-
-function keyPath(code) {
-  const keys = [];
-  let rest = code.trimStart();
-  for (;;) {
-    const match = /^(?:[A-Za-z0-9_-]+|'[^'\r\n]*'|"(?:[^"\\\r\n]|\\[^\r\n])*")/.exec(rest);
-    if (!match) unsafe("unrecognized TOML key");
-    keys.push(decodeKey(match[0]));
-    rest = rest.slice(match[0].length).trimStart();
-    if (!rest.startsWith(".")) return { keys, rest };
-    rest = rest.slice(1).trimStart();
-  }
-}
-
-function declaration(code) {
-  const header = code.startsWith("[");
-  const array = header && code.startsWith("[[");
-  const { keys, rest } = keyPath(header ? code.slice(array ? 2 : 1) : code);
-  if (header ? rest !== (array ? "]]" : "]") : !rest.startsWith("=")) unsafe();
-  return { keys, header, array, value: header ? null : rest.slice(1).trim() };
-}
 
 // An unchanged, newly generated sandbox has value provenance. A legacy or
 // edited sandbox belongs to the client as a whole and remains byte-preserved.
@@ -214,8 +130,8 @@ export async function readConfig(file) {
   });
 }
 
-export async function writeTomlBlock(file, body) {
-  const { source } = inspectConfig(await readConfig(file), file);
+export async function writeTomlBlock(file, body, preparedSource) {
+  const source = preparedSource ?? inspectConfig(await readConfig(file), file).source;
   const separator = source === "" || source.endsWith("\n") ? "" : "\n";
   await mkdir(path.dirname(file), { recursive: true });
   await writeFile(file, `${source}${separator}${renderBlock(body)}\n`);

--- a/packages/adapter-codex/src/install.mjs
+++ b/packages/adapter-codex/src/install.mjs
@@ -9,7 +9,8 @@ import { bakeSkillCommand, blankJson, blankText, removeIfEmpty, removeInstalledT
   tomlString, writeForeignJson, writeHookShim }
   from "@agents-can-communicate/adapter-sdk";
 import { AccError, EXIT } from "@agents-can-communicate/protocol";
-import { inspectConfig, readConfig, removeTomlBlock, sandboxOwnership, writeTomlBlock } from "./config-block.mjs";
+import { inspectConfig, readConfig, sandboxOwnership, writeTomlBlock } from "./config-block.mjs";
+import { outgoingStatus, prepareLivePermissions, removeLivePermissions } from "./live-permissions.mjs";
 
 // Kept cohesive above 300 lines because Codex plugin install, cache, config,
 // detection, and ownership share one client topology; splitting would duplicate
@@ -159,7 +160,8 @@ const sandboxReview = (config, file, stateRoot) =>
     : [];
 
 export async function installCodexPlugin({ home, agentsHome = home,
-  codexHome = path.join(home, ".codex"), dataHome, stateRoot, runner, node, cli, preserveVersions = false }) {
+  codexHome = path.join(home, ".codex"), dataHome, stateRoot, runner, node, cli, preserveVersions = false,
+  requestedLivePolicy, livePolicy, clientVersion, platform }) {
   // Read before writing, so a manifest that will not parse is found before a
   // plugin tree is laid down that nothing will then be able to remove.
   const existing = await readJson(marketplacePath(agentsHome), { name: MARKETPLACE,
@@ -179,7 +181,10 @@ export async function installCodexPlugin({ home, agentsHome = home,
       `marketplace ${MARKETPLACE} or its plugin is already registered in this config; `
       + "remove it and install again", { config });
   }
-  const theirSandbox = foreign.sandbox;
+  const permissions = prepareLivePermissions(foreign.source, { home, codexHome, stateRoot,
+    file: config, requestedLivePolicy, livePolicy, clientVersion, platform });
+  const theirSandbox = permissions.skipLegacy || inspectConfig(permissions.source, config).sandbox;
+  const permissionActions = permissions.status?.state === "unverified" ? [permissions.status.diagnostic] : [];
 
   const target = pluginPath(agentsHome);
   await rm(target, { recursive: true, force: true });
@@ -207,7 +212,7 @@ export async function installCodexPlugin({ home, agentsHome = home,
     `[plugins.${tomlString(QUALIFIED)}]`,
     "enabled = true",
     ...sandboxTable(stateRoot, theirSandbox),
-  ]);
+  ], permissions.source);
 
   // The client runs the cached copy, so this has to happen after the shim and
   // the rewritten hooks.json are in place.
@@ -235,9 +240,11 @@ export async function installCodexPlugin({ home, agentsHome = home,
   // while ACC invented its own marketplace name and so had a root to itself.
   // make the record stale the moment the plugin version changes.
   return { ok: true, changes: [target, file, config, cachePath(codexHome)],
-    needsAction: [HOOK_REVIEW, ...sandboxReview(before, config, stateRoot)],
+    needsAction: [HOOK_REVIEW, ...permissionActions,
+      ...(permissions.skipLegacy ? [] : sandboxReview(before, config, stateRoot))],
     diagnostics: ["hooks require explicit trust in Codex before they run",
-      ...sandboxReview(before, config, stateRoot)] };
+      ...(permissions.status ? [permissions.status.diagnostic] : []),
+      ...(permissions.skipLegacy ? [] : sandboxReview(before, config, stateRoot))] };
 }
 
 /** Remove each directory that is empty, in the order given. */
@@ -255,21 +262,25 @@ export async function preflightCodexUninstall({ home, agentsHome = home,
     if (error.code === "ENOENT") return "";
     throw error;
   });
-  return { existing, withoutOurs: inspectConfig(before, configPath(codexHome)).source };
+  const permissions = removeLivePermissions(inspectConfig(before, configPath(codexHome)).source);
+  return { existing, before, withoutOurs: permissions.source, permissionState: permissions.state };
 }
 
 export async function uninstallCodexPlugin({ home, agentsHome = home,
   codexHome = path.join(home, ".codex"), keep = [] }) {
   const file = marketplacePath(agentsHome);
   // Direct adapter callers need the same check as the installer boundary.
-  const { existing, withoutOurs } = await preflightCodexUninstall({ home, agentsHome, codexHome });
+  const { existing, before, withoutOurs, permissionState } = await preflightCodexUninstall({ home, agentsHome, codexHome });
   const changes = [];
   if (existing !== null) {
     const kept = (existing.plugins ?? []).filter(entry => entry.name !== PLUGIN_NAME);
     if (kept.length !== (existing.plugins ?? []).length) changes.push(PLUGIN_NAME);
     await writeMarketplace(file, { ...existing, plugins: kept });
   }
-  if (await removeTomlBlock(configPath(codexHome))) changes.push(configPath(codexHome));
+  if (before !== withoutOurs) {
+    await writeFile(configPath(codexHome), withoutOurs);
+    changes.push(configPath(codexHome));
+  }
   // The client's `[hooks.state."<plugin>:…"]` tables stay. 0.1.9 removed them as
   // litter naming a plugin that was gone; that was wrong, and wrong in a way
   // worth writing down. The check behind it perturbed the record - a hook whose
@@ -312,13 +323,16 @@ export async function uninstallCodexPlugin({ home, agentsHome = home,
     marketplaceRoot(agentsHome),
     cacheRoot(codexHome),
   ]);
-  return { ok: true, changes, diagnostics: declaresSandbox(withoutOurs)
-    ? ["existing sandbox_workspace_write configuration was preserved; review any retained writable_roots after removal"]
-    : [] };
+  const permissionReview = permissionState === "customized"
+    ? ["customized native permissions were preserved together with their default selection and network proxy; review them in Codex config"] : [];
+  return { ok: true, changes, needsAction: permissionReview, diagnostics: [
+    ...(declaresSandbox(withoutOurs)
+      ? ["existing sandbox_workspace_write configuration was preserved; review any retained writable_roots after removal"] : []),
+    ...permissionReview] };
 }
 
 export async function detectCodex({ home, agentsHome = home,
-  codexHome = path.join(home, ".codex"), stateRoot }) {
+  codexHome = path.join(home, ".codex"), stateRoot, clientVersion, platform, nativeDelivery }) {
   const marketplace = await readJson(marketplacePath(agentsHome), null);
   const published = (marketplace?.plugins ?? []).some(entry => entry.name === PLUGIN_NAME);
   const config = await readFile(configPath(codexHome), "utf8").catch(() => "");
@@ -326,11 +340,17 @@ export async function detectCodex({ home, agentsHome = home,
   const pluginEntry = config.includes(`[plugins."${QUALIFIED}"]`);
   const cached = await stat(cachePath(codexHome))
     .then(() => true).catch(() => false);
+  const outgoingDelivery = outgoingStatus(config, { home, codexHome, stateRoot,
+    file: configPath(codexHome), clientVersion, platform });
   // Saved trust is not readiness. Codex compares every current definition's
   // hash and can disable a trusted hook. Even a commented or stale single record
   // previously suppressed this check. Leave verification to Codex's /hooks;
   // detection neither invents its hash algorithm nor starts a client service.
-  return { ok: true, changes: [], diagnostics: [
+  return { ok: true, changes: [], outgoingDelivery,
+    nativeSetup: nativeDelivery?.reasonCode === "native_endpoint_unavailable"
+      ? "Codex CLI: run codex app-server daemon start, then open a new Codex session; ACC never starts or restarts the daemon"
+      : null,
+    diagnostics: [
     published ? "acc plugin published in the marketplace" : "acc plugin not registered",
     registered && pluginEntry
       ? "marketplace and plugin entries found in config; activation not verified"
@@ -347,7 +367,8 @@ export async function detectCodex({ home, agentsHome = home,
       : []),
   ],
   needsAction: cached
-    ? [HOOK_REVIEW, ...sandboxReview(config, configPath(codexHome), stateRoot)]
+    ? [HOOK_REVIEW, ...sandboxReview(config, configPath(codexHome), stateRoot),
+      ...(outgoingDelivery.state === "unverified" ? [outgoingDelivery.diagnostic] : [])]
     : [] };
 }
 

--- a/packages/adapter-codex/src/live-permissions.mjs
+++ b/packages/adapter-codex/src/live-permissions.mjs
@@ -1,0 +1,110 @@
+import path from "node:path";
+import { channelSocketDirectory, tomlString } from "@agents-can-communicate/adapter-sdk";
+import { compareStableVersions, parseStableVersion } from "./app-server-client.mjs";
+import { addPermissions, inspectPermissions } from "./permission-ownership.mjs";
+import { scanConfig } from "./toml-scan.mjs";
+
+const PROFILE = "acc-workspace";
+const MINIMUM = "0.153.4";
+const equal = (keys, expected) => JSON.stringify(keys) === JSON.stringify(expected);
+const literal = value => { try { return JSON.parse(value); } catch { return null; } };
+const supported = context => context.platform === "darwin-arm64"
+  && parseStableVersion(context.clientVersion) !== null
+  && compareStableVersions(context.clientVersion, MINIMUM) >= 0;
+const hasPermissions = entries => entries.some(entry =>
+  ["permissions", "default_permissions", "profile", "profiles"].includes(entry.keys[0]));
+const configured = (source, context) => {
+  const entries = scanConfig(source);
+  if (entries.some(entry => ["profile", "profiles"].includes(entry.keys[0]))) return false;
+  const value = keys => entries.find(entry => !entry.header && equal(entry.keys, keys))?.value;
+  const profile = literal(value(["default_permissions"]));
+  if (!profile || value(["sandbox_mode"]) || entries.some(entry => entry.keys[0] === "sandbox_workspace_write")) return false;
+  return literal(value(["permissions", profile, "extends"])) === ":workspace"
+    && value(["features", "network_proxy"]) === "true"
+    && value(["permissions", profile, "network", "enabled"]) === "true"
+    && literal(value(["permissions", profile, "filesystem", context.stateRoot])) === "write"
+    && sockets(context).every(socket => literal(value(["permissions", profile, "network", "unix_sockets", socket])) === "allow");
+};
+
+// Match the channel's per-user temporary directory and Codex's actual home.
+// Grants cover only ACC's local channel namespace, never arbitrary Unix sockets.
+const sockets = context => [channelSocketDirectory(),
+  path.join(context.codexHome ?? path.join(context.home, ".codex"), "app-server-control", "app-server-control.sock")];
+
+export function outgoingStatus(source, context) {
+  const state = inspectPermissions(source).state;
+  const ready = state === "owned" && supported(context) && configured(source, context);
+  const reasonCode = state === "customized" ? "permission_configuration_modified"
+    : !supported(context) ? "permission_configuration_uncaptured"
+      : ready ? null : "sender_permissions_unverified";
+  return { state: reasonCode === null ? "configured" : "unverified", reasonCode,
+    setup: supported(context)
+      ? "Codex outgoing setup: default workspace settings gain ACC state write access and an ACC local socket allowlist "
+        + "through the network proxy (external network stays denied); custom policies are preserved. Start a new session after installation."
+      : null,
+    diagnostic: reasonCode === null
+      ? "outgoing live delivery: local socket permissions configured for new sessions; active session overrides remain unverified"
+      : `outgoing live delivery: sender permissions unverified in ${context.file}; `
+        + (reasonCode === "permission_configuration_uncaptured"
+          ? `automatic setup requires Codex ${MINIMUM} or newer on darwin-arm64`
+          : "existing permissions were preserved; run acc install --adapter codex, then start a new session; "
+            + "custom permission policies must allow ACC state and local sockets through the network proxy") };
+}
+
+export function prepareLivePermissions(source, context) {
+  const owned = inspectPermissions(source);
+  const requested = (context.requestedLivePolicy ?? context.livePolicy ?? "off") !== "off";
+  if (owned.state === "customized") return { source, skipLegacy: true, status: outgoingStatus(source, context) };
+  if (!requested) return { source: owned.source, skipLegacy: hasPermissions(scanConfig(owned.source)) };
+  if (!supported(context) || !context.stateRoot) {
+    return { source, skipLegacy: hasPermissions(scanConfig(source)), status: outgoingStatus(source, context) };
+  }
+  if (owned.state === "owned" && configured(source, context)) {
+    return { source, skipLegacy: true, status: outgoingStatus(source, context) };
+  }
+  source = owned.source;
+  const entries = scanConfig(source);
+  const find = keys => entries.filter(entry => equal(entry.keys, keys));
+  const modes = find(["sandbox_mode"]), defaults = find(["default_permissions"]);
+  const legacy = entries.filter(entry => entry.keys[0] === "sandbox_workspace_write");
+  const features = entries.filter(entry => entry.keys[0] === "features");
+  const featureTable = find(["features"]);
+  const proxies = find(["features", "network_proxy"]);
+  const customized = entries.some(entry => ["permissions", "profile", "profiles"].includes(entry.keys[0]))
+    || modes.length > 1 || defaults.length > 1
+    || modes.some(entry => entry.header || literal(entry.value) !== "workspace-write")
+    || defaults.some(entry => entry.header || literal(entry.value) !== ":workspace")
+    || (legacy.length > 0 && (legacy.length !== 2 || !legacy[0].header || legacy[0].array
+      || !equal(legacy[1].keys, ["sandbox_workspace_write", "writable_roots"])
+      || JSON.stringify(literal(legacy[1].value)) !== JSON.stringify([context.stateRoot])))
+    || (features.length > 0 && (featureTable.length !== 1 || !featureTable[0].header || featureTable[0].array))
+    || proxies.length > 1 || proxies.some(entry => entry.header || !["true", "false"].includes(entry.value));
+  if (customized) return { source, skipLegacy: hasPermissions(entries), status: outgoingStatus(source, context) };
+  const edits = [{ id: "selection", start: 0, end: 0, body: `default_permissions = "${PROFILE}"\n` }];
+  for (const [id, values] of [["mode", modes], ["default", defaults]]) {
+    if (values.length) edits.push({ id, start: values[0].start, end: values[0].end, body: "" });
+  }
+  if (legacy.length) {
+    const end = entries.find(entry => entry.header && entry.start > legacy[0].start)?.start ?? source.length;
+    edits.push({ id: "legacy", start: legacy[0].start, end, body: "" });
+  }
+  const proxy = proxies[0], table = featureTable[0];
+  edits.push({ id: "proxy", start: proxy?.start ?? table?.end ?? source.length,
+    end: proxy?.end ?? table?.end ?? source.length, table: table ? ["features"] : null,
+    body: `${table ? "" : "[features]\n"}network_proxy = true\n` });
+  // Preserve a final line without a newline through the same ownership unit.
+  const last = entries.at(-1);
+  if (last && !source.endsWith("\n") && !edits.some(edit => edit.start <= last.start && edit.end >= last.end)) {
+    edits.push({ id: "tail", start: last.start, end: last.end, body: `${last.raw}\n` });
+  }
+  edits.push({ id: "profile", start: source.length, end: source.length, body:
+    `[permissions.${PROFILE}]\nextends = ":workspace"\n`
+    + `[permissions.${PROFILE}.filesystem]\n${tomlString(context.stateRoot)} = "write"\n`
+    + `[permissions.${PROFILE}.network]\nenabled = true\n`
+    + `[permissions.${PROFILE}.network.unix_sockets]\n`
+    + sockets(context).map(socket => `${tomlString(socket)} = "allow"\n`).join("") });
+  const prepared = addPermissions(source, edits);
+  return { source: prepared, skipLegacy: true, status: outgoingStatus(prepared, context) };
+}
+
+export const removeLivePermissions = source => inspectPermissions(source);

--- a/packages/adapter-codex/src/native-delivery.mjs
+++ b/packages/adapter-codex/src/native-delivery.mjs
@@ -133,6 +133,7 @@ export async function offerMessage({ binding, message, runtimeDir, timeoutMs = 5
       return { accepted: true, transport: "codex-app-server", clientVersion: endpoint.clientVersion };
     });
   } catch (error) {
+    if (["EPERM", "EACCES"].includes(error?.code)) return rejected("transport_permission_denied");
     const reason = safeReason(error);
     return rejected(reason === "request_timeout" ? "transport_error"
       : reason === "vendor_error" ? "transport_rejected" : "recipient_unavailable");

--- a/packages/adapter-codex/src/permission-ownership.mjs
+++ b/packages/adapter-codex/src/permission-ownership.mjs
@@ -1,0 +1,109 @@
+import { createHash } from "node:crypto";
+import { scanConfig, unsafe } from "./toml-scan.mjs";
+
+const BEGIN = "# ACC native permissions begin ";
+const END = "# ACC native permissions end ";
+const META = "# ACC native permissions restore ";
+const hash = (body, record) => createHash("sha256")
+  .update(JSON.stringify({ body, id: record.id, before: record.before, table: record.table })).digest("hex");
+const marker = (source, prefix) => source.startsWith(prefix) ? source.slice(prefix.length) : null;
+
+// Permission selection, proxy and network grants form one ownership unit. If
+// any component changes, none can be removed independently: enabled networking
+// without its proxy has a different security meaning to Codex.
+export function inspectPermissions(source) {
+  const blocks = [];
+  let open = null, metadata = null;
+  for (const entry of scanConfig(source)) {
+    const comment = entry.code ? "" : entry.raw.trim();
+    const start = marker(comment, BEGIN), end = marker(comment, END);
+    if (start !== null) {
+      if (open || !/^[a-z]+$/.test(start) || blocks.some(block => block.id === start)) {
+        unsafe("duplicate or nested native permission marker");
+      }
+      open = { id: start, start: entry.start, table: entry.table, contentStart: entry.end };
+    } else if (comment.startsWith(META)) {
+      if (!open || open.id !== "selection" || metadata !== null || entry.start !== open.contentStart) {
+        unsafe("misplaced permission metadata");
+      }
+      try { metadata = JSON.parse(comment.slice(META.length)); }
+      catch { unsafe("invalid permission metadata"); }
+      open.contentStart = entry.end;
+    } else if (end !== null) {
+      if (!open || open.id !== end) unsafe("unmatched native permission marker");
+      blocks.push({ ...open, end: entry.end, body: source.slice(open.contentStart, entry.start) });
+      open = null;
+    }
+  }
+  if (open) return { source, state: "customized" };
+  if (!blocks.length && !metadata) return { source, state: "absent" };
+  if (!Array.isArray(metadata) || metadata.length !== blocks.length
+    || metadata.some(item => !item || typeof item !== "object" || Array.isArray(item))
+    || new Set(metadata.map(item => item.id)).size !== metadata.length) return { source, state: "customized" };
+  for (const block of blocks) {
+    const record = metadata.find(item => item.id === block.id);
+    if (!record || Object.keys(record).sort().join() !== "before,hash,id,table"
+      || typeof record.before !== "string" || record.hash !== hash(block.body, record)
+      || (block.id === "selection" && block.table.length !== 0)
+      || JSON.stringify(block.table) !== JSON.stringify(record.table)) {
+      return { source, state: "customized" };
+    }
+  }
+  // A retained reference or declaration must not be left pointing at a deleted
+  // profile. Ignore peer-looking text inside strings/comments as markers.
+  const entries = scanConfig(source);
+  const inside = entry => blocks.some(block => entry.start >= block.start && entry.end <= block.end);
+  const generatedTables = entries.filter(entry => entry.header && inside(entry)).map(entry => JSON.stringify(entry.keys));
+  const outside = entries.filter(entry => !inside(entry));
+  // New profile declarations and selectors are custom policy, regardless of
+  // how TOML spells their values (including escaped or multiline references).
+  if (outside.some(entry => entry.code && (entry.keys.includes("default_permissions")
+    || entry.keys[0] === "permissions"
+    || (!entry.header && generatedTables.includes(JSON.stringify(entry.table)))))) {
+    return { source, state: "customized" };
+  }
+  let restored = source;
+  for (const block of blocks.toSorted((a, b) => b.start - a.start)) {
+    restored = restored.slice(0, block.start) + metadata.find(item => item.id === block.id).before
+      + restored.slice(block.end);
+  }
+  // Inserting restored headers can reparent foreign assignments added after
+  // a removal marker. Verify the candidate's scopes before restoring any byte.
+  let restoredEntries;
+  try { restoredEntries = new Map(scanConfig(restored).map(entry => [entry.start, entry])); }
+  catch { return { source, state: "customized" }; }
+  for (const entry of outside.filter(item => item.code)) {
+    const delta = blocks.filter(block => block.end <= entry.start).reduce((total, block) =>
+      total + metadata.find(item => item.id === block.id).before.length - (block.end - block.start), 0);
+    const candidate = restoredEntries.get(entry.start + delta);
+    if (!candidate || JSON.stringify(candidate.keys) !== JSON.stringify(entry.keys)) {
+      return { source, state: "customized" };
+    }
+  }
+  return { source: restored, state: "owned" };
+}
+
+export function addPermissions(source, edits) {
+  const metadata = edits.map(({ id, start, end, body, table = [] }) => {
+    const record = { id, before: source.slice(start, end), table };
+    return { ...record, hash: hash(body, record) };
+  });
+  const initialMetadata = JSON.stringify(metadata);
+  // Insertions at the same offset retain caller order (selection always first).
+  for (const edit of edits.map((item, index) => ({ ...item, index }))
+    .sort((a, b) => b.start - a.start || b.index - a.index)) {
+    const block = `${BEGIN}${edit.id}\n`
+      + (edit.id === "selection" ? `${META}${JSON.stringify(metadata)}\n` : "")
+      + edit.body + `${END}${edit.id}\n`;
+    source = source.slice(0, edit.start) + block + source.slice(edit.end);
+  }
+  // Record the installed scope, which can differ after removing a legacy table.
+  for (const entry of scanConfig(source)) {
+    const id = !entry.code ? marker(entry.raw.trim(), BEGIN) : null;
+    const record = metadata.find(item => item.id === id);
+    if (!record) continue;
+    record.table = entry.table;
+    record.hash = hash(edits.find(item => item.id === id).body, record);
+  }
+  return source.replace(`${META}${initialMetadata}`, `${META}${JSON.stringify(metadata)}`);
+}

--- a/packages/adapter-codex/src/toml-scan.mjs
+++ b/packages/adapter-codex/src/toml-scan.mjs
@@ -1,0 +1,99 @@
+import { AccError, EXIT } from "@agents-can-communicate/protocol";
+
+export const unsafe = (reason = "unrecognized TOML declaration") => {
+  throw new AccError(EXIT.CONFLICT, `cannot safely edit Codex config: ${reason}; `
+    + "repair ambiguous TOML or ACC markers before retrying", { reason });
+};
+// A bounded lexical scan, not a TOML value parser. Newlines inside strings,
+// arrays and inline tables cannot introduce a header or a managed marker.
+export function* statements(source) {
+  let start = 0, code = "", quote = null;
+  const stack = [];
+  for (let i = 0; i < source.length;) {
+    const char = source[i];
+    if (quote) {
+      if (quote[0] === '"' && char === "\\") {
+        code += source.slice(i, i + 2); i += 2; continue;
+      }
+      if (source.startsWith(quote, i)) {
+        let count = quote.length;
+        if (quote.length === 3) {
+          while (source[i + count] === quote[0]) count++;
+          if (count > 5) unsafe("unsupported string quote delimiter");
+        }
+        code += source.slice(i, i + count); i += count; quote = null; continue;
+      }
+      if (quote.length === 1 && /[\r\n]/.test(char)) unsafe("newline in single-line string");
+      code += char; i++; continue;
+    }
+    if (char === "#") {
+      while (i < source.length && source[i] !== "\n") i++;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = source.startsWith(char.repeat(3), i) ? char.repeat(3) : char;
+      code += quote; i += quote.length; continue;
+    }
+    if (char === "[" || char === "{") stack.push(char);
+    if (char === "]" || char === "}") {
+      if (stack.pop() !== (char === "]" ? "[" : "{")) unsafe("mismatched collection delimiter");
+    }
+    code += char; i++;
+    if (char === "\n" && stack.length === 0) {
+      yield { raw: source.slice(start, i), code: code.trim(), start, end: i };
+      start = i; code = "";
+    }
+  }
+  if (quote || stack.length) unsafe(quote ? "unclosed string" : "unclosed collection");
+  if (start < source.length) yield { raw: source.slice(start), code: code.trim(), start, end: source.length };
+}
+
+function decodeKey(key) {
+  if (key[0] === "'") return key.slice(1, -1);
+  if (key[0] !== '"') return key;
+  return key.slice(1, -1).replace(/\\(U[\da-fA-F]{8}|u[\da-fA-F]{4}|[btnfr"\\])|\\./g,
+    (match, escape) => {
+      if (!escape) unsafe("unsupported quoted-key escape");
+      if (/^[uU]/.test(escape)) {
+        const point = Number.parseInt(escape.slice(1), 16);
+        if (point > 0x10ffff || (point >= 0xd800 && point <= 0xdfff)) {
+          unsafe("invalid quoted-key Unicode escape");
+        }
+        return String.fromCodePoint(point);
+      }
+      return ({ b: "\b", t: "\t", n: "\n", f: "\f", r: "\r", '"': '"', "\\": "\\" })[escape];
+    });
+}
+
+function keyPath(code) {
+  const keys = [];
+  let rest = code.trimStart();
+  for (;;) {
+    const match = /^(?:[A-Za-z0-9_-]+|'[^'\r\n]*'|"(?:[^"\\\r\n]|\\[^\r\n])*")/.exec(rest);
+    if (!match) unsafe("unrecognized TOML key");
+    keys.push(decodeKey(match[0]));
+    rest = rest.slice(match[0].length).trimStart();
+    if (!rest.startsWith(".")) return { keys, rest };
+    rest = rest.slice(1).trimStart();
+  }
+}
+
+export function declaration(code) {
+  const header = code.startsWith("[");
+  const array = header && code.startsWith("[[");
+  const { keys, rest } = keyPath(header ? code.slice(array ? 2 : 1) : code);
+  if (header ? rest !== (array ? "]]" : "]") : !rest.startsWith("=")) unsafe();
+  return { keys, header, array, value: header ? null : rest.slice(1).trim() };
+}
+
+// Resolved declaration paths are only structural facts, never parsed user values.
+export function scanConfig(source) {
+  let table = [];
+  return [...statements(source)].map(item => {
+    if (!item.code) return { ...item, table: [...table], keys: [] };
+    const entry = declaration(item.code);
+    if (entry.header) table = entry.keys;
+    return { ...item, ...entry, table: [...table],
+      keys: entry.header ? entry.keys : [...table, ...entry.keys] };
+  });
+}

--- a/packages/adapter-codex/test/live-permissions-install.test.mjs
+++ b/packages/adapter-codex/test/live-permissions-install.test.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { createCodexAdapter } from "../src/adapter.mjs";
+import { applyPlan, detectInstallation, planInstallation } from "@agents-can-communicate/installer";
+
+async function fixture(t, before = "") {
+  const home = await mkdtemp(path.join(tmpdir(), "acc-codex-permissions-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const codexHome = path.join(home, ".codex");
+  await mkdir(codexHome);
+  const file = path.join(codexHome, "config.toml");
+  await writeFile(file, before);
+  const context = { home, codexHome, dataHome: path.join(home, "data"),
+    stateRoot: path.join(home, "data", "acc"), node: process.execPath,
+    runner: fileURLToPath(new URL("../../../bin/acc-hook.mjs", import.meta.url)),
+    cli: fileURLToPath(new URL("../../../bin/acc.mjs", import.meta.url)),
+    clientVersion: "0.153.4", platform: "darwin-arm64", requestedLivePolicy: "actionable",
+    livePolicy: "off", env: {} };
+  return { context, file, read: () => readFile(file, "utf8"), adapter: createCodexAdapter() };
+}
+
+test("consent configures outbound permissions even before the daemon is available", async t => {
+  const f = await fixture(t, 'model = "user-model"\n[features]\nother_feature = true\n');
+  await f.adapter.install(f.context);
+  const source = await f.read();
+  assert.match(source, /^default_permissions = "acc-workspace"$/m);
+  assert.match(source, /^network_proxy = true$/m);
+  assert.equal((source.match(/^\[features\]$/gm) ?? []).length, 1);
+  assert.match(source, /^\[permissions\.acc-workspace\]$/m);
+  assert.match(source, /^extends = ":workspace"$/m);
+  assert.ok(source.includes(`${JSON.stringify(f.context.stateRoot)} = "write"`));
+  assert.ok(source.includes(`${JSON.stringify(path.join(f.context.codexHome,
+    "app-server-control", "app-server-control.sock"))} = "allow"`));
+  assert.doesNotMatch(source, /^\[sandbox_workspace_write\]$/m);
+  assert.match(source, /model = "user-model"/);
+  assert.match(source, /other_feature = true/);
+});
+
+test("reinstall is stable and uninstall restores pre-existing default configuration", async t => {
+  const before = '# user preference\nmodel = "user-model"\n[features]\nnetwork_proxy = false\nother_feature = true\n';
+  const f = await fixture(t, before);
+  await f.adapter.install(f.context);
+  const first = await f.read();
+  assert.match(first, /default_permissions = "acc-workspace"/);
+  await f.adapter.install(f.context);
+  assert.equal(await f.read(), first);
+  await f.adapter.uninstall(f.context);
+  assert.equal(await f.read(), before);
+});
+
+test("explicit off restores the previous policy without leaving proxy or profile grants", async t => {
+  const f = await fixture(t);
+  await f.adapter.install(f.context);
+  assert.match(await f.read(), /default_permissions = "acc-workspace"/);
+  await f.adapter.install({ ...f.context, requestedLivePolicy: "off", livePolicy: "off" });
+  assert.doesNotMatch(await f.read(), /default_permissions|network_proxy|permissions\.acc-workspace/);
+  assert.match(await f.read(), /\[sandbox_workspace_write\]/);
+});
+
+test("an ACC-only legacy sandbox is migrated and restored without losing its bytes", async t => {
+  const f = await fixture(t);
+  const before = 'sandbox_mode = "workspace-write"\n[features]\nother_feature = true\n'
+    + `[sandbox_workspace_write]\nwritable_roots = [${JSON.stringify(f.context.stateRoot)}]\n`;
+  await writeFile(f.file, before);
+  await f.adapter.install(f.context);
+  assert.doesNotMatch(await f.read(), /^sandbox_mode\s*=|^\[sandbox_workspace_write\]/m);
+  assert.match(await f.read(), /default_permissions = "acc-workspace"/);
+  await f.adapter.uninstall(f.context);
+  assert.equal(await f.read(), before);
+});
+
+test("custom permission profiles are preserved and do not acquire an incompatible legacy sandbox", async t => {
+  const before = 'default_permissions = "team"\n[permissions.team]\nextends = ":workspace"\n'
+    + '[permissions.team.filesystem]\n"/secrets" = "deny"\n';
+  const f = await fixture(t, before);
+  const installed = await f.adapter.install(f.context);
+  assert.ok((await f.read()).startsWith(before));
+  assert.doesNotMatch(await f.read(), /sandbox_workspace_write|permissions\.acc-workspace/);
+  assert.ok(installed.needsAction.some(line => /outgoing|outbound/i.test(line)
+    && line.includes(f.file)), "the operator must see that outgoing access is still unverified");
+  await f.adapter.uninstall(f.context);
+  assert.equal(await f.read(), before);
+});
+
+test("customized generated permissions retain their proxy and selection on uninstall", async t => {
+  const f = await fixture(t);
+  await f.adapter.install(f.context);
+  const original = await f.read();
+  assert.match(original, /extends = ":workspace"/);
+  await writeFile(f.file, original.replace('extends = ":workspace"',
+    'extends = ":workspace"\ndescription = "user customization"'));
+  const result = await f.adapter.uninstall(f.context);
+  const retained = await f.read();
+  assert.match(retained, /default_permissions = "acc-workspace"/);
+  assert.match(retained, /network_proxy = true/);
+  assert.match(retained, /user customization/);
+  assert.ok(result.diagnostics.some(line => /kept|preserved/.test(line) && /permission/.test(line)));
+});
+
+test("unknown or uncaptured clients do not receive unverified security settings", async t => {
+  for (const change of [{ clientVersion: null }, { clientVersion: "0.152.1" }, { platform: "linux-x64" }]) {
+    const f = await fixture(t);
+    const result = await f.adapter.install({ ...f.context, ...change });
+    assert.doesNotMatch(await f.read(), /default_permissions|network_proxy/);
+    assert.ok(result.needsAction.some(line => /outgoing|outbound/.test(line)));
+  }
+});
+
+test("detected version and platform reach applied permissions and subsequent diagnosis", async t => {
+  const f = await fixture(t);
+  const { clientVersion: _version, platform: _platform, ...context } = f.context;
+  const detect = () => detectInstallation({ adapters: [f.adapter], context,
+    platform: "darwin-arm64", pathEnv: "", probe: async () => "codex-cli 0.153.4" });
+  const detected = await detect();
+  const plan = planInstallation({ adapters: [f.adapter], context, detected,
+    deliveryByAdapter: { codex: "actionable" } });
+  const result = await applyPlan({ adapters: [f.adapter], context, plan, dataHome: context.dataHome });
+  assert.deepEqual(result.failed, []);
+  assert.match(await f.read(), /default_permissions = "acc-workspace"/);
+  const after = await detect();
+  assert.equal(after[0].outgoingDelivery.state, "configured");
+});

--- a/packages/adapter-codex/test/live-permissions-ownership.test.mjs
+++ b/packages/adapter-codex/test/live-permissions-ownership.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { prepareLivePermissions, removeLivePermissions } from "../src/live-permissions.mjs";
+
+const context = { home: "/users/test", codexHome: "/users/test/.codex", stateRoot: "/users/test/data/acc",
+  file: "/users/test/.codex/config.toml", requestedLivePolicy: "actionable", livePolicy: "off",
+  clientVersion: "0.153.4", platform: "darwin-arm64" };
+
+test("generated permissions preserve TOML scopes and restore raw bytes", () => {
+  for (const before of [
+    'model = "mine"',
+    'model = "mine"\n[features]\nother = true',
+    'default_permissions = ":workspace"\n[features]\nnetwork_proxy = false\n',
+    'model = "mine"\r\n[features]\r\nother = true\r\n',
+    'model_instructions = """\n# ACC native permissions begin selection\n[features]\nnetwork_proxy = false\n"""\n',
+    '[features]\nother = true\n[sandbox_workspace_write]\n# my comment\nwritable_roots = ["/users/test/data/acc"]',
+  ]) {
+    const prepared = prepareLivePermissions(before, context);
+    assert.equal(prepared.status.state, "configured", before);
+    assert.equal(prepareLivePermissions(prepared.source, context).source, prepared.source);
+    assert.equal(removeLivePermissions(prepared.source).source, before);
+  }
+});
+
+test("edited, removed or newly referenced pieces preserve the whole dependent permission unit", () => {
+  const source = prepareLivePermissions('model = "mine"\n[features]\nother = true\n', context).source;
+  const variants = [
+    source.replace("network_proxy = true", "network_proxy = false"),
+    source.replace('extends = ":workspace"', 'extends = ":read-only"'),
+    source.replace(/# ACC native permissions begin proxy\n[\s\S]*?# ACC native permissions end proxy\n/, ""),
+    source + '[permissions.other]\nextends = "acc-workspace"\n',
+  ];
+  for (const edited of variants) {
+    assert.equal(removeLivePermissions(edited).state, "customized");
+    assert.equal(removeLivePermissions(edited).source, edited);
+    assert.equal(prepareLivePermissions(edited, { ...context, requestedLivePolicy: "off" }).source, edited);
+  }
+});
+
+test("custom legacy and inline policies remain user owned", () => {
+  for (const before of [
+    '[sandbox_workspace_write]\nwritable_roots = ["/users/test/data/acc", "/other"]\n',
+    'features = { network_proxy = false }\n',
+    'sandbox_mode = "read-only"\n',
+    'permissions = { team = { extends = ":read-only" } }\n',
+    'profile = "direct"\n[profiles.direct.features]\nnetwork_proxy = false\n',
+    'profile = "restricted"\n[profiles.restricted]\nsandbox_mode = "read-only"\n',
+  ]) {
+    const prepared = prepareLivePermissions(before, context);
+    assert.equal(prepared.status.state, "unverified");
+    assert.equal(prepared.source, before);
+  }
+});
+
+test("edited restoration metadata cannot insert settings on removal", () => {
+  const source = prepareLivePermissions('model = "mine"\n', context).source;
+  const edited = source.replace(/(# ACC native permissions restore )(.+)/, (_line, prefix, json) => {
+    const records = JSON.parse(json);
+    records.find(record => record.id === "proxy").before = 'network_proxy = false\n';
+    return prefix + JSON.stringify(records);
+  });
+  assert.equal(removeLivePermissions(edited).state, "customized");
+  assert.equal(removeLivePermissions(edited).source, edited);
+});
+
+test("foreign assignments under generated headers and escaped references retain their dependencies", () => {
+  const source = prepareLivePermissions('model = "mine"\n', context).source;
+  for (const edited of [
+    source.replace("# ACC native permissions end proxy\n", "# ACC native permissions end proxy\nother_feature = true\n"),
+    source + '[permissions.other]\nextends = "\\u0061cc-workspace"\n',
+    source + '[profiles.other]\ndefault_permissions = "\\u0061cc-workspace"\n',
+  ]) {
+    assert.equal(removeLivePermissions(edited).state, "customized");
+    assert.equal(removeLivePermissions(edited).source, edited);
+  }
+});
+
+test("restoring legacy tables cannot reparent a new foreign assignment", () => {
+  const before = '[features]\nother = true\n[sandbox_workspace_write]\n'
+    + 'writable_roots = ["/users/test/data/acc"]\n[projects.foo]\ntrust_level = "trusted"\n';
+  const source = prepareLivePermissions(before, context).source;
+  const edited = source.replace("# ACC native permissions end legacy\n",
+    "# ACC native permissions end legacy\nanother_feature = true\n");
+  assert.equal(removeLivePermissions(edited).state, "customized");
+  assert.equal(removeLivePermissions(edited).source, edited);
+});

--- a/packages/adapter-codex/test/native-delivery.test.mjs
+++ b/packages/adapter-codex/test/native-delivery.test.mjs
@@ -11,6 +11,17 @@ const message = { messageId: "message_1", kind: "question", subject: "Synthetic"
 const bindingOf = handshake => ({ opaqueEndpointRef: handshake.opaqueEndpointRef,
   clientVersion: handshake.clientVersion });
 
+test("sender socket permission failures are distinct from a missing Codex receiver", async t => {
+  const h = await nativeFixture(t);
+  const handshake = await native.bindNativeSession(h);
+  for (const code of ["EPERM", "EACCES"]) {
+    const result = await native.offerMessage({ ...h, binding: bindingOf(handshake), message,
+      open: () => { throw Object.assign(new Error("private transport detail"), { code }); } });
+    assert.equal(result.safeErrorCode, "transport_permission_denied");
+    assert.equal(JSON.stringify(result).includes("private transport detail"), false);
+  }
+});
+
 test("a live queue probe succeeds without rewriting the vendor invocation", async t => {
   const h = await nativeFixture(t);
   const probe = await native.probeNativeDelivery(h);

--- a/packages/adapter-codex/test/untrusted-is-inert.test.mjs
+++ b/packages/adapter-codex/test/untrusted-is-inert.test.mjs
@@ -63,10 +63,10 @@ test("the thing a person must do is said where a person reads it", async t => {
 
   const actions = await actionsOf(context);
 
-  assert.equal(actions.length, 1, `no action was asked for: ${JSON.stringify(actions)}`);
-  assert.match(actions[0], /codex/);
-  assert.match(actions[0], /trust/i);
-  assert.match(actions[0], /\/hooks/);
+  const hookAction = actions.find(line => /\/hooks/.test(line));
+  assert.ok(hookAction, `no hook review was asked for: ${JSON.stringify(actions)}`);
+  assert.match(hookAction, /codex/);
+  assert.match(hookAction, /trust/i);
 });
 
 test("a plugin registration cannot establish that the client enabled it", async t => {

--- a/packages/adapter-gemini-cli/extension/gemini-extension.json
+++ b/packages/adapter-gemini-cli/extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Coordinate this Gemini CLI session with other AI agent sessions working in the same workspace.",
   "contextFileName": "skills/acc/SKILL.md"
 }

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-grok/package.json
+++ b/packages/adapter-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-grok",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-sdk/src/channel-directory.mjs
+++ b/packages/adapter-sdk/src/channel-directory.mjs
@@ -1,0 +1,8 @@
+import os from "node:os";
+import path from "node:path";
+
+// macOS Unix paths are capped at 104 bytes. A stable, short per-user namespace
+// also lets a sandbox grant access regardless of each client's TMPDIR value.
+export const channelSocketDirectory = () => path.join(
+  process.platform === "darwin" ? "/tmp" : os.tmpdir(),
+  `acc-ch-${typeof process.getuid === "function" ? process.getuid() : "u"}`);

--- a/packages/adapter-sdk/src/index.mjs
+++ b/packages/adapter-sdk/src/index.mjs
@@ -25,3 +25,4 @@ export { clearSessionBinding, listSessionBindings, loadSessionBinding,
   from "./session-binding.mjs";
 
 export { clearNativeAttempt, loadNativeAttempt, storeNativeAttempt } from "./native-attempt.mjs";
+export { channelSocketDirectory } from "./channel-directory.mjs";

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/src/doctor-command.mjs
+++ b/packages/cli/src/doctor-command.mjs
@@ -273,6 +273,8 @@ export async function runDoctor({ options, context, runtime }) {
       + `${describeNative(adapter.nativeDelivery, { clientVersion: adapter.version })}; `
       + `fallback: ${describeDeliveryFallback(adapter)}`),
   ...nativeSessionLines(adapters),
+  ...adapters.filter(adapter => adapter.present && adapter.outgoingDelivery)
+    .map(adapter => `  ${adapter.displayName} ${adapter.outgoingDelivery.diagnostic}`),
   ...(manager === null ? [] : [`  automatic updates ${manager.auto ? "on" : "off"}; ACC ${manager.active.version}`
     + (manager.pin ? `; pinned to ${manager.pin}` : ""), ...(manager.notice ? [`  ${manager.notice}`] : [])]),
   ...data.remediation.map(line => `  ${line}`),

--- a/packages/cli/src/install-command.mjs
+++ b/packages/cli/src/install-command.mjs
@@ -153,6 +153,8 @@ export function describeOutcome({ action, acted, failed = [], skipped = [],
   ...operations.filter(operation => operation.applied)
     .flatMap(operation => (operation.needsAction ?? [])
       .map(step => `  ${operation.adapterId}: ${step}`)),
+  ...operations.filter(operation => operation.applied)
+    .flatMap(operation => (operation.setupNotes ?? []).map(note => `  ${note}`)),
   ...skipped.map(entry => `  skip ${entry.adapterId}: ${entry.reason}`),
   ...failed.map(entry => `  ${entry.adapterId}: ${entry.error}`),
   // Said once, where it is needed: the reader has just been shown a list of
@@ -212,6 +214,7 @@ function questionFor(entry) {
   return [
     `Let ${entry.displayName} answer peer requests while idle? (experimental)`,
     "  Yes: automatic turns can spend tokens without waiting for you.",
+    ...(entry.outgoingDelivery?.setup ? [`       ${entry.outgoingDelivery.setup}`] : []),
     ...(warns ? ["       Allow development channels when prompted; check the client's startup notice."] : []),
     ...(entry.nativeDelivery.state !== "eligible"
       ? ["       Save consent now; delivery waits for an available client service."] : []),

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -137,7 +137,9 @@ function recordedText(message, delivery) {
   const diagnostics = delivery.map(item => item.outcome === "offered"
     ? `live offered to ${item.recipientParticipantId} via ${item.transport}`
     : item.outcome === "queued"
-      ? `live offer unavailable (${item.errorCode ?? "durable_fallback"})`
+      ? item.errorCode === "transport_permission_denied"
+        ? "live offer blocked by sender permissions; message remains queued; run acc doctor in the sending session"
+        : `live offer unavailable (${item.errorCode ?? "durable_fallback"})`
       : `delivery already ${item.outcome}`);
   return [`recorded ${message.messageId}`, ...diagnostics].join("; ");
 }

--- a/packages/cli/src/native-delivery-status.mjs
+++ b/packages/cli/src/native-delivery-status.mjs
@@ -32,7 +32,7 @@ export function nativeRemediation(entry) {
       + "then run acc doctor here");
   }
   if (native.reasonCode === "native_endpoint_unavailable") {
-    steps.push(`${entry.displayName}: check the client's local delivery service setup; `
+    steps.push(entry.nativeSetup ?? `${entry.displayName}: check the client's local delivery service setup; `
       + "ACC does not start or restart that service");
   } else if (native.reasonCode === "native_session_unavailable") {
     steps.push(`${entry.displayName}: open a session connected to the client's local delivery service`);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/src/receipts.mjs
+++ b/packages/core/src/receipts.mjs
@@ -10,6 +10,7 @@ export const SAFE_OFFER_ERROR_CODES = Object.freeze([
   "recipient_unavailable",
   "transport_error",
   "transport_rejected",
+  "transport_permission_denied",
   "unsupported_client_version",
 ]);
 

--- a/packages/delivery-router/package.json
+++ b/packages/delivery-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/delivery-router",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/delivery-router/src/router.mjs
+++ b/packages/delivery-router/src/router.mjs
@@ -1,7 +1,7 @@
 import { refreshExpiredBinding } from "./refresh-binding.mjs";
 
 const SAFE_ERRORS = new Set(["ambiguous_recipient_sessions", "delivery_disabled",
-  "recipient_busy", "recipient_unavailable", "transport_error", "transport_rejected",
+  "recipient_busy", "recipient_unavailable", "transport_error", "transport_rejected", "transport_permission_denied",
   "unsupported_client_version"]);
 const NAMED_LIVE_TRANSPORTS = new Set(["claude-channel", "codex-app-server"]);
 

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/src/apply.mjs
+++ b/packages/installer/src/apply.mjs
@@ -35,6 +35,7 @@ export async function applyPlan({ plan, adapters, context, dataHome, dryRun = fa
         const createdDirectories = await missingArtifactParents({ home: context.home,
           artifacts: operation.artifacts });
         const installContext = { ...context,
+          clientVersion: operation.clientVersion, platform: operation.platform,
           requestedLivePolicy: operation.livePolicy ?? "off",
           livePolicy: operation.effectiveLivePolicy ?? "off" };
         const outcome = await adapter.install(installContext);
@@ -103,6 +104,7 @@ export async function applyPlan({ plan, adapters, context, dataHome, dryRun = fa
           retainedNativeActivation: retainedMechanisms.length === 0 ? null
             : { ...operation.deactivation, mechanisms: retainedMechanisms } });
         results.operations.push({ ...operation, applied: true,
+          needsAction: outcome.needsAction ?? [],
           changes: outcome.changes ?? [], removed: owned.removed, kept: owned.kept,
           removedDirectories: directories.removed, keptDirectories: directories.kept,
           missingDirectories: directories.missing,

--- a/packages/installer/src/detect.mjs
+++ b/packages/installer/src/detect.mjs
@@ -118,7 +118,7 @@ export async function detectInstallation({ adapters, context, probe = spawnProbe
     // deterministic rather than dependent on registry order.
     .sort((left, right) => left.id.localeCompare(right.id))
     .map(async adapter => {
-      const entry = { adapterId: adapter.id, displayName: adapter.displayName,
+      const entry = { adapterId: adapter.id, displayName: adapter.displayName, platform,
         present: false, version: null, versionOutput: null, installed: false,
         diagnostics: [], needsAction: [], capabilities: effectiveCapabilities(adapter),
         deliveryDiagnostic: null, error: null };
@@ -146,7 +146,10 @@ export async function detectInstallation({ adapters, context, probe = spawnProbe
           ? "native_delivery_unsupported" : "version_unavailable");
 
       try {
-        const detected = await adapter.detect(context);
+        const detected = await adapter.detect({ ...context, clientVersion: entry.version,
+          platform, nativeDelivery: entry.nativeDelivery });
+        if (detected.outgoingDelivery) entry.outgoingDelivery = detected.outgoingDelivery;
+        if (detected.nativeSetup) entry.nativeSetup = detected.nativeSetup;
         entry.diagnostics = [...(detected.diagnostics ?? [])];
         // What a person has to do, as opposed to what is true. Adapters that
         // have nothing to ask for say nothing.

--- a/packages/installer/src/plan.mjs
+++ b/packages/installer/src/plan.mjs
@@ -117,7 +117,9 @@ export function planInstallation({ adapters, detected, context, action = "instal
     const deliverySummary = action === "install"
       ? describeInstallDelivery(entry, delivery, effectiveLivePolicy) : null;
     const installContext = { ...context, requestedLivePolicy: delivery,
-      livePolicy: effectiveLivePolicy };
+      livePolicy: effectiveLivePolicy, clientVersion: entry.version, platform: entry.platform };
+    const setupNotes = action === "install" && delivery !== "off"
+      ? [entry.outgoingDelivery?.setup, entry.nativeSetup].filter(note => typeof note === "string") : [];
     // A consented activation that this run keeps, activates, or takes back.
     // Only an explicit off or an uninstall removes one; an absent record never
     // creates one.
@@ -139,6 +141,7 @@ export function planInstallation({ adapters, detected, context, action = "instal
       displayName: adapter.displayName,
       action,
       clientVersion: entry.version ?? record?.version ?? null,
+      platform: entry.platform ?? context?.platform,
       // "Remove these files for a client that is not here" is a different thing
       // to approve than an ordinary uninstall, so it is said rather than left
       // to be inferred from a client version that is null.
@@ -148,6 +151,7 @@ export function planInstallation({ adapters, detected, context, action = "instal
       effectiveLivePolicy,
       ...(deliveryDiagnostic === null ? {} : { deliveryDiagnostic }),
       ...(deliverySummary === null ? {} : { deliverySummary }),
+      ...(setupNotes.length ? { setupNotes } : {}),
       ...(nativeActivation === null ? {} : { nativeActivation }),
       ...(deactivation === null ? {} : { deactivation }),
       artifacts,
@@ -157,6 +161,7 @@ export function planInstallation({ adapters, detected, context, action = "instal
         ...(entry.present ? [] : [`${adapter.displayName ?? adapter.id} is no longer on `
           + "this machine; removing what ACC recorded writing"]),
         ...(deliverySummary === null ? [] : [deliverySummary]),
+        ...setupNotes,
         ...artifacts.filter(a => a.kind === "tree")
           .map(a => `${action === "install" ? "create" : "remove"} ${a.path}`),
         ...artifacts.filter(a => a.kind === "merge")

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/tests/acceptance/codex-live-permissions-packed.test.mjs
+++ b/tests/acceptance/codex-live-permissions-packed.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+import { createPackedAcc } from "../helpers/packed-acc.mjs";
+
+const run = promisify(execFile);
+
+test("installed live setup discloses permissions, diagnoses them, and reverses only its unchanged bundle", {
+  skip: process.platform !== "darwin" || process.arch !== "arm64",
+}, async t => {
+  const packed = await createPackedAcc(t);
+  await packed.setClientVersions({ codex: "0.153.4" });
+  const config = path.join(packed.clientHome, ".codex", "config.toml");
+  const before = 'model = "user-model"\n[features]\nnetwork_proxy = false\nother = true\n';
+  await mkdir(path.dirname(config), { recursive: true });
+  await writeFile(config, before);
+  const human = args => run(process.execPath, [packed.accBin, ...args, "--home", packed.clientHome],
+    { cwd: packed.project, env: packed.env });
+  const args = ["install", "--adapter", "codex", "--delivery", "actionable"];
+  assert.match((await human([...args, "--dry-run"])).stdout, /network proxy/);
+  assert.equal(await readFile(config, "utf8"), before);
+  assert.match((await human(args)).stdout, /network proxy/);
+  const generated = await readFile(config, "utf8");
+  assert.match(generated, /default_permissions = "acc-workspace"/);
+  const doctor = await packed.acc(["doctor", "--home", packed.clientHome]);
+  assert.equal(doctor.adapters.find(entry => entry.adapterId === "codex").outgoingDelivery.state, "configured");
+  assert.match((await human(["doctor"])).stdout, /outgoing live delivery: local socket permissions configured/);
+  assert.match((await human(["doctor"])).stdout, /codex app-server daemon start/);
+  assert.ok(doctor.remediation.some(line => line.includes("codex app-server daemon start")));
+  await writeFile(config, generated.replace("network_proxy = true", "network_proxy = false"));
+  assert.match((await human(["doctor"])).stdout, /outgoing live delivery: sender permissions unverified/);
+  assert.match((await human(["uninstall", "--adapter", "codex"])).stdout, /customized native permissions were preserved/);
+  assert.match(await readFile(config, "utf8"), /default_permissions = "acc-workspace"/);
+  // Restore the unchanged generated file to verify recorded reinstall/removal.
+  await writeFile(config, generated);
+  await human(args);
+  await human(["uninstall", "--adapter", "codex"]);
+  assert.equal(await readFile(config, "utf8"), before);
+});

--- a/tests/native-transport-permissions.test.mjs
+++ b/tests/native-transport-permissions.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { createCoordinationService } from "@agents-can-communicate/core";
+import { createDeliveryRouter } from "@agents-can-communicate/delivery-router";
+import { createAccChannel, endpointDir } from "../packages/adapter-claude-code/src/channel.mjs";
+import { offerMessage } from "../packages/adapter-claude-code/src/native-delivery.mjs";
+import { createFakeClock, createFakeIds, createMemoryStore } from "./helpers/memory-store.mjs";
+
+for (const code of ["EPERM", "EACCES"]) {
+  test(`${code} while connecting preserves a permission diagnosis through router and receipts`, async t => {
+    const root = await mkdtemp(path.join(tmpdir(), "acc-permission-"));
+    t.after(() => rm(root, { recursive: true, force: true }));
+    const channel = createAccChannel({ endpointDir: endpointDir(root), clientPid: process.pid,
+      write: () => {}, routeReply: async () => {}, routeAck: async () => {} });
+    await channel.listen();
+    t.after(() => channel.close());
+    const clock = createFakeClock(new Date().toISOString());
+    const ids = createFakeIds();
+    const workspaceId = "workspace_permission";
+    const store = createMemoryStore({ clock, ids, workspaceId });
+    const service = createCoordinationService({ store, clock, ids });
+    const session = participantId => service.openSession({ workspaceId, participantId,
+      harness: "fixture", heartbeatCadenceMs: 30_000 });
+    const sender = await session("sender");
+    const receiver = await session("receiver");
+    await service.publishDeliveryBinding({ sessionId: receiver.sessionId,
+      generation: receiver.generation, adapterId: "claude_code", clientVersion: "2.1.267",
+      availableModes: ["livePush"], livePolicy: "actionable", opaqueEndpointRef: channel.endpointId,
+      leaseUntil: new Date(Date.now() + 60_000).toISOString() });
+    // A real live endpoint with an OS connection failure at the sender boundary.
+    const connect = () => {
+      const socket = new net.Socket();
+      queueMicrotask(() => socket.emit("error", Object.assign(new Error("private socket path"), { code })));
+      return socket;
+    };
+    const adapter = { id: "claude_code", capabilities: { delivery: { livePush: true } },
+      nativeDelivery: {}, offerMessage: input => offerMessage({ ...input, runtimeDir: root, connect }) };
+    const router = createDeliveryRouter({ service, clock, adapters: [adapter] });
+    const message = await service.sendMessage({ sessionId: sender.sessionId,
+      generation: sender.generation, toParticipantIds: ["receiver"], kind: "request",
+      obligation: "reply", subject: "permission probe", body: "synthetic",
+      clientMessageId: `client_${code}`, artifacts: [], inReplyTo: null });
+    const [delivery] = await router.offer(message);
+    assert.equal(delivery.errorCode, "transport_permission_denied");
+    assert.equal(delivery.outcome, "queued");
+    assert.equal((await service.readReceipt({ messageId: message.messageId,
+      recipientParticipantId: "receiver" })).state, "queued");
+    const events = (await store.eventsSince(workspaceId, null, 100)).events;
+    const failed = events.find(event => event.type === "message.offer_failed");
+    assert.equal(failed.payload.safeErrorCode, "transport_permission_denied");
+    assert.equal(JSON.stringify(failed).includes("private socket path"), false);
+  });
+}
+
+test("macOS channels keep the same short socket namespace across client TMPDIR values", {
+  skip: process.platform !== "darwin",
+}, async t => {
+  const root = await mkdtemp("/private/tmp/acc-channel-location-");
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const before = process.env.TMPDIR;
+  let channel;
+  try {
+    process.env.TMPDIR = root;
+    channel = createAccChannel({ endpointDir: endpointDir(root), clientPid: process.pid,
+      write: () => {}, routeReply: async () => {}, routeAck: async () => {} });
+  } finally {
+    if (before === undefined) delete process.env.TMPDIR;
+    else process.env.TMPDIR = before;
+  }
+  await channel.listen();
+  t.after(() => channel.close());
+  const record = JSON.parse(await readFile(path.join(endpointDir(root), `${channel.endpointId}.json`)));
+  assert.equal(path.dirname(record.socketPath), `/tmp/acc-ch-${process.getuid()}`);
+});

--- a/tests/process/codex-live-fallback.test.mjs
+++ b/tests/process/codex-live-fallback.test.mjs
@@ -131,7 +131,8 @@ test("doctor names unavailable fallback without withdrawing captured live delive
   if (capturedPlatform) {
     assert.match(human, /local delivery service is unavailable/);
     assert.match(human, /acc install --adapter codex --delivery actionable/);
-    assert.match(human, /ACC does not start or restart that service/);
+    assert.match(human, /codex app-server daemon start/);
+    assert.match(human, /ACC never starts or restarts the daemon/);
   }
   await assertOnlyVersionProbes(place);
 


### PR DESCRIPTION
Codex could receive a native request while its sandbox blocked the reply to Claude. ACC 0.4.3 configures outgoing local socket access for supported default workspace policies and reports sender permission failures separately from unavailable recipients.

- Configure permissions from recorded live consent, including before the daemon is ready. Preserve custom policies; restore the selection, proxy and grants as one ownership unit.
- Show outgoing setup in install previews/consent and doctor, with the concrete missing-daemon command. Preserve EPERM/EACCES through native transports, router and queued receipts.
- Stabilize the macOS ACC socket directory across client TMPDIR values. Update README, configuration, troubleshooting and upgrade guidance.
- Align all package versions to 0.4.3 and record the exact candidate artifact.

Validation: mandatory pre-push syntax and full suite (1,972 passed, 0 failed, 1 skipped); regression RED/GREEN checks; configuration review; exact installed-package verification; all 23 managed-update checks; published 0.4.2 → candidate upgrade; 259/259 source/archive/installed/managed files identical. The real Codex 0.154.0 sandbox allowed ACC sockets while denying unrelated Unix/TCP connections. Claude 2.1.267 → Codex 0.154.0 → Claude completed the installed live round trip with two native offers and no additional model prompts or manual inbox reads. Capture setup and limitations are in `docs/release-evidence/v0.4.3.md`.

No tag, npm publication or merge has been performed.
