### PR TITLE
release: ACC 0.4.4 automatic update recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.4.4 — unreleased
+
+- `acc update` can ask once to restart a verified Codex service on macOS arm64.
+  A detached worker waits for idle work, refreshes integrations, restarts and verifies
+  the service, and records progress for `acc doctor`. `--yes` provides explicit
+  noninteractive consent; background checks never grant that permission.
+- Native delivery consent and existing activation setup survive updates when a service
+  or feature probe is unavailable. Effective capability still reports degradation.
+- Update diagnostics group bindings and leases by actual PID, name concrete blockers,
+  and refresh stale pending notices. Unknown process ownership remains a hold.
+- Background update workers release their update lock between polls. New management
+  entry points can recover older pending runtimes and retire a verified obsolete ACC
+  updater while preserving the integration-write fence.
+- Update and service-recovery limitations, first-hop bootstrap and client reconnection
+  requirements are documented. Workspace data format and delivery defaults are unchanged.
+
 ## 0.4.3 — release candidate
 
 - Live opt-in configures Codex outgoing socket access on macOS arm64 with Codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@ The exact archive passed installed-package verification and an isolated upgrade 
 published 0.4.2 with 0.4.3 already pending. One real-terminal confirmation completed
 private Codex daemon maintenance after the requesting command exited. All 269 archive
 files matched the activated runtime. See [candidate evidence](docs/release-evidence/v0.4.4.md)
-for failure checks and limits. The full suite runs after this evidence commit through
-the mandatory pre-push gate. This candidate has not been tagged or published.
+for failure checks and limits. The final full suite passed with 2,017 passes, zero
+failures and one environment-dependent skip. The mandatory pre-push gate repeats
+release checks. This candidate has not been tagged or published.
 
 ## 0.4.3 — release candidate
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.4.4 — unreleased
+## 0.4.4 — release candidate
 
 - `acc update` can ask once to restart a verified Codex service on macOS arm64.
   A detached worker waits for idle work, refreshes integrations, restarts and verifies
@@ -15,6 +15,19 @@
   updater while preserving the integration-write fence.
 - Update and service-recovery limitations, first-hop bootstrap and client reconnection
   requirements are documented. Workspace data format and delivery defaults are unchanged.
+
+| Candidate artifact | Value |
+|---|---|
+| Built from | `59ef6d53406b0bd4a52459408fe9cd23aca034a6` |
+| Tarball | `agents-can-communicate-0.4.4.tgz`, 362,506 bytes, 269 files |
+| sha256 | `3ec046c2524c0bb35fe1d0b0f9fa07f03e53ab81e439ec80cdd48b0fce04196e` |
+
+The exact archive passed installed-package verification and an isolated upgrade from
+published 0.4.2 with 0.4.3 already pending. One real-terminal confirmation completed
+private Codex daemon maintenance after the requesting command exited. All 269 archive
+files matched the activated runtime. See [candidate evidence](docs/release-evidence/v0.4.4.md)
+for failure checks and limits. The full suite runs after this evidence commit through
+the mandatory pre-push gate. This candidate has not been tagged or published.
 
 ## 0.4.3 — release candidate
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 | Candidate artifact | Value |
 |---|---|
-| Built from | `59ef6d53406b0bd4a52459408fe9cd23aca034a6` |
+| Built from | `1731a3b8285147bb74e297b9775a7e2b47983a85` |
 | Tarball | `agents-can-communicate-0.4.4.tgz`, 362,506 bytes, 269 files |
 | sha256 | `3ec046c2524c0bb35fe1d0b0f9fa07f03e53ab81e439ec80cdd48b0fce04196e` |
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ state, commonly your home directory, cannot be used as a workspace; start the cl
 project directory. See [Troubleshooting](docs/TROUBLESHOOTING.md).
 
 Already using ACC? Follow the [upgrade guide](docs/UPGRADING.md), including the 0.4.x →
-0.4.3 update and the data-format boundary when moving from 0.3.1.
+0.4.4 update and the data-format boundary when moving from 0.3.1.
 
 ## When messages arrive
 
@@ -142,8 +142,10 @@ One npm package. ACC needs no separate account, model API key, or hosted service
 
 Initial installation enables automatic updates. ACC downloads stable releases in the
 background and waits for active clients and ACC processes to exit before switching the
-runtime and refreshing integrations. Restart clients afterward and complete any requested
-hook or plugin trust review.
+runtime and refreshing integrations. When a verified Codex service needs a restart,
+`acc update` asks once, then completes maintenance in a separate process. Open clients
+disconnect; `acc doctor` reports progress and the result. See [update and recovery details](docs/UPGRADING.md#confirmed-client-service-maintenance).
+Restart or resume clients afterward and complete any requested hook or plugin trust review.
 
 For an immediate update:
 

--- a/bin/acc-maintenance-worker.mjs
+++ b/bin/acc-maintenance-worker.mjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import { runMaintenance } from "../node_modules/@agents-can-communicate/cli/src/managed-runtime/maintenance-worker.mjs";
+
+// This private entry has no workspace admission/lease and no inherited stdio.
+// Durable checkpoints remain available to the next acc update after a crash.
+await runMaintenance(process.argv[2], { jobId: process.argv[3] }).catch(() => { process.exitCode = 1; });

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,8 +15,10 @@ flowchart LR
   T -->|reply or acknowledge| C
 ```
 
-ACC never starts, resumes, interrupts, supervises, or terminates the target client. A
-transport that requires owning that lifecycle is outside the product boundary.
+Message delivery never starts, resumes, interrupts, supervises, or terminates the target
+client. A transport that requires owning that lifecycle is outside the product boundary.
+Separately, explicit update maintenance can restart a verified client service after the
+user confirms the disconnection; it does not launch or assign agent tasks.
 
 ## Packages and dependency direction
 
@@ -90,8 +92,8 @@ turn.
 Claude Code Channel has installed-client evidence on 2.1.258 and 2.1.260; Codex
 LocalDaemon has it on 0.152.1 and 0.153.4. Both use a captured platform minimum,
 current probe and exact session handshake. Codex preserves the ordinary client
-launch and verifies its registered thread and workspace; ACC owns no vendor daemon
-lifecycle. Gemini CLI and Kimi Code have exact-version next-turn evidence only;
+launch and verifies its registered thread and workspace; native delivery owns no vendor
+daemon lifecycle. Gemini CLI and Kimi Code have exact-version next-turn evidence only;
 Grok and generic MCP use inbox polling.
 
 ## Storage and workspace identity
@@ -184,7 +186,12 @@ remains fenced and repairs forward, with the old active pointer retained but nor
 workspace admission unavailable until recovery completes. Native bindings cease holding
 after observed SessionEnd cleanup or confirmed process death; the vendor daemon may remain
 running. Unknown PIDs remain holds until lifecycle cleanup. Presence TTL, `acc finish`,
-and delivery off alone do not prove native lifecycle end. ACC never manages the daemon.
+and delivery off alone do not prove native lifecycle end. Normal background updates never
+restart a vendor daemon. An explicitly approved maintenance job can do so through the
+adapter lifecycle port: it waits for idle work, validates exact process identity, stops
+the service under the admission fence, refreshes integrations, and restores and verifies
+the service even after a refresh failure. Checkpoints and the detached worker live outside
+repositories. Approved crash recovery never blindly repeats a stop.
 
 Lock ownership never expires by age. Retained nonempty tombstones prevent delayed observers
 from reclaiming a successor. Under an acquired lock, maintenance removes historical

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -232,7 +232,7 @@ external AI client. An addressed handoff requires acknowledgement; a room handof
 | `acc doctor` | `--home`, `--repair` |
 | `acc config init` | `--yes`, `--force` |
 | `acc config validate` | — |
-| `acc update` | `--check`, `--auto on\|off`, `--pin VERSION\|none`, `--apply` (alias) |
+| `acc update` | `--check`, `--auto on\|off`, `--pin VERSION\|none`, `--yes`, `--apply` (alias) |
 | `acc help` | — |
 | `acc version` | — |
 
@@ -248,8 +248,8 @@ effective policy off and prints the reason. Claude Code shell activation writes 
 zsh PATH block and a shim that `exec`s the real client; `ACC_BYPASS=1` bypasses that
 activation. Codex LocalDaemon delivery uses recorded installation consent without changing
 ordinary launch arguments. Its opt-in remains active when shim variables are absent or
-bypassed; `acc install --adapter codex --delivery off` disables new native offers. ACC never
-starts or stops the vendor daemon. The install summary names each client's requested policy,
+bypassed; `acc install --adapter codex --delivery off` disables new native offers. Installation
+and message delivery do not start or stop the vendor daemon. The install summary names each client's requested policy,
 activation state and verified fallback. `doctor` separates protocol readiness, recorded
 consent and a live channel in the current workspace, with a next step for missing activation.
 A supported version or an installed plugin alone is not an active delivery channel.
@@ -281,8 +281,13 @@ holds. `finish`, presence TTL, and delivery off are not observed native end. Hoo
 wait for network work. `ACC_NO_UPDATE_CHECK=1` disables update networking and background
 scheduling.
 
-`acc update` requests the update immediately; it reports a pending update when a running or
-unidentified client prevents activation. `--check` only checks and cannot be combined with
+`acc update` requests the update immediately. If a verified Codex service blocks activation
+or runs an older version than the installed CLI, it asks once to restart that service.
+After confirmation, a detached worker waits for idle work and other ACC processes, refreshes
+integrations, restarts the service and verifies the result. Open clients disconnect; use
+`acc doctor` for progress and resume the clients afterward. `--yes` supplies explicit
+noninteractive restart consent. Without consent, or with unknown ownership, the update
+remains pending. See [maintenance limits and recovery](UPGRADING.md#confirmed-client-service-maintenance). `--check` only checks and cannot be combined with
 settings changes. `--auto off` disables background updates, and `--auto on` enables them.
 `--pin 0.4.0` holds an exact stable version; `--pin none` follows stable releases. A pin
 cannot downgrade the active runtime. The old `--apply` flag remains accepted.
@@ -290,7 +295,9 @@ cannot downgrade the active runtime. The old `--apply` flag remains accepted.
 Failed downloads keep the working runtime. A failed integration refresh exits with code
 `4`, names the failed adapter and configuration error, and keeps workspace admission closed.
 Fix the reported configuration problem, then run `acc update` to finish it. `acc doctor`
-reports the update policy and pending notice. Native clients may still require hook trust
+reports the update policy and pending notice. During blocked activation, a current launcher
+returns `scope: update` and `workspaceInspection: unavailable_during_update` without opening
+workspace state; `doctor --repair` remains blocked. Native clients may still require hook trust
 or activation review. See [Upgrading](UPGRADING.md) for the initial 0.3.1 transition and
 recovery details.
 

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -14,7 +14,8 @@ settings, clients, and checkouts. Neither is automatically in charge. Claude can
 for the endpoint shape; Codex can answer or decline under its own instructions.
 
 This resembles coordination among subagents, but the sessions were opened independently by
-the user. ACC never launches, assigns, supervises, or closes them.
+the user. ACC does not launch, assign or supervise their work. Separately, an explicit
+update can ask to restart a client service; this disconnects clients and requires user consent.
 
 ## Workspace, participant, and session
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -139,7 +139,8 @@ reports degraded reachability; it does not rewrite the installed consent.
 
 Codex LocalDaemon delivery separately requires macOS arm64, Codex 0.152.1 or newer, a
 current feature probe, and exact thread, canonical cwd, process, version and protocol
-checks. Its daemon must already be running; ACC never starts or stops it. Codex reads
+checks. Its daemon must already be running; installation and delivery do not start or stop it.
+Explicit update maintenance can restart a verified service after separate confirmation. Codex reads
 consent from the installation record, not a shell-shim variable. Unavailable or ineligible
 sessions retain durable inbox fallback. Use `acc install --adapter codex --delivery off`
 to stop new native offers; bypassing a shim does not disable that recorded opt-in.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -15,7 +15,7 @@ pair or session-bound ACC MCP tools. See [CLI ownership](CLI.md#coordinate-from-
 
 ACC requires macOS or Linux and Node.js 24 or newer.
 
-Already using ACC? Follow the [upgrade guide](UPGRADING.md) for the 0.4.x → 0.4.3
+Already using ACC? Follow the [upgrade guide](UPGRADING.md) for the 0.4.x → 0.4.4
 update or the data-format boundary when upgrading from 0.3.1.
 
 ```bash
@@ -30,7 +30,9 @@ acc install
 Initial installation also enables automatic updates; reinstalling keeps an explicit opt-out.
 ACC downloads releases in the background and
 refreshes its runtime and skills when active clients have left. Use `acc update` for an
-immediate update, or `acc update --auto off` to disable background updates. See
+immediate update; an eligible Codex service restart asks for one confirmation. ACC then
+handles maintenance and reports progress in `acc doctor`; clients disconnect and can be
+resumed afterward. Use `acc update --auto off` to disable background updates. See
 [update controls](UPGRADING.md#automatic-updates-after-installation).
 
 The installer connects only the supported clients it finds. Open a new terminal and

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -112,7 +112,8 @@ All recipients have the same durable record, but adapters expose different accel
   to an independently opened thread. It is experimental, off by default, and can
   spend tokens. Messages wait for a running turn to finish; a daemon-retained
   thread can receive them after its terminal exits. ACC adds no launch arguments
-  and does not manage the vendor daemon.
+  and does not manage the vendor daemon during message delivery. Separately,
+  [confirmed update maintenance](UPGRADING.md#confirmed-client-service-maintenance) can restart it.
 
 Grok, generic MCP, unsupported versions and uncaptured platforms use inbox polling.
 [Capabilities](CAPABILITIES.md) lists evidence and fallback.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,7 +1,7 @@
 # Releasing
 
 Use this procedure to build one auditable npm artifact, verify that exact tarball, and keep
-its evidence tied to the commit that supplied its bytes. The package is currently `0.4.3`;
+its evidence tied to the commit that supplied its bytes. The package is currently `0.4.4`;
 the commands derive the version from `package.json` so the filename cannot drift.
 
 ```mermaid

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -24,9 +24,10 @@ graph LR
   H["human authority"] --> C
 ```
 
-ACC does not read raw transcripts, relay permission approvals, or start target clients. A
-native delivery path may only offer an attributed peer envelope to an already-running,
-user-owned session.
+ACC does not read raw transcripts or relay permission approvals. A native delivery path
+may only offer an attributed peer envelope to an already-running, user-owned session.
+Confirmed update maintenance is a separate service restart operation; a peer message or
+live-delivery opt-in does not authorize it.
 
 ## Peer-content boundary
 
@@ -122,8 +123,14 @@ author as a software-supply trust boundary; they do not establish that package c
 
 ACC process leases hold activation until confirmed exit. Native bindings hold until observed
 SessionEnd cleanup or confirmed process death; unknown PIDs remain conservative holds.
-`acc finish`, presence TTL, and delivery off do not establish native lifecycle end. ACC does
-not manage the vendor daemon.
+`acc finish`, presence TTL, and delivery off do not establish native lifecycle end.
+Normal installation and message delivery do not manage vendor services. Explicit
+`acc update` maintenance requires one separate confirmation (or `--yes`) for the recorded
+candidate and verified service identity. The detached worker retains that approval for
+recovery, rechecks PID/start time, executable, socket, versions and idle state, and preserves
+unrelated or unidentified process holds. The vendor exposes no atomic turn-drain operation:
+a turn arriving between the final check and stop can be interrupted. See
+[confirmed maintenance](UPGRADING.md#confirmed-client-service-maintenance).
 
 A failed download leaves the active runtime available. A partial integration refresh retains
 the old active pointer but fences normal workspace admission in `activating`; it does not

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -240,8 +240,11 @@ Run `acc doctor` to see the update policy and pending notice. ACC process leases
 persistent MCP servers, require confirmed process exit. Native bindings clear on observed
 SessionEnd or confirmed process death; a vendor daemon may remain alive after SessionEnd.
 Unknown PIDs remain holds until lifecycle cleanup. Close the relevant client sessions and
-ACC processes; `finish`, presence TTL, and delivery off do not prove native end. ACC never
-manages the daemon or expires safety holds merely by elapsed time.
+ACC processes; `finish`, presence TTL, and delivery off do not prove native end.
+`acc update` can offer a confirmed restart of an eligible Codex service. Unknown or
+unrelated holds still require lifecycle cleanup or confirmed process exit; safety holds
+do not expire merely by elapsed time. See
+[maintenance and recovery](UPGRADING.md#confirmed-client-service-maintenance).
 
 Use `acc update` to retry a failed download or finish an interrupted integration refresh.
 A download failure keeps the working version. A partial integration refresh blocks

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,13 +1,14 @@
-# Upgrading to 0.4.3
+# Upgrading to 0.4.4
 
-## From 0.4.2, 0.4.1 or 0.4.0
+## From 0.4.3, 0.4.2, 0.4.1 or 0.4.0
 
-This patch keeps the existing workspace data format. It fixes outgoing native delivery
-from Codex's sandbox, separates permission failures from unavailable recipients, and
-shows outgoing setup alongside receiving-channel state in doctor. It also includes the
-previous 0.4.x delivery diagnostics, session recovery and client integration fixes.
+This patch keeps the existing workspace data format. It adds confirmed service maintenance
+to the updater, preserves native delivery setup when readiness probes are unavailable,
+and names the actual processes blocking activation. It includes the previous 0.4.x
+outgoing sandbox permissions, delivery diagnostics, session recovery and integration fixes.
 
-Close participating clients and persistent ACC MCP processes, then run:
+Run the update command; it can offer a confirmed restart for an eligible Codex service.
+Other active clients and persistent ACC MCP processes still need to finish before activation:
 
 ```bash
 acc update
@@ -15,8 +16,8 @@ acc version
 acc doctor
 ```
 
-After publication, `acc version` should report 0.4.3. If a pin keeps an older version,
-select 0.4.3 or clear it first. A managed update refreshes installed integrations and
+After publication, `acc version` should report 0.4.4. If a pin keeps an older version,
+select 0.4.4 or clear it first. A managed update refreshes installed integrations and
 skills; use the npm instructions below for unmanaged or pre-0.4 installations. Start
 clients again and complete any hook/trust review they request. With existing live consent,
 Codex 0.153.4 or newer on macOS arm64 receives local socket permissions when its workspace
@@ -36,12 +37,51 @@ Claude admitted inbound Channels messages. See [delivery troubleshooting](TROUBL
 Upgrading preserves delivery consent. If doctor reports native delivery off and you want
 automatic peer requests, use `acc install --adapter codex --delivery actionable` (or the
 relevant adapter); this can spend model tokens. Codex can save that consent before its
-local service/session becomes available. ACC does not start the vendor daemon, and it
+local service/session becomes available. Installation does not start the vendor daemon; ACC
 keeps durable inbox access when no verified live channel is bound.
 
 In Grok, public status supplies the session's own CLI arguments through the next tool
 hook. Grok still uses explicit inbox reads; this patch adds no external wake or guards.
 Start clients in a project directory, rather than a home directory containing ACC state.
+
+## Confirmed client service maintenance
+
+On macOS arm64, `acc update` can ask once to restart a verified Codex service that blocks
+activation or runs a different version from the installed CLI. The captured maintenance
+contract uses Codex CLI 0.154.0 and its `pid` backend, with compatible commands and protocol
+checked again at runtime. The installed CLI and managed executable must already match;
+ACC does not replace vendor binaries or install an operating-system service.
+
+After confirmation, a detached ACC worker waits up to 15 minutes for idle Codex turns,
+empty queues and other ACC processes to exit. It rechecks the approved candidate, settings,
+PID/start time, executable, socket ownership and versions before stopping the service.
+It refreshes integrations, starts the service again and verifies the result. If refreshing
+integrations fails, it still restores the service and reports the incomplete update.
+A later update worker can resume an already approved recovery without another question.
+`acc doctor --json` exposes `update.maintenance`; ordinary `acc doctor` describes its state.
+A current launcher can use the newer management reader while the old runtime is active.
+When admission is blocked, doctor returns an update-only report without inspecting the
+workspace or repairing it. Older launchers gain this reader after activation, or through
+the one-time launcher bootstrap described below.
+
+Open clients disconnect. Resume them afterward and complete any client-owned hook trust
+review. Codex has no atomic idle-check-and-stop operation: a new turn arriving during the
+final check can be interrupted. ACC does not promise that client UIs reconnect themselves
+or that an interrupted turn continues automatically. Unknown ownership, incompatible
+service layouts and unrelated active processes remain visible blockers.
+
+For an unattended command, `acc update --yes` explicitly consents to the same restart.
+`acc update --check` stays read-only. Background discovery never grants restart consent.
+Changing the candidate or pin before the stop cancels that approval; idle-wait expiration
+also leaves the service untouched. Delivery consent and automatic-update opt-outs survive
+an update even when a native service or feature probe is temporarily unavailable.
+
+An old installation can already be stuck with both a pre-0.4.4 pending runtime and the
+old updater that waits indefinitely. That code cannot discover this fix. Bootstrap the
+new launcher once with `npm install --global agents-can-communicate@0.4.4`, then run
+`acc update`. The new launcher stages its verified runtime and retires only an exactly
+identified obsolete ACC background updater while no integrations are being written.
+This does not terminate an unrelated client or bypass its lifetime hold.
 
 ## From 0.3.1
 
@@ -64,7 +104,7 @@ restores access; deleting or editing the record is not a remedy.
 2. Install the released package, then refresh the client integrations:
 
    ```bash
-   npm install --global agents-can-communicate@0.4.3
+   npm install --global agents-can-communicate@0.4.4
    acc version
    acc install
    ```
@@ -104,7 +144,8 @@ confirmed process exit. Native bindings hold until observed client SessionEnd cl
 confirmed process death; the vendor daemon can remain running after that lifecycle event.
 Unknown PIDs remain conservative holds until lifecycle cleanup. `acc finish`, presence TTL,
 and delivery off alone do not prove native end. Close the relevant client sessions and
-persistent ACC processes to release holds; ACC does not manage the vendor daemon.
+persistent ACC processes to release holds, or accept the eligible Codex service maintenance
+offer in `acc update`. Background updates never request fresh restart consent.
 Hooks never wait for a network download. If integration refresh temporarily prevents
 coordination, a hook lets the client continue; its next genuine user turn can restore a
 missing binding.
@@ -114,7 +155,7 @@ acc update                    # download and apply, or report what is keeping it
 acc update --check            # check without installing or changing update settings
 acc update --auto off         # disable background updates
 acc update --auto on          # enable them again
-acc update --pin 0.4.3        # stay on this exact stable version
+acc update --pin 0.4.4        # stay on this exact stable version
 acc update --pin none         # follow stable releases again
 ```
 

--- a/docs/WHY_ACC.md
+++ b/docs/WHY_ACC.md
@@ -46,7 +46,7 @@ actionable before two sessions collide.
 ## Choose another layer when
 
 Choose a managed runtime if you want the system to create agents, assign execution state,
-select models, spend token budgets, or control process lifecycle. Choose a tracker when
+select models, spend token budgets, or control ongoing agent execution. Choose a tracker when
 you need organizational planning. Choose a hosted service when participants must
 coordinate across machines.
 

--- a/docs/release-evidence/v0.4.4.md
+++ b/docs/release-evidence/v0.4.4.md
@@ -17,9 +17,12 @@ The root, all 14 bundled packages, lock entries and Gemini extension are aligned
 to 0.4.4. Syntax checking passed for 501 modules. The exact archive passed
 `scripts/verify-package.mjs`: clean consumer entry points, doctor, a non-Git workspace,
 installation/removal, preserved client-home topology and packed documentation links.
-No runtime dependency was added. The final full suite runs after this evidence commit;
-the earlier run had 2,014 passes, one skip, and only the expected outdated candidate
-record failure while this new measurement was not yet recorded.
+No runtime dependency was added. The final full suite passed: 2,018 tests, 2,017 passes,
+zero failures and one environment-dependent skip. The skipped existing uninstall test
+requires Gemini CLI to be absent; it is installed on the capture machine. An obsolete
+acceptance assertion was updated to require readable doctor diagnostics during an
+incomplete refresh, while repair remains fenced. Disabling that diagnostic route made
+the corrected installed-package test fail; restoring it made the test pass.
 
 ## Installed artifact and one confirmation
 

--- a/docs/release-evidence/v0.4.4.md
+++ b/docs/release-evidence/v0.4.4.md
@@ -7,6 +7,7 @@ probes, and reports concrete update blockers and recovery state.
 | Measurement | Value |
 |---|---|
 | Built from | `59ef6d53406b0bd4a52459408fe9cd23aca034a6` |
+| Identical rebuild after test fix | `1731a3b8285147bb74e297b9775a7e2b47983a85` |
 | Archive | `agents-can-communicate-0.4.4.tgz`, 362,506 bytes, 269 files |
 | SHA-256 | `3ec046c2524c0bb35fe1d0b0f9fa07f03e53ab81e439ec80cdd48b0fce04196e` |
 | Platform / Node | macOS arm64 / 24.4.0 |
@@ -23,6 +24,13 @@ requires Gemini CLI to be absent; it is installed on the capture machine. An obs
 acceptance assertion was updated to require readable doctor diagnostics during an
 incomplete refresh, while repair remains fenced. Disabling that diagnostic route made
 the corrected installed-package test fail; restoring it made the test pass.
+
+The first macOS CI run exposed a test synchronization race: the worker readiness file
+could exist before its `ready` content was written. The fixture now exposes that empty
+publication window deliberately and waits for the complete marker. The original wait
+failed with an empty string; the corrected worker tests passed all six cases. Repacking
+the test-only fix at the revision above produced an archive byte-for-byte identical to
+the captured artifact. Its original source and capture provenance remain unchanged.
 
 ## Installed artifact and one confirmation
 

--- a/docs/release-evidence/v0.4.4.md
+++ b/docs/release-evidence/v0.4.4.md
@@ -1,0 +1,81 @@
+# ACC 0.4.4 candidate evidence
+
+This candidate is prepared for review. It has not been tagged or published.
+It adds confirmed update maintenance, preserves native setup through unavailable
+probes, and reports concrete update blockers and recovery state.
+
+| Measurement | Value |
+|---|---|
+| Built from | `59ef6d53406b0bd4a52459408fe9cd23aca034a6` |
+| Archive | `agents-can-communicate-0.4.4.tgz`, 362,506 bytes, 269 files |
+| SHA-256 | `3ec046c2524c0bb35fe1d0b0f9fa07f03e53ab81e439ec80cdd48b0fce04196e` |
+| Platform / Node | macOS arm64 / 24.4.0 |
+| Source / archive comparison | 269/269 file bytes identical |
+| Archive / activated runtime comparison | 269/269 file bytes and modes identical |
+
+The root, all 14 bundled packages, lock entries and Gemini extension are aligned
+to 0.4.4. Syntax checking passed for 501 modules. The exact archive passed
+`scripts/verify-package.mjs`: clean consumer entry points, doctor, a non-Git workspace,
+installation/removal, preserved client-home topology and packed documentation links.
+No runtime dependency was added. The final full suite runs after this evidence commit;
+the earlier run had 2,014 passes, one skip, and only the expected outdated candidate
+record failure while this new measurement was not yet recorded.
+
+## Installed artifact and one confirmation
+
+The final capture used the exact archive above with a private Codex CLI 0.154.0 daemon
+and isolated client home, ACC state and configuration. Published ACC 0.4.2 was installed,
+published 0.4.3 was staged as a pending runtime, a native process hold was recorded,
+and the actual old background updater was left waiting with its worker lock held.
+
+The new launcher staged the verified 0.4.4 implementation and retired the precisely
+identified obsolete ACC updater. A noninteractive update reported that confirmation
+was required and left the private daemon running. The old published CLI then loaded
+the candidate bridge in a real pseudo-terminal and asked exactly once. After that
+foreground command exited, the detached worker completed maintenance without more input.
+
+The approved private daemon PID exited, a different daemon PID started, and CLI/server
+versions matched at 0.154.0. The active ACC runtime became 0.4.4 with no pending version;
+its 269 files matched the exact archive. Doctor reported completed maintenance. Delivery
+off remained off and the recorded automatic-update setting remained on. This local
+bootstrap consumed no alternate archive or registry request. The private daemon was
+stopped afterward and temporary homes were removed. The operator's real daemon was
+never restarted.
+
+Separate installed-package checks exercised a native service absent during update,
+retained Claude activation after a failed feature probe, automatic-update opt-out,
+and recovery of the installed Claude shim on an ordinary later launch. Fenced and
+pending update diagnostics were exercised through the installed doctor command;
+workspace inspection and repair remained unavailable on that management-only route.
+
+## Failure and mutation checks
+
+Tests failed on the original unavailable-probe update gate and duplicate process counts.
+Exact mutations then demonstrated protection of retained native setup, native holds,
+fresh doctor diagnostics, explicit consent, approved candidate settings, restoration
+after refresh failure, final-check busy retry, and waiting-state diagnostics. Adapter
+mutations exercised process identity and active-turn/queue guards. Legacy entry and
+worker mutations covered argument containment, protocol validation, caller identity,
+read-only checks, lock release, and safe old-helper retirement.
+
+Independent review identified and corrected consent being consumed by a late busy
+refusal, stale-daemon maintenance being skipped after a successful activation, and
+update diagnostics being inaccessible while workspace admission was fenced.
+
+## Limits
+
+Maintenance lifecycle capture is macOS arm64, Codex CLI 0.154.0, pid backend. The
+installed CLI and managed executable must already match; ACC does not update vendor
+binaries or install an OS service. Other backends/platforms remain unsupported for
+this maintenance operation. Delivery capability declarations were not broadened.
+
+Codex exposes no atomic turn-drain fence. A turn arriving after the final observation
+can be interrupted by the approved restart. No UI reconnection, automatic continuation
+of an interrupted turn, or live model-to-model delivery after this restart was captured.
+The private maintenance test used no authentication or model requests and created no
+user conversation. This record does not extend earlier native delivery evidence.
+
+An entirely old launcher, active runtime and pending candidate cannot discover code
+none of them contains. The documented one-time new-launcher bootstrap is required for
+that already-stuck state. Unknown ownership and unrelated live ACC processes remain
+holds; approval is bounded to the observed service and recorded candidate/settings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -114,59 +114,59 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.4.3"
+      "version": "0.4.4"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.4.3"
+      "version": "0.4.4"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.4.3"
+      "version": "0.4.4"
     },
     "packages/adapter-grok": {
       "name": "@agents-can-communicate/adapter-grok",
-      "version": "0.4.3"
+      "version": "0.4.4"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.4.3"
+      "version": "0.4.4"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.4.3"
+      "version": "0.4.4"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.4.3"
+      "version": "0.4.4"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.4.3"
+      "version": "0.4.4"
     },
     "packages/delivery-router": {
       "name": "@agents-can-communicate/delivery-router",
-      "version": "0.4.3"
+      "version": "0.4.4"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.4.3"
+      "version": "0.4.4"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.4.3"
+      "version": "0.4.4"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.4.3"
+      "version": "0.4.4"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.4.3"
+      "version": "0.4.4"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.4.3"
+      "version": "0.4.4"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.4.3",
+  "version": "0.4.4",
+  "accManagedUpdateProtocol": 2,
   "type": "module",
   "description": "Local-first coordination for independently opened AI agent sessions.",
   "keywords": [

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/COMPATIBILITY.md
+++ b/packages/adapter-codex/COMPATIBILITY.md
@@ -1,5 +1,40 @@
 # Codex compatibility
 
+## Explicit update maintenance (2026-09-10)
+
+The separate update-maintenance ports were exercised with installed Codex CLI
+0.154.0 on darwin-arm64 using the `pid` backend and a fresh private `CODEX_HOME`.
+The adapter inspected the actual daemon, stopped it through `app-server daemon
+stop`, proved process death, started it through the supported `start` command,
+and verified the restarted server. A repeated start check returned the restored
+instance without another lifecycle command. A detached worker also completed
+start/restart/stop after its launcher exited. See the
+[metadata capture](fixtures/maintenance/codex-cli-0.154.0-darwin-arm64.json).
+
+CLI 0.154.0 successfully stopped a private 0.153.4 server and started the installed
+0.154.0 executable. Neither `start` nor `restart` upgraded an older managed binary
+automatically. Maintenance therefore requires matching installed CLI and managed
+versions; ACC does not copy binaries, run bootstrap, or modify Codex configuration.
+The captured modern executable path is `current/bin/codex`; the legacy
+`current/codex` process alias is accepted only when it resolves to the same file.
+
+Inspection verifies the vendor PID/start-time record against process metadata,
+the captured executable invocation, ownership of the exact control socket, CLI
+version output, and the live protocol handshake. Only loaded-thread IDs,
+metadata-only `thread/read` with `includeTurns:false`, and pending queue counts
+are used; persisted results contain identity fields and counts, never thread
+content. Active work or queued input postpones stopping. Stop repeats inspection
+against the approved identity, and unknown process death keeps maintenance open.
+Unsupported platforms, backends, binary versions, and malformed metadata refuse
+the operation. This does not broaden native delivery or hook capabilities.
+
+No atomic drain or maintenance admission fence appeared in the generated 0.154.0
+API schema or lifecycle help. Checks are observations, so they do not prove that
+a new turn cannot begin between observation and stopping. Active-turn survival,
+UI reconnection, other operating systems, and launchd were not captured. The real
+user daemon was inspected read-only and remained running; every private daemon
+and temporary home was cleaned up.
+
 ## Observed ACC 0.3.1 to 0.4 hook activation
 
 On stock Codex 0.153.4, the 0.4 hook-command quoting change modified all five ACC hook
@@ -30,7 +65,7 @@ race itself is covered by separate deterministic router regression tests.
 
 Native `delivery.livePush` uses the darwin-arm64 minimum 0.152.1, current feature
 probe, recorded recipient consent, and exact thread, canonical cwd, live process,
-stable version and protocol checks. ACC adds no client arguments and does not
+stable version and protocol checks. Native delivery adds no client arguments and does not
 start, restart or stop a vendor daemon. Unsupported platforms, older clients,
 Embedded sessions, unavailable sockets and failed identity checks keep the durable
 inbox. Ordinary hook capabilities remain limited to their exact 0.147.0 capture.

--- a/packages/adapter-codex/fixtures/maintenance/codex-cli-0.154.0-darwin-arm64.json
+++ b/packages/adapter-codex/fixtures/maintenance/codex-cli-0.154.0-darwin-arm64.json
@@ -1,0 +1,474 @@
+{
+  "schemaVersion": 1,
+  "capturedAt": "2026-09-10",
+  "platform": "darwin-arm64",
+  "cliVersion": "0.154.0",
+  "backend": "pid",
+  "scope": "Explicit update maintenance only; no new native message delivery or hook capability.",
+  "provenance": {
+    "source": "Installed standalone Codex0.154.0 and retained0.153.4; fresh private CODEX_HOME. No authentication, model call, user thread mutation, transcript capture, or real daemon restart.",
+    "normalization": "Operator installation and private temporary home paths replaced with placeholders. Metadata values and command outcomes retained.",
+    "captures": [
+      {
+        "name": "adapter-lifecycle.json",
+        "sha256": "521e3eed0d4f453d772ecd87d241a8565f0173b1f7e9bc19bb8dddecdb9ac502"
+      },
+      {
+        "name": "version-migration.json",
+        "sha256": "e364b7cc2aadaf026d4ab4a655f2c579beafa3d4c51b70f515afa5440cfb846c"
+      },
+      {
+        "name": "detached-lifecycle.json",
+        "sha256": "1cfad003d69172fe285fdb250fff9ff065cdf38e33464c4057b36ff1718366d7"
+      },
+      {
+        "name": "real-adapter-inspection-read-only.json",
+        "sha256": "3f61cb75350be9925b83c9458d4aa9e11212492a7490c625130484286e35bc50"
+      },
+      {
+        "name": "restart-does-not-update-managed.json",
+        "sha256": "19b86e754ac49e94a54b12eef407d23cf9b776cfd45bb738af45fb5cc99d2221"
+      }
+    ]
+  },
+  "adapterLifecycle": {
+    "capturedAt": "2026-09-10T06:37:28.182Z",
+    "privateHome": "<private-codex-home>",
+    "operations": [
+      {
+        "method": "inspectMaintenance",
+        "result": {
+          "serviceId": "codex-app-server",
+          "state": "ready",
+          "reasonCode": null,
+          "pid": 17893,
+          "processStartTime": "Thu Sep 10 02:37:28 2026",
+          "codexHome": "<private-codex-home>",
+          "cliPath": "<installed-codex-home>/packages/standalone/releases/0.154.0-aarch64-apple-darwin/bin/codex",
+          "cliVersion": "0.154.0",
+          "serverVersion": "0.154.0",
+          "managedPath": "<private-codex-home>/packages/standalone/current/codex",
+          "managedVersion": "0.154.0",
+          "socketPath": "<private-codex-home>/app-server-control/app-server-control.sock",
+          "busyThreads": 0,
+          "queuedRequests": 0
+        }
+      },
+      {
+        "method": "stopForMaintenance",
+        "result": {
+          "ok": true,
+          "reasonCode": null
+        }
+      },
+      {
+        "method": "startAfterMaintenance",
+        "result": {
+          "ok": true,
+          "reasonCode": null,
+          "snapshot": {
+            "serviceId": "codex-app-server",
+            "state": "ready",
+            "reasonCode": null,
+            "pid": 18246,
+            "processStartTime": "Thu Sep 10 02:37:30 2026",
+            "codexHome": "<private-codex-home>",
+            "cliPath": "<installed-codex-home>/packages/standalone/releases/0.154.0-aarch64-apple-darwin/bin/codex",
+            "cliVersion": "0.154.0",
+            "serverVersion": "0.154.0",
+            "managedPath": "<private-codex-home>/packages/standalone/current/codex",
+            "managedVersion": "0.154.0",
+            "socketPath": "<private-codex-home>/app-server-control/app-server-control.sock",
+            "busyThreads": 0,
+            "queuedRequests": 0
+          }
+        }
+      },
+      {
+        "method": "startAfterMaintenance-idempotent",
+        "result": {
+          "ok": true,
+          "reasonCode": null,
+          "snapshot": {
+            "serviceId": "codex-app-server",
+            "state": "ready",
+            "reasonCode": null,
+            "pid": 18246,
+            "processStartTime": "Thu Sep 10 02:37:30 2026",
+            "codexHome": "<private-codex-home>",
+            "cliPath": "<installed-codex-home>/packages/standalone/releases/0.154.0-aarch64-apple-darwin/bin/codex",
+            "cliVersion": "0.154.0",
+            "serverVersion": "0.154.0",
+            "managedPath": "<private-codex-home>/packages/standalone/current/codex",
+            "managedVersion": "0.154.0",
+            "socketPath": "<private-codex-home>/app-server-control/app-server-control.sock",
+            "busyThreads": 0,
+            "queuedRequests": 0
+          }
+        }
+      }
+    ],
+    "initialStart": {
+      "status": 0,
+      "stdout": "{\"status\":\"started\",\"backend\":\"pid\",\"pid\":17893,\"managedCodexPath\":\"<private-codex-home>/packages/standalone/current/codex\",\"managedCodexVersion\":\"0.154.0\",\"socketPath\":\"<private-codex-home>/app-server-control/app-server-control.sock\",\"cliVersion\":\"0.154.0\",\"appServerVersion\":\"0.154.0\"}\n",
+      "stderr": ""
+    },
+    "cleanupStop": {
+      "status": 0,
+      "stdout": "{\"status\":\"stopped\",\"backend\":\"pid\",\"managedCodexPath\":\"<private-codex-home>/packages/standalone/current/codex\",\"managedCodexVersion\":\"0.154.0\",\"socketPath\":\"<private-codex-home>/app-server-control/app-server-control.sock\",\"cliVersion\":\"0.154.0\"}\n",
+      "stderr": ""
+    },
+    "pidFileAbsent": true,
+    "socketAbsent": true,
+    "privateHomeRemoved": true
+  },
+  "oldDaemonReadOnlyInspection": {
+    "capturedAt": "2026-09-10T06:40:47.859Z",
+    "snapshot": {
+      "serviceId": "codex-app-server",
+      "state": "busy",
+      "reasonCode": "service_busy",
+      "pid": 30290,
+      "processStartTime": "Wed Sep  9 19:32:59 2026",
+      "codexHome": "<installed-codex-home>",
+      "cliPath": "<installed-codex-home>/packages/standalone/releases/0.154.0-aarch64-apple-darwin/bin/codex",
+      "cliVersion": "0.154.0",
+      "serverVersion": "0.153.4",
+      "managedPath": "<installed-codex-home>/packages/standalone/current/bin/codex",
+      "managedVersion": "0.154.0",
+      "socketPath": "<installed-codex-home>/app-server-control/app-server-control.sock",
+      "busyThreads": 6,
+      "queuedRequests": 0
+    }
+  },
+  "cliVersionTransition": {
+    "oldBinary": "<installed-codex-home>/packages/standalone/releases/0.153.4-aarch64-apple-darwin/bin/codex",
+    "managed": "<private-codex-home>/packages/standalone/current/codex",
+    "commands": [
+      {
+        "label": "start-old-managed-with-current-cli",
+        "args": [
+          "app-server",
+          "daemon",
+          "start"
+        ],
+        "status": 0,
+        "signal": null,
+        "stdout": "{\"status\":\"started\",\"backend\":\"pid\",\"pid\":95123,\"managedCodexPath\":\"<private-codex-home>/packages/standalone/current/codex\",\"managedCodexVersion\":\"0.153.4\",\"socketPath\":\"<private-codex-home>/app-server-control/app-server-control.sock\",\"cliVersion\":\"0.154.0\",\"appServerVersion\":\"0.153.4\"}\n",
+        "stderr": ""
+      },
+      {
+        "label": "version-cli-new-server-old",
+        "args": [
+          "app-server",
+          "daemon",
+          "version"
+        ],
+        "status": 0,
+        "signal": null,
+        "stdout": "{\"status\":\"running\",\"backend\":\"pid\",\"managedCodexPath\":\"<private-codex-home>/packages/standalone/current/codex\",\"managedCodexVersion\":\"0.153.4\",\"socketPath\":\"<private-codex-home>/app-server-control/app-server-control.sock\",\"cliVersion\":\"0.154.0\",\"appServerVersion\":\"0.153.4\"}\n",
+        "stderr": ""
+      },
+      {
+        "label": "stop-old-daemon-with-current-cli",
+        "args": [
+          "app-server",
+          "daemon",
+          "stop"
+        ],
+        "status": 0,
+        "signal": null,
+        "stdout": "{\"status\":\"stopped\",\"backend\":\"pid\",\"managedCodexPath\":\"<private-codex-home>/packages/standalone/current/codex\",\"managedCodexVersion\":\"0.153.4\",\"socketPath\":\"<private-codex-home>/app-server-control/app-server-control.sock\",\"cliVersion\":\"0.154.0\"}\n",
+        "stderr": ""
+      },
+      {
+        "label": "start-updated-managed-with-current-cli",
+        "args": [
+          "app-server",
+          "daemon",
+          "start"
+        ],
+        "status": 0,
+        "signal": null,
+        "stdout": "{\"status\":\"started\",\"backend\":\"pid\",\"pid\":95197,\"managedCodexPath\":\"<private-codex-home>/packages/standalone/current/codex\",\"managedCodexVersion\":\"0.154.0\",\"socketPath\":\"<private-codex-home>/app-server-control/app-server-control.sock\",\"cliVersion\":\"0.154.0\",\"appServerVersion\":\"0.154.0\"}\n",
+        "stderr": ""
+      },
+      {
+        "label": "version-cli-new-server-new",
+        "args": [
+          "app-server",
+          "daemon",
+          "version"
+        ],
+        "status": 0,
+        "signal": null,
+        "stdout": "{\"status\":\"running\",\"backend\":\"pid\",\"managedCodexPath\":\"<private-codex-home>/packages/standalone/current/codex\",\"managedCodexVersion\":\"0.154.0\",\"socketPath\":\"<private-codex-home>/app-server-control/app-server-control.sock\",\"cliVersion\":\"0.154.0\",\"appServerVersion\":\"0.154.0\"}\n",
+        "stderr": ""
+      },
+      {
+        "label": "cleanup-stop",
+        "args": [
+          "app-server",
+          "daemon",
+          "stop"
+        ],
+        "status": 0,
+        "signal": null,
+        "stdout": "{\"status\":\"stopped\",\"backend\":\"pid\",\"managedCodexPath\":\"<private-codex-home>/packages/standalone/current/codex\",\"managedCodexVersion\":\"0.154.0\",\"socketPath\":\"<private-codex-home>/app-server-control/app-server-control.sock\",\"cliVersion\":\"0.154.0\"}\n",
+        "stderr": ""
+      },
+      {
+        "label": "cleanup-version",
+        "args": [
+          "app-server",
+          "daemon",
+          "version"
+        ],
+        "status": 1,
+        "signal": null,
+        "stdout": "",
+        "stderr": "Error: failed to connect to <private-codex-home>/app-server-control/app-server-control.sock\n\nCaused by:\n    No such file or directory (os error 2)\n"
+      }
+    ],
+    "identities": [
+      {
+        "label": "old-daemon",
+        "pidRecord": {
+          "pid": 95123,
+          "processStartTime": "Thu Sep 10 02:19:16 2026"
+        },
+        "psStatus": 0,
+        "psStdout": "95123     1 Thu Sep 10 02:19:16 2026     <private-codex-home>/packages/standalone/current/codex app-server --listen unix://\n"
+      },
+      {
+        "label": "new-daemon",
+        "pidRecord": {
+          "pid": 95197,
+          "processStartTime": "Thu Sep 10 02:19:18 2026"
+        },
+        "psStatus": 0,
+        "psStdout": "95197     1 Thu Sep 10 02:19:18 2026     <private-codex-home>/packages/standalone/current/codex app-server --listen unix://\n"
+      }
+    ],
+    "complete": true
+  },
+  "detachedLifecycle": {
+    "workerPid": 92968,
+    "initialParentPid": 1,
+    "launcherPid": 92959,
+    "beganAt": "2026-09-10T06:18:14.426Z",
+    "commands": [
+      {
+        "label": "detached-start",
+        "args": [
+          "app-server",
+          "daemon",
+          "start"
+        ],
+        "status": 0,
+        "signal": null,
+        "stdout": "{\"status\":\"started\",\"backend\":\"pid\",\"pid\":92970,\"managedCodexPath\":\"<private-codex-home>/packages/standalone/current/codex\",\"managedCodexVersion\":\"0.154.0\",\"socketPath\":\"<private-codex-home>/app-server-control/app-server-control.sock\",\"cliVersion\":\"0.154.0\",\"appServerVersion\":\"0.154.0\"}\n",
+        "stderr": ""
+      },
+      {
+        "label": "detached-version-before-restart",
+        "args": [
+          "app-server",
+          "daemon",
+          "version"
+        ],
+        "status": 0,
+        "signal": null,
+        "stdout": "{\"status\":\"running\",\"backend\":\"pid\",\"managedCodexPath\":\"<private-codex-home>/packages/standalone/current/codex\",\"managedCodexVersion\":\"0.154.0\",\"socketPath\":\"<private-codex-home>/app-server-control/app-server-control.sock\",\"cliVersion\":\"0.154.0\",\"appServerVersion\":\"0.154.0\"}\n",
+        "stderr": ""
+      },
+      {
+        "label": "detached-restart",
+        "args": [
+          "app-server",
+          "daemon",
+          "restart"
+        ],
+        "status": 0,
+        "signal": null,
+        "stdout": "{\"status\":\"restarted\",\"backend\":\"pid\",\"pid\":93034,\"managedCodexPath\":\"<private-codex-home>/packages/standalone/current/codex\",\"managedCodexVersion\":\"0.154.0\",\"socketPath\":\"<private-codex-home>/app-server-control/app-server-control.sock\",\"cliVersion\":\"0.154.0\",\"appServerVersion\":\"0.154.0\"}\n",
+        "stderr": ""
+      },
+      {
+        "label": "detached-version-after-restart",
+        "args": [
+          "app-server",
+          "daemon",
+          "version"
+        ],
+        "status": 0,
+        "signal": null,
+        "stdout": "{\"status\":\"running\",\"backend\":\"pid\",\"managedCodexPath\":\"<private-codex-home>/packages/standalone/current/codex\",\"managedCodexVersion\":\"0.154.0\",\"socketPath\":\"<private-codex-home>/app-server-control/app-server-control.sock\",\"cliVersion\":\"0.154.0\",\"appServerVersion\":\"0.154.0\"}\n",
+        "stderr": ""
+      },
+      {
+        "label": "detached-stop",
+        "args": [
+          "app-server",
+          "daemon",
+          "stop"
+        ],
+        "status": 0,
+        "signal": null,
+        "stdout": "{\"status\":\"stopped\",\"backend\":\"pid\",\"managedCodexPath\":\"<private-codex-home>/packages/standalone/current/codex\",\"managedCodexVersion\":\"0.154.0\",\"socketPath\":\"<private-codex-home>/app-server-control/app-server-control.sock\",\"cliVersion\":\"0.154.0\"}\n",
+        "stderr": ""
+      },
+      {
+        "label": "detached-version-after-stop",
+        "args": [
+          "app-server",
+          "daemon",
+          "version"
+        ],
+        "status": 1,
+        "signal": null,
+        "stdout": "",
+        "stderr": "Error: failed to connect to <private-codex-home>/app-server-control/app-server-control.sock\n\nCaused by:\n    No such file or directory (os error 2)\n"
+      }
+    ],
+    "pidRecords": [
+      {
+        "label": "before-restart",
+        "pid": 92970,
+        "processStartTime": "Thu Sep 10 02:18:14 2026"
+      },
+      {
+        "label": "after-restart",
+        "pid": 93034,
+        "processStartTime": "Thu Sep 10 02:18:15 2026"
+      }
+    ],
+    "parentPidBeforeCommands": 1,
+    "parentPidAfterCommands": 1,
+    "finishedAt": "2026-09-10T06:18:15.591Z",
+    "completed": true
+  },
+  "restartDoesNotUpdateManagedBinary": {
+    "capturedAt": "2026-09-10T06:28:36.794Z",
+    "privateHome": "<private-codex-home>",
+    "fixtureSource": "<installed-codex-home>/packages/standalone/releases/0.153.4-aarch64-apple-darwin/bin/codex",
+    "cli": "<installed-codex-cli>",
+    "commands": [
+      {
+        "label": "managed-before",
+        "binary": "<private-codex-home>/packages/standalone/current/codex",
+        "args": [
+          "--version"
+        ],
+        "status": 0,
+        "signal": null,
+        "stdout": "codex-cli 0.153.4\n",
+        "stderr": ""
+      },
+      {
+        "label": "start",
+        "binary": "<installed-codex-cli>",
+        "args": [
+          "app-server",
+          "daemon",
+          "start"
+        ],
+        "status": 0,
+        "signal": null,
+        "stdout": "{\"status\":\"started\",\"backend\":\"pid\",\"pid\":5384,\"managedCodexPath\":\"<private-codex-home>/packages/standalone/current/codex\",\"managedCodexVersion\":\"0.153.4\",\"socketPath\":\"<private-codex-home>/app-server-control/app-server-control.sock\",\"cliVersion\":\"0.154.0\",\"appServerVersion\":\"0.153.4\"}\n",
+        "stderr": ""
+      },
+      {
+        "label": "restart",
+        "binary": "<installed-codex-cli>",
+        "args": [
+          "app-server",
+          "daemon",
+          "restart"
+        ],
+        "status": 0,
+        "signal": null,
+        "stdout": "{\"status\":\"restarted\",\"backend\":\"pid\",\"pid\":5436,\"managedCodexPath\":\"<private-codex-home>/packages/standalone/current/codex\",\"managedCodexVersion\":\"0.153.4\",\"socketPath\":\"<private-codex-home>/app-server-control/app-server-control.sock\",\"cliVersion\":\"0.154.0\",\"appServerVersion\":\"0.153.4\"}\n",
+        "stderr": ""
+      },
+      {
+        "label": "version-after-restart",
+        "binary": "<installed-codex-cli>",
+        "args": [
+          "app-server",
+          "daemon",
+          "version"
+        ],
+        "status": 0,
+        "signal": null,
+        "stdout": "{\"status\":\"running\",\"backend\":\"pid\",\"managedCodexPath\":\"<private-codex-home>/packages/standalone/current/codex\",\"managedCodexVersion\":\"0.153.4\",\"socketPath\":\"<private-codex-home>/app-server-control/app-server-control.sock\",\"cliVersion\":\"0.154.0\",\"appServerVersion\":\"0.153.4\"}\n",
+        "stderr": ""
+      },
+      {
+        "label": "managed-after",
+        "binary": "<private-codex-home>/packages/standalone/current/codex",
+        "args": [
+          "--version"
+        ],
+        "status": 0,
+        "signal": null,
+        "stdout": "codex-cli 0.153.4\n",
+        "stderr": ""
+      },
+      {
+        "label": "stop-private",
+        "binary": "<installed-codex-cli>",
+        "args": [
+          "app-server",
+          "daemon",
+          "stop"
+        ],
+        "status": 0,
+        "signal": null,
+        "stdout": "{\"status\":\"stopped\",\"backend\":\"pid\",\"managedCodexPath\":\"<private-codex-home>/packages/standalone/current/codex\",\"managedCodexVersion\":\"0.153.4\",\"socketPath\":\"<private-codex-home>/app-server-control/app-server-control.sock\",\"cliVersion\":\"0.154.0\"}\n",
+        "stderr": ""
+      },
+      {
+        "label": "version-after-stop",
+        "binary": "<installed-codex-cli>",
+        "args": [
+          "app-server",
+          "daemon",
+          "version"
+        ],
+        "status": 1,
+        "signal": null,
+        "stdout": "",
+        "stderr": "Error: failed to connect to <private-codex-home>/app-server-control/app-server-control.sock\n\nCaused by:\n    No such file or directory (os error 2)\n"
+      }
+    ],
+    "privatePids": [
+      5384,
+      5436
+    ],
+    "cleanupProcesses": [
+      {
+        "pid": 5384,
+        "status": 1,
+        "stdout": "",
+        "stderr": ""
+      },
+      {
+        "pid": 5436,
+        "status": 1,
+        "stdout": "",
+        "stderr": ""
+      }
+    ],
+    "pidFileAbsent": true,
+    "socketAbsent": true,
+    "privateHomeRemoved": true,
+    "finishedAt": "2026-09-10T06:28:38.736Z"
+  },
+  "limitations": [
+    "No vendor atomic drain or admission fence in generated0.154.0 CLI/schema.",
+    "No active-turn survival or UI reconnect guarantee.",
+    "No launchd, Linux, Windows, bootstrap, configuration edits, binary copying by ACC, or authentication.",
+    "Private binary copies were fixture setup only; production maintenance calls supported CLI stop/start."
+  ]
+}

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/src/adapter.mjs
+++ b/packages/adapter-codex/src/adapter.mjs
@@ -2,6 +2,8 @@ import { defineAdapter, projectContext, projectContextResult }
   from "@agents-can-communicate/adapter-sdk";
 import { probeNativeDelivery, planNativeActivation, bindNativeSession, refreshNativeSession, retireNativeSession, offerMessage } from "./native-delivery.mjs";
 import certification from "../certification.json" with { type: "json" };
+import { createCodexMaintenance } from "./maintenance.mjs";
+export { sameMaintenanceIdentity } from "./maintenance.mjs";
 
 import { PROTOCOL_CONTRACT } from "./app-server-client.mjs";
 import { allowOutcome, denyOutcome, injectOutcome, normalizeCodexHook }
@@ -16,8 +18,9 @@ export const CODEX_DELIVERY_FALLBACK = Object.freeze({
   diagnostic: "Codex native delivery requires codex-cli 0.152.1 or newer on darwin-arm64, "
     + "recorded recipient consent and a reachable LocalDaemon session with exact thread, cwd, "
     + "process, version and protocol verification. Embedded or unreachable sessions retain "
-    + "durable messages. ACC does not start, restart or stop the vendor daemon and adds no "
-    + "launch arguments; fallback is exact-certified next-turn delivery or acc inbox",
+    + "durable messages. Native delivery does not start, restart or stop the vendor daemon and adds no "
+    + "launch arguments; fallback is exact-certified next-turn delivery or acc inbox. "
+    + "Explicitly confirmed acc update maintenance has a separate daemon restart check",
 });
 
 /**
@@ -61,6 +64,7 @@ export function createCodexAdapter() {
     },
     probeNativeDelivery, planNativeActivation, bindNativeSession,
     refreshNativeSession, retireNativeSession, offerMessage,
+    ...createCodexMaintenance(),
     startSession: async () => ({ ok: true, changes: [], diagnostics: [] }),
     endSession: async () => ({ ok: true, changes: [], diagnostics: [] }),
     guardWrite: async () => ({ ok: true, changes: [], diagnostics: [] }),

--- a/packages/adapter-codex/src/maintenance-host.mjs
+++ b/packages/adapter-codex/src/maintenance-host.mjs
@@ -1,0 +1,120 @@
+import { execFile } from "node:child_process";
+import { constants } from "node:fs";
+import { access, lstat, open, realpath } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { compareStableVersions, parseStableVersion } from "./app-server-client.mjs";
+
+export const MINIMUM_MAINTENANCE_CLI = "0.154.0";
+export const absolute = value => typeof value === "string" && path.isAbsolute(value)
+  && !/[\0\r\n]/.test(value);
+export const failMaintenance = reasonCode => { throw Object.assign(new Error(reasonCode), { reasonCode }); };
+const own = info => typeof process.getuid !== "function" || info.uid === process.getuid();
+export const startTimeValid = value => typeof value === "string"
+  && /^[A-Z][a-z]{2} [A-Z][a-z]{2} [ \d]\d \d\d:\d\d:\d\d \d{4}$/.test(value);
+export const managedExecutablePaths = codexHome => ["bin/codex", "codex"].map(name =>
+  path.join(codexHome, "packages/standalone/current", name));
+
+export function runMaintenanceCommand(command, args, options) {
+  return new Promise(resolve => execFile(command, args,
+    { ...options, timeout: 20_000, maxBuffer: 131_072, windowsHide: true },
+    (error, stdout, stderr) => resolve({ status: error ?
+      (typeof error.code === "number" ? error.code : null) : 0, stdout, stderr })));
+}
+
+export async function maintenanceContext(context = {}) {
+  const env = context.env ?? process.env;
+  const home = context.home ?? env.HOME ?? os.homedir();
+  let codexHome = env.CODEX_HOME ?? path.join(home, ".codex");
+  if (!absolute(home) || !absolute(codexHome)) failMaintenance("invalid_service_home");
+  try { codexHome = await realpath(codexHome); }
+  catch (error) { if (error.code !== "ENOENT") throw error; }
+  const [binPath, legacyPath] = managedExecutablePaths(codexHome);
+  const managedPath = await metadataExists(binPath) ? binPath : legacyPath;
+  return { codexHome, socketPath: path.join(codexHome, "app-server-control/app-server-control.sock"),
+    pidPath: path.join(codexHome, "app-server-daemon/app-server.pid"),
+    managedPath,
+    platform: context.platform ?? `${process.platform}-${process.arch}`,
+    options: { cwd: codexHome, env: { ...env, HOME: home, CODEX_HOME: codexHome } } };
+}
+
+export async function metadataExists(file) {
+  try { await lstat(file); return true; }
+  catch (error) { if (error.code === "ENOENT") return false; throw error; }
+}
+
+async function resolveCli(pathEnv) {
+  for (const directory of String(pathEnv ?? "").split(path.delimiter)) {
+    if (!absolute(directory)) continue;
+    const candidate = path.join(directory, "codex");
+    try {
+      await access(candidate, constants.X_OK);
+      const resolved = await realpath(candidate);
+      if ((await lstat(resolved)).isFile()) return resolved;
+    } catch { /* another PATH entry may be usable */ }
+  }
+  failMaintenance("maintenance_cli_unavailable");
+}
+
+const cliVersion = response => response.status === 0
+  ? /^codex-cli (\d+\.\d+\.\d+)\s*$/.exec(response.stdout)?.[1] ?? null : null;
+
+export async function probeMaintenanceInstall(paths, run) {
+  const cliPath = await resolveCli(paths.options.env.PATH);
+  const version = cliVersion(await run(cliPath, ["--version"], paths.options));
+  if (!parseStableVersion(version) || compareStableVersions(version, MINIMUM_MAINTENANCE_CLI) < 0) {
+    failMaintenance("maintenance_cli_unsupported");
+  }
+  const help = await run(cliPath, ["app-server", "daemon", "--help"], paths.options);
+  if (help.status !== 0 || ["start", "stop", "version"].some(command =>
+    !new RegExp(`^\\s+${command}\\s+`, "m").test(help.stdout))) failMaintenance("maintenance_cli_unsupported");
+  const managedVersion = cliVersion(await run(paths.managedPath, ["--version"], paths.options));
+  if (managedVersion !== version) failMaintenance("managed_binary_mismatch");
+  return { cliPath, cliVersion: version, managedVersion };
+}
+
+export async function readMaintenancePid(file) {
+  let handle;
+  try {
+    handle = await open(file, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+    const info = await handle.stat();
+    if (!info.isFile() || !own(info) || info.size > 4_096 || (info.mode & 0o022) !== 0) {
+      failMaintenance("daemon_identity_unavailable");
+    }
+    const value = JSON.parse(await handle.readFile("utf8"));
+    if (!Number.isSafeInteger(value.pid) || value.pid < 2 || !startTimeValid(value.processStartTime)) {
+      failMaintenance("daemon_identity_unavailable");
+    }
+    return { pid: value.pid, processStartTime: value.processStartTime };
+  } finally { await handle?.close(); }
+}
+
+export async function observeMaintenanceProcess(pid, paths, run) {
+  const response = await run("/bin/ps", ["-p", String(pid), "-o", "lstart=,command="], paths.options);
+  if (response.status === 1 && response.stdout === "" && response.stderr === "") return { state: "dead" };
+  if (response.status !== 0) return { state: "unknown" };
+  const match = /^(.{24})\s+(.+)$/.exec(response.stdout.trim());
+  if (!match || !startTimeValid(match[1])) return { state: "unknown" };
+  return { state: "alive", processStartTime: match[1], command: match[2] };
+}
+
+export async function verifyMaintenanceProcess(snapshot, paths, run) {
+  const process = await observeMaintenanceProcess(snapshot.pid, paths, run);
+  const suffix = " app-server --listen unix://";
+  const executable = process.command?.endsWith(suffix) ? process.command.slice(0, -suffix.length) : null;
+  if (process.state !== "alive" || process.processStartTime !== snapshot.processStartTime
+    || !managedExecutablePaths(paths.codexHome).includes(executable)
+    || await realpath(executable) !== await realpath(paths.managedPath)) {
+    failMaintenance("daemon_identity_unavailable");
+  }
+  const sockets = await run("/usr/sbin/lsof", ["-n", "-a", "-p", String(snapshot.pid), "-U", "-Fn"], paths.options);
+  if (sockets.status !== 0 || !sockets.stdout.split("\n").includes(`n${paths.socketPath}`)) {
+    failMaintenance("daemon_socket_unproven");
+  }
+}
+
+export async function approvedProcessIsDead(expected, paths, run) {
+  const observed = await observeMaintenanceProcess(expected.pid, paths, run);
+  return observed.state === "dead" || (observed.state === "alive"
+    && observed.processStartTime !== expected.processStartTime);
+}

--- a/packages/adapter-codex/src/maintenance-threads.mjs
+++ b/packages/adapter-codex/src/maintenance-threads.mjs
@@ -1,0 +1,49 @@
+import { initializeCodex } from "./app-server-client.mjs";
+import { failMaintenance } from "./maintenance-host.mjs";
+
+async function loadedThreads(peer) {
+  const ids = [], cursors = new Set();
+  let cursor = null;
+  for (let page = 0; page < 20; page += 1) {
+    const response = await peer.request("thread/loaded/list", { limit: 100, ...(cursor ? { cursor } : {}) });
+    if (!Array.isArray(response?.data) || response.data.some(id => typeof id !== "string" || !id)) {
+      failMaintenance("maintenance_protocol_unavailable");
+    }
+    ids.push(...response.data);
+    cursor = response.nextCursor ?? null;
+    if (cursor === null) {
+      if (new Set(ids).size !== ids.length) failMaintenance("maintenance_protocol_unavailable");
+      return ids.sort();
+    }
+    if (typeof cursor !== "string" || !cursor || cursors.has(cursor)) failMaintenance("maintenance_protocol_unavailable");
+    cursors.add(cursor);
+  }
+  failMaintenance("maintenance_protocol_unavailable");
+}
+
+// The caller receives counts only. No thread/list previews, turns, queue bodies,
+// notification history, or vendor errors are retained in maintenance snapshots.
+export async function maintenanceWorkload(snapshot, open) {
+  let peer;
+  try {
+    peer = await open({ socketPath: snapshot.socketPath });
+    if (await initializeCodex(peer) !== snapshot.serverVersion) failMaintenance("daemon_version_changed");
+    const ids = await loadedThreads(peer);
+    let busyThreads = 0, queuedRequests = 0;
+    for (const threadId of ids) {
+      const response = await peer.request("thread/read", { threadId, includeTurns: false });
+      const thread = response?.thread;
+      if (thread?.id !== threadId || !Array.isArray(thread.turns) || thread.turns.length !== 0
+        || !["idle", "active"].includes(thread.status?.type)) failMaintenance("maintenance_protocol_unavailable");
+      if (thread.status.type === "active") busyThreads += 1;
+      const queue = await peer.request("thread/queue/list", { threadId });
+      if (!Array.isArray(queue?.data) || queue.nextCursor != null
+        || queue.data.some(entry => typeof entry?.id !== "string" || !entry.id)) {
+        failMaintenance("maintenance_protocol_unavailable");
+      }
+      queuedRequests += queue.data.length;
+    }
+    if (JSON.stringify(await loadedThreads(peer)) !== JSON.stringify(ids)) failMaintenance("loaded_threads_changed");
+    return { busyThreads, queuedRequests };
+  } finally { await peer?.close(); }
+}

--- a/packages/adapter-codex/src/maintenance.mjs
+++ b/packages/adapter-codex/src/maintenance.mjs
@@ -1,0 +1,108 @@
+import path from "node:path";
+import { openCodexAppServer, parseStableVersion } from "./app-server-client.mjs";
+import { socketIsReady } from "./native-endpoint.mjs";
+import { absolute, approvedProcessIsDead, failMaintenance, maintenanceContext,
+  managedExecutablePaths, metadataExists, probeMaintenanceInstall, readMaintenancePid, runMaintenanceCommand,
+  startTimeValid, verifyMaintenanceProcess } from "./maintenance-host.mjs";
+import { maintenanceWorkload } from "./maintenance-threads.mjs";
+
+const identityKeys = ["serviceId", "pid", "processStartTime", "codexHome", "cliPath", "cliVersion",
+  "serverVersion", "managedPath", "managedVersion", "socketPath"];
+const installationKeys = ["codexHome", "cliPath", "cliVersion", "managedPath", "managedVersion", "socketPath"];
+const refused = (reasonCode, snapshot) => ({ ok: false, reasonCode, ...(snapshot ? { snapshot } : {}) });
+const sameFields = (left, right, fields) => fields.every(key => left?.[key] === right?.[key]);
+
+function validApproval(value) {
+  return value?.serviceId === "codex-app-server" && ["ready", "busy"].includes(value.state)
+    && Number.isSafeInteger(value.pid) && value.pid > 1 && startTimeValid(value.processStartTime)
+    && ["codexHome", "cliPath", "managedPath", "socketPath"].every(key => absolute(value[key]))
+    && ["cliVersion", "serverVersion", "managedVersion"].every(key => parseStableVersion(value[key]))
+    && value.managedVersion === value.cliVersion
+    && managedExecutablePaths(value.codexHome).includes(value.managedPath)
+    && value.socketPath === path.join(value.codexHome, "app-server-control/app-server-control.sock");
+}
+
+export function sameMaintenanceIdentity(expected, current) {
+  return validApproval(expected) && validApproval(current) && sameFields(expected, current, identityKeys);
+}
+
+export function createCodexMaintenance({ run = runMaintenanceCommand, open = openCodexAppServer } = {}) {
+  async function inspectMaintenance(context) {
+    let snapshot = { serviceId: "codex-app-server", state: "unsupported", reasonCode: null,
+      pid: null, processStartTime: null, codexHome: null, cliPath: null, cliVersion: null,
+      serverVersion: null, managedPath: null, managedVersion: null, socketPath: null,
+      busyThreads: 0, queuedRequests: 0 };
+    try {
+      const paths = await maintenanceContext(context);
+      Object.assign(snapshot, { codexHome: paths.codexHome, socketPath: paths.socketPath, managedPath: paths.managedPath });
+      if (!await metadataExists(paths.socketPath) && !await metadataExists(paths.pidPath)) return null;
+      if (paths.platform !== "darwin-arm64") failMaintenance("maintenance_platform_unsupported");
+      if (!await socketIsReady(paths.socketPath)) failMaintenance("daemon_socket_unproven");
+      Object.assign(snapshot, await probeMaintenanceInstall(paths, run));
+      const version = await run(snapshot.cliPath, ["app-server", "daemon", "version"], paths.options);
+      if (version.status !== 0) failMaintenance("daemon_version_unavailable");
+      const observed = JSON.parse(version.stdout);
+      if (observed.status !== "running" || observed.backend !== "pid") failMaintenance("maintenance_backend_unsupported");
+      if (observed.managedCodexPath !== snapshot.managedPath || observed.socketPath !== snapshot.socketPath
+        || observed.cliVersion !== snapshot.cliVersion || observed.managedCodexVersion !== snapshot.managedVersion
+        || !parseStableVersion(observed.appServerVersion)) failMaintenance("daemon_identity_unavailable");
+      snapshot.serverVersion = observed.appServerVersion;
+      Object.assign(snapshot, await readMaintenancePid(paths.pidPath));
+      await verifyMaintenanceProcess(snapshot, paths, run);
+      Object.assign(snapshot, await maintenanceWorkload(snapshot, open));
+      const finalPid = await readMaintenancePid(paths.pidPath);
+      if (!sameFields(snapshot, finalPid, ["pid", "processStartTime"])) failMaintenance("service_identity_changed");
+      await verifyMaintenanceProcess(snapshot, paths, run);
+      snapshot.state = snapshot.busyThreads || snapshot.queuedRequests ? "busy" : "ready";
+      snapshot.reasonCode = snapshot.state === "busy" ? "service_busy" : null;
+    } catch (error) { snapshot.reasonCode = error.reasonCode ?? "maintenance_inspection_failed"; }
+    return snapshot;
+  }
+
+  async function stopForMaintenance({ context, expected } = {}) {
+    let stopAttempted = false;
+    const refuseStop = (reasonCode, snapshot) => ({ ...refused(reasonCode, snapshot), stopAttempted });
+    if (!validApproval(expected)) return refuseStop("invalid_maintenance_approval");
+    try {
+      const current = await inspectMaintenance(context);
+      if (!sameMaintenanceIdentity(expected, current)) return refuseStop("service_identity_changed", current);
+      if (current.state !== "ready" || current.busyThreads !== 0 || current.queuedRequests !== 0) {
+        return refuseStop("service_busy", current);
+      }
+      const paths = await maintenanceContext(context);
+      stopAttempted = true;
+      const stopped = await run(current.cliPath, ["app-server", "daemon", "stop"], paths.options);
+      if (stopped.status !== 0) return refuseStop("daemon_stop_failed");
+      if (!await approvedProcessIsDead(expected, paths, run)) return refuseStop("daemon_death_unverified");
+      return { ok: true, reasonCode: null, stopAttempted };
+    } catch { return refuseStop("daemon_stop_failed"); }
+  }
+
+  async function startAfterMaintenance({ context, expected } = {}) {
+    if (!validApproval(expected)) return refused("invalid_maintenance_approval");
+    try {
+      const pinned = { ...context, env: { ...(context?.env ?? process.env), CODEX_HOME: expected.codexHome } };
+      const paths = await maintenanceContext(pinned);
+      if (paths.platform !== "darwin-arm64") return refused("maintenance_platform_unsupported");
+      const install = { ...paths, ...await probeMaintenanceInstall(paths, run) };
+      if (!sameFields(expected, install, installationKeys)) return refused("service_identity_changed");
+      const existing = await inspectMaintenance(pinned);
+      if (existing) {
+        if (["ready", "busy"].includes(existing.state) && sameFields(expected, existing, installationKeys)
+          && existing.serverVersion === expected.cliVersion) return { ok: true, reasonCode: null, snapshot: existing };
+        return refused("service_identity_changed", existing);
+      }
+      if (!await approvedProcessIsDead(expected, paths, run)) return refused("daemon_death_unverified");
+      const started = await run(install.cliPath, ["app-server", "daemon", "start"], paths.options);
+      if (started.status !== 0) return refused("daemon_start_failed");
+      const current = await inspectMaintenance(pinned);
+      if (!current || !["ready", "busy"].includes(current.state)
+        || !sameFields(expected, current, installationKeys) || current.serverVersion !== expected.cliVersion) {
+        return refused("daemon_start_unverified", current);
+      }
+      return { ok: true, reasonCode: null, snapshot: current };
+    } catch { return refused("daemon_start_failed"); }
+  }
+
+  return { inspectMaintenance, stopForMaintenance, startAfterMaintenance };
+}

--- a/packages/adapter-codex/test/maintenance-fixture.mjs
+++ b/packages/adapter-codex/test/maintenance-fixture.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { chmod, mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { createCodexMaintenance } from "../src/maintenance.mjs";
+
+export async function maintenanceFixture(t, { binLayout = false } = {}) {
+  const root = await realpath(await mkdtemp(path.join(
+    process.platform === "win32" ? os.tmpdir() : "/tmp", "acc-maint-")));
+  const home = path.join(root, "home"), codexHome = path.join(home, ".codex");
+  const bin = path.join(root, "bin"), cliPath = path.join(bin, "codex");
+  const managedPath = path.join(codexHome, `packages/standalone/current/${binLayout ? "bin/" : ""}codex`);
+  const socketPath = path.join(codexHome, "app-server-control/app-server-control.sock");
+  const pidPath = path.join(codexHome, "app-server-daemon/app-server.pid");
+  for (const file of [cliPath, managedPath, socketPath, pidPath]) {
+    await mkdir(path.dirname(file), { recursive: true });
+  }
+  for (const file of [cliPath, managedPath]) { await writeFile(file, "fixture"); await chmod(file, 0o755); }
+  if (binLayout) await symlink("bin/codex", path.join(codexHome, "packages/standalone/current/codex"));
+  const state = { pid: 45678, processStartTime: "Thu Sep 10 03:15:00 2026", running: false,
+    cliVersion: "0.154.0", managedVersion: "0.154.0", serverVersion: "0.153.4",
+    threads: [{ id: "private-thread", status: { type: "idle" } }], queued: [],
+    processUnknown: false, processCommand: null, socketOwned: true, backend: "pid" };
+  let socket;
+  const writePid = () => writeFile(pidPath, JSON.stringify({ pid: state.pid,
+    processStartTime: state.processStartTime }));
+  async function start() {
+    socket = net.createServer();
+    await new Promise((resolve, reject) => { socket.once("error", reject); socket.listen(socketPath, resolve); });
+    state.running = true; await writePid();
+  }
+  async function stop() {
+    if (socket) { await new Promise(resolve => socket.close(resolve)); socket = null; }
+    state.running = false; await rm(pidPath, { force: true });
+  }
+  t.after(async () => { await stop(); await rm(root, { recursive: true, force: true }); });
+  await start();
+  const context = { home, env: { HOME: home, CODEX_HOME: codexHome, PATH: bin }, platform: "darwin-arm64" };
+  const commands = [], requests = [];
+  const ok = stdout => ({ status: 0, stdout, stderr: "" });
+  const run = async (command, args, options) => {
+    if (command === "/bin/ps") {
+      if (state.processUnknown) return { status: 1, stdout: "", stderr: "permission denied" };
+      if (!state.running || Number(args[1]) !== state.pid) return { status: 1, stdout: "", stderr: "" };
+      return ok(`${state.processStartTime} ${state.processCommand ?? `${managedPath} app-server --listen unix://`}\n`);
+    }
+    if (command === "/usr/sbin/lsof") return ok(state.socketOwned ? `p${state.pid}\nn${socketPath}\n` : "");
+    assert.ok([cliPath, managedPath].includes(command), "never execute an approved job's arbitrary path");
+    assert.equal(options.env.CODEX_HOME, codexHome);
+    const argsText = args.join(" ");
+    if (argsText === "--version") return ok(`codex-cli ${command === cliPath ? state.cliVersion : state.managedVersion}\n`);
+    if (argsText === "app-server daemon --help") return ok("Commands:\n  start Start\n  stop Stop\n  restart Restart\n  version Version\n");
+    const action = args.at(-1);
+    if (action === "stop") { commands.push(action);
+      if (state.stopThrows) throw new Error("private vendor command failure");
+      if (state.stopFails) return { status: 1, stdout: "", stderr: "private vendor command failure" };
+      await stop();
+      if (state.unknownAfterStop) state.processUnknown = true;
+      return ok('{"status":"stopped"}\n'); }
+    if (action === "start") {
+      commands.push(action); state.pid += 1; state.processStartTime = "Thu Sep 10 03:16:00 2026";
+      state.serverVersion = state.managedVersion; await start(); return ok('{"status":"started"}\n');
+    }
+    assert.equal(action, "version");
+    if (!state.running) return { status: 1, stdout: "", stderr: "No such file or directory (os error 2)" };
+    return ok(JSON.stringify({ status: "running", backend: state.backend, managedCodexPath: managedPath,
+      managedCodexVersion: state.managedVersion, socketPath, cliVersion: state.cliVersion,
+      appServerVersion: state.serverVersion }));
+  };
+  const open = async () => ({ notify() {}, close() {}, async request(method, params) {
+    requests.push({ method, params });
+    if (method === "initialize") return { userAgent: `codex/${state.serverVersion} (Mac OS)` };
+    if (method === "thread/loaded/list") return { data: state.threads.map(thread => thread.id), nextCursor: null };
+    if (method === "thread/read") {
+      assert.equal(params.includeTurns, false, "maintenance must exclude transcript turns");
+      return { thread: { ...state.threads.find(thread => thread.id === params.threadId),
+        turns: state.turns ?? [], preview: "PRIVATE CONTENT MUST NOT ESCAPE" } };
+    }
+    if (method === "thread/queue/list") return state.queueResponse ?? { data: state.queued, nextCursor: null };
+    throw new Error(`Unexpected maintenance RPC: ${method}`);
+  } });
+  return { ...createCodexMaintenance({ run, open }), context, state, commands, requests,
+    root, cliPath, managedPath, codexHome, socketPath, pidPath, writePid, stop, start };
+}

--- a/packages/adapter-codex/test/maintenance.test.mjs
+++ b/packages/adapter-codex/test/maintenance.test.mjs
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createCodexAdapter } from "../src/adapter.mjs";
+import { maintenanceFixture } from "./maintenance-fixture.mjs";
+import path from "node:path";
+
+const unixSocketHost = { skip: process.platform === "win32"
+  ? "Codex maintenance fixtures require Unix filesystem sockets" : false };
+
+test("Codex update maintenance is exposed separately from native message delivery", () => {
+  const adapter = createCodexAdapter();
+  for (const method of ["inspectMaintenance", "stopForMaintenance", "startAfterMaintenance"]) {
+    assert.equal(typeof adapter[method], "function", `${method} must be available to update recovery`);
+  }
+});
+
+test("inspection verifies current process and socket identity without collecting thread content", unixSocketHost, async t => {
+  const h = await maintenanceFixture(t);
+  const result = await h.inspectMaintenance(h.context);
+  assert.equal(result?.state, "ready");
+  assert.equal(result.serviceId, "codex-app-server");
+  assert.equal(result.pid, 45678);
+  assert.equal(result.cliVersion, "0.154.0");
+  assert.equal(result.serverVersion, "0.153.4");
+  assert.equal(result.busyThreads, 0);
+  assert.equal(result.queuedRequests, 0);
+  assert.equal(JSON.stringify(result).includes("PRIVATE"), false);
+  assert.equal(JSON.stringify(result).includes("private-thread"), false);
+  await h.stop();
+  assert.equal(await h.inspectMaintenance(h.context), null);
+});
+
+test("active turns and pending vendor input postpone maintenance", unixSocketHost, async t => {
+  const h = await maintenanceFixture(t);
+  h.state.threads[0].status.type = "active";
+  let result = await h.inspectMaintenance(h.context);
+  assert.equal(result?.state, "busy"); assert.equal(result.busyThreads, 1);
+  h.state.threads[0].status.type = "idle";
+  h.state.queued.push({ id: "queued-1", input: [{ text: "PRIVATE" }] });
+  result = await h.inspectMaintenance(h.context);
+  assert.equal(result?.state, "busy"); assert.equal(result.queuedRequests, 1);
+  assert.equal(JSON.stringify(result).includes("PRIVATE"), false);
+});
+
+test("unproven process, socket, binary and platform combinations never become ready", unixSocketHost, async t => {
+  const h = await maintenanceFixture(t);
+  for (const change of [{ processUnknown: true }, { processCommand: "/wrong/codex app-server --listen unix://" },
+    { socketOwned: false }, { managedVersion: "0.153.4" }, { cliVersion: "0.153.4" }, { backend: "launchd" }]) {
+    const original = Object.fromEntries(Object.keys(change).map(key => [key, h.state[key]]));
+    Object.assign(h.state, change);
+    assert.equal((await h.inspectMaintenance(h.context))?.state, "unsupported", JSON.stringify(change));
+    Object.assign(h.state, original);
+  }
+  assert.equal((await h.inspectMaintenance({ ...h.context, platform: "linux-x64" }))?.state, "unsupported");
+  assert.deepEqual(h.commands, []);
+});
+
+test("stop rechecks exact approved identity and cannot stop a replacement process", unixSocketHost, async t => {
+  const h = await maintenanceFixture(t), expected = await h.inspectMaintenance(h.context);
+  h.state.pid += 1; await h.writePid();
+  const result = await h.stopForMaintenance({ context: h.context, expected });
+  assert.equal(result.ok, false);
+  assert.equal(result.reasonCode, "service_identity_changed");
+  assert.equal(result.stopAttempted, false);
+  assert.equal(h.state.running, true);
+  assert.deepEqual(h.commands, []);
+});
+
+test("a turn starting after approval is protected by the final stop check", unixSocketHost, async t => {
+  const h = await maintenanceFixture(t), expected = await h.inspectMaintenance(h.context);
+  h.state.threads[0].status.type = "active";
+  const result = await h.stopForMaintenance({ context: h.context, expected });
+  assert.equal(result.ok, false);
+  assert.equal(result.reasonCode, "service_busy");
+  assert.equal(result.stopAttempted, false);
+  assert.equal(h.state.running, true);
+  assert.deepEqual(h.commands, []);
+});
+
+test("supported stop/start verifies death and restores the installed version idempotently", unixSocketHost, async t => {
+  const h = await maintenanceFixture(t), expected = await h.inspectMaintenance(h.context);
+  const stopped = await h.stopForMaintenance({ context: h.context, expected });
+  assert.equal(stopped.ok, true);
+  assert.equal(stopped.stopAttempted, true);
+  assert.equal(h.state.running, false);
+  const started = await h.startAfterMaintenance({ context: h.context, expected });
+  assert.equal(started.ok, true);
+  assert.equal(started.snapshot.serverVersion, "0.154.0");
+  assert.equal((await h.startAfterMaintenance({ context: h.context, expected })).ok, true);
+  assert.deepEqual(h.commands, ["stop", "start"]);
+});
+
+test("start refuses a different old-version instance or unvalidated executable path", unixSocketHost, async t => {
+  const h = await maintenanceFixture(t), expected = await h.inspectMaintenance(h.context);
+  h.state.pid += 1; await h.writePid();
+  assert.equal((await h.startAfterMaintenance({ context: h.context, expected })).ok, false);
+  assert.equal((await h.startAfterMaintenance({ context: h.context,
+    expected: { ...expected, cliPath: "/arbitrary/command" } })).ok, false);
+  assert.deepEqual(h.commands, []);
+});
+
+test("current bin layout admits its captured legacy process alias only after realpath equality", unixSocketHost, async t => {
+  const h = await maintenanceFixture(t, { binLayout: true });
+  h.state.processCommand = `${path.join(h.codexHome, "packages/standalone/current/codex")} app-server --listen unix://`;
+  const expected = await h.inspectMaintenance(h.context);
+  assert.equal(expected?.state, "ready");
+  assert.equal(expected.managedPath, h.managedPath);
+  assert.equal((await h.stopForMaintenance({ context: h.context, expected })).ok, true);
+});
+
+test("same PID with a later process birth cannot consume an earlier approval", unixSocketHost, async t => {
+  const h = await maintenanceFixture(t), expected = await h.inspectMaintenance(h.context);
+  h.state.processStartTime = "Thu Sep 10 04:15:00 2026"; await h.writePid();
+  assert.equal((await h.stopForMaintenance({ context: h.context, expected })).reasonCode, "service_identity_changed");
+  assert.deepEqual(h.commands, []);
+});
+
+test("unknown process death retains maintenance even after the vendor stop reports success", unixSocketHost, async t => {
+  const h = await maintenanceFixture(t), expected = await h.inspectMaintenance(h.context);
+  h.state.unknownAfterStop = true;
+  const stopped = await h.stopForMaintenance({ context: h.context, expected });
+  assert.equal(stopped.reasonCode, "daemon_death_unverified");
+  assert.equal(stopped.stopAttempted, true);
+  assert.equal((await h.startAfterMaintenance({ context: h.context, expected })).ok, false);
+  assert.deepEqual(h.commands, ["stop"]);
+});
+
+test("malformed thread or queue metadata never certifies an empty workload", unixSocketHost, async t => {
+  const h = await maintenanceFixture(t);
+  for (const queueResponse of [{}, { data: null }, { data: [null] }, { data: [], nextCursor: "more" }]) {
+    h.state.queueResponse = queueResponse;
+    assert.equal((await h.inspectMaintenance(h.context))?.state, "unsupported");
+  }
+  delete h.state.queueResponse;
+  h.state.turns = [{ private: "content" }];
+  const observed = await h.inspectMaintenance(h.context);
+  assert.equal(observed?.state, "unsupported");
+  assert.equal(JSON.stringify(observed).includes("content"), false);
+});
+
+test("stop command failure preserves the attempted boundary for conservative recovery", unixSocketHost, async t => {
+  const h = await maintenanceFixture(t), expected = await h.inspectMaintenance(h.context);
+  assert.equal((await h.stopForMaintenance({ context: h.context })).stopAttempted, false);
+  for (const failure of ["stopFails", "stopThrows"]) {
+    h.state[failure] = true;
+    const result = await h.stopForMaintenance({ context: h.context, expected });
+    assert.equal(result.ok, false);
+    assert.equal(result.reasonCode, "daemon_stop_failed");
+    assert.equal(result.stopAttempted, true);
+    assert.equal(JSON.stringify(result).includes("private vendor"), false);
+    h.state[failure] = false;
+  }
+  assert.deepEqual(h.commands, ["stop", "stop"]);
+});

--- a/packages/adapter-gemini-cli/extension/gemini-extension.json
+++ b/packages/adapter-gemini-cli/extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Coordinate this Gemini CLI session with other AI agent sessions working in the same workspace.",
   "contextFileName": "skills/acc/SKILL.md"
 }

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-grok/package.json
+++ b/packages/adapter-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-grok",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/src/args.mjs
+++ b/packages/cli/src/args.mjs
@@ -58,7 +58,7 @@ export const COMMANDS = Object.freeze({
   uninstall: { required: [], optional: ["home"], repeated: ["adapter"], flags: ["dry-run"] },
   // Asking npm whether there is a newer ACC. The one command that touches the
   // network, and never on the hook path.
-  update: { required: [], optional: ["auto", "pin"], flags: ["check", "apply"] },
+  update: { required: [], optional: ["auto", "pin"], flags: ["check", "apply", "yes"] },
   // The two things a person types first after installing from a registry. The
   // CLI answered neither: `acc --version` and `acc --help` were both "unknown
   // command", and `acc` on its own asked for a command without naming one.

--- a/packages/cli/src/doctor-command.mjs
+++ b/packages/cli/src/doctor-command.mjs
@@ -15,7 +15,7 @@ import { ALL_ADAPTERS, clientContext, probeTimeout } from "./install-command.mjs
 import { describePresence } from "./main.mjs";
 import { platformPaths } from "./platform-paths.mjs";
 import { noticeUpdate } from "./update-check.mjs";
-import { activationBlockerNotice, listActivationBlockers } from "./managed-runtime/activation.mjs";
+import { managedUpdateDiagnostic } from "./managed-runtime/diagnostics.mjs";
 import { readControl } from "./managed-runtime/state.mjs";
 import { diagnoseFilesystemStore, repairFilesystemStore }
   from "@agents-can-communicate/storage-filesystem";
@@ -205,18 +205,10 @@ export async function runDoctor({ options, context, runtime }) {
     ? await runtime.version().catch(() => null)
     : null;
   const manager = runtime?.managerRoot ? await readControl(runtime.managerRoot) : null;
-  const blockers = manager?.pending
-    ? await listActivationBlockers(runtime.managerRoot, { ignorePid: process.pid }) : null;
   const update = manager === null
     ? await noticeUpdate({ dataHome, running, env: runtime?.env ?? {},
       now: Date.parse(clock.now()), get: runtime?.fetch, io: { readFile, writeFile, mkdir } })
-    : { checked: false, running, latest: manager.pending?.version ?? null,
-      newer: manager.pending !== null, auto: manager.auto, pin: manager.pin,
-      pending: manager.pending?.version ?? null, phase: manager.phase,
-      notice: blockers === null ? manager.notice : manager.phase === "activating" && !blockers.length
-        ? "Integration refresh is incomplete; run acc update to recover."
-        : activationBlockerNotice(manager.pending.version, blockers),
-      ...(blockers === null ? {} : { holds: blockers.length, blockers }) };
+    : await managedUpdateDiagnostic(runtime.managerRoot, manager, running);
 
   // Before the store is read for anything else. `collectStatus` reads every
   // record, so on the store this command exists to describe it threw first and

--- a/packages/cli/src/doctor-command.mjs
+++ b/packages/cli/src/doctor-command.mjs
@@ -15,6 +15,7 @@ import { ALL_ADAPTERS, clientContext, probeTimeout } from "./install-command.mjs
 import { describePresence } from "./main.mjs";
 import { platformPaths } from "./platform-paths.mjs";
 import { noticeUpdate } from "./update-check.mjs";
+import { activationBlockerNotice, listActivationBlockers } from "./managed-runtime/activation.mjs";
 import { readControl } from "./managed-runtime/state.mjs";
 import { diagnoseFilesystemStore, repairFilesystemStore }
   from "@agents-can-communicate/storage-filesystem";
@@ -204,12 +205,18 @@ export async function runDoctor({ options, context, runtime }) {
     ? await runtime.version().catch(() => null)
     : null;
   const manager = runtime?.managerRoot ? await readControl(runtime.managerRoot) : null;
+  const blockers = manager?.pending
+    ? await listActivationBlockers(runtime.managerRoot, { ignorePid: process.pid }) : null;
   const update = manager === null
     ? await noticeUpdate({ dataHome, running, env: runtime?.env ?? {},
       now: Date.parse(clock.now()), get: runtime?.fetch, io: { readFile, writeFile, mkdir } })
     : { checked: false, running, latest: manager.pending?.version ?? null,
       newer: manager.pending !== null, auto: manager.auto, pin: manager.pin,
-      pending: manager.pending?.version ?? null, phase: manager.phase, notice: manager.notice };
+      pending: manager.pending?.version ?? null, phase: manager.phase,
+      notice: blockers === null ? manager.notice : manager.phase === "activating" && !blockers.length
+        ? "Integration refresh is incomplete; run acc update to recover."
+        : activationBlockerNotice(manager.pending.version, blockers),
+      ...(blockers === null ? {} : { holds: blockers.length, blockers }) };
 
   // Before the store is read for anything else. `collectStatus` reads every
   // record, so on the store this command exists to describe it threw first and
@@ -276,7 +283,7 @@ export async function runDoctor({ options, context, runtime }) {
   ...adapters.filter(adapter => adapter.present && adapter.outgoingDelivery)
     .map(adapter => `  ${adapter.displayName} ${adapter.outgoingDelivery.diagnostic}`),
   ...(manager === null ? [] : [`  automatic updates ${manager.auto ? "on" : "off"}; ACC ${manager.active.version}`
-    + (manager.pin ? `; pinned to ${manager.pin}` : ""), ...(manager.notice ? [`  ${manager.notice}`] : [])]),
+    + (manager.pin ? `; pinned to ${manager.pin}` : ""), ...(update.notice ? [`  ${update.notice}`] : [])]),
   ...data.remediation.map(line => `  ${line}`),
   // `0 of 4` is a true line that reads as a broken machine, and on an
   // MCP-only one it would read that way on every run forever. The server needs

--- a/packages/cli/src/help.mjs
+++ b/packages/cli/src/help.mjs
@@ -106,6 +106,8 @@ const NOTES = Object.freeze({
     "Use acc update --check to only report whether a newer release exists.",
     "An initial acc install enables automatic updates; reinstalling preserves your choice. Activation waits for active clients and ACC processes.",
     "--auto on|off changes automatic updates; --pin VERSION holds an exact stable version; --pin none follows stable releases.",
+    "An eligible Codex service restart asks once; a detached worker waits for idle work and verifies completion. Open clients disconnect; acc doctor reports progress.",
+    "--yes explicitly consents to that restart without a prompt; --check never schedules maintenance.",
     "--apply remains accepted as a compatibility alias for acc update."],
 });
 

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -18,6 +18,7 @@ import { runUpdateCommand } from "./update-command.mjs";
 import { runConfigCommand } from "./config-command.mjs";
 import { runInstallCommand } from "./install-command.mjs";
 import { runDoctor } from "./doctor-command.mjs";
+import { runManagementDoctor } from "./managed-runtime/diagnostics.mjs";
 import { createGitProbe } from "./git-probe.mjs";
 import { canonicalClaim } from "./claim-spelling.mjs";
 import { platformDataHome, runtimePaths } from "./runtime-paths.mjs";
@@ -412,7 +413,8 @@ export async function main(argv, runtime) {
   let parsed;
   try {
     parsed = parseArgs(argv);
-    if (runtime.managementOnly && !["help", "version", "update"].includes(parsed.command)) {
+    const managementDoctor = runtime.managementOnly && parsed.command === "doctor" && !parsed.options.repair;
+    if (runtime.managementOnly && !managementDoctor && !["help", "version", "update"].includes(parsed.command)) {
       throw new AccError(EXIT.DATA, "runtime unavailable; retry after the update or run acc update to recover");
     }
     // `config` is the one command that must work on a workspace ACC cannot
@@ -423,7 +425,7 @@ export async function main(argv, runtime) {
     // discovery cannot open the workspace - that is what a user is trying to
     // find out - install touches client configuration rather than ACC state,
     // and `help` has to answer in a directory that is no workspace at all.
-    const context = NO_WORKSPACE.includes(parsed.command)
+    const context = managementDoctor || NO_WORKSPACE.includes(parsed.command)
       ? null
       : parsed.command === "doctor"
         ? await openDiagnosticContext(parsed.options, runtime)
@@ -434,7 +436,7 @@ export async function main(argv, runtime) {
     const options = context === null ? parsed.options
       : await resolveOwner({ command: parsed.command, options: parsed.options,
         context, env: runtime.env });
-    const { data, text, error: outcome } = await HANDLERS[parsed.command](
+    const { data, text, error: outcome } = await (managementDoctor ? runManagementDoctor : HANDLERS[parsed.command])(
       { options, context, runtime });
     // A handler may have done real work and still failed: `acc install` writes
     // for the clients it could and reports the one it could not. The data is

--- a/packages/cli/src/managed-runtime/activation.mjs
+++ b/packages/cli/src/managed-runtime/activation.mjs
@@ -95,7 +95,7 @@ async function prepareCandidate(control, root, env) {
   const file = path.join(control.pending.root, "node_modules", "@agents-can-communicate", "cli",
     "src", "managed-runtime", "refresh.mjs");
   const { prepareRefresh } = await import(pathToFileURL(file).href);
-  return prepareRefresh({ control, root, env });
+  return prepareRefresh({ control, root, env, callerProtocol: 2 });
 }
 // JSON parser diagnostics may quote private config bytes. Keep the cause and
 // known artifact paths, never the offending input or terminal control bytes.
@@ -109,7 +109,7 @@ const recipe = c => JSON.stringify([c.active, c.pending, c.home, c.targets, c.au
 
 /** Detection is outside the fence; every integration write and commit stays inside it. */
 export async function activatePending(root, { prepare = prepareCandidate, env = process.env,
-  pidIsAlive = defaultPidIsAlive, ignorePid = null } = {}) {
+  pidIsAlive = defaultPidIsAlive, ignorePid = null, beforeActivation = null } = {}) {
   root = await canonicalManagerRoot(root);
   const before = await readControl(root);
   if (!before?.pending) return { activated: false, reason: "no_pending_update" };
@@ -117,6 +117,7 @@ export async function activatePending(root, { prepare = prepareCandidate, env = 
   return withManagerLock(root, async () => {
     const current = await readControl(root);
     if (!current || recipe(current) !== recipe(before)) return { activated: false, reason: "state_changed" };
+    if (beforeActivation) await beforeActivation(current);
     const blockers = await listActivationBlockers(root, { pidIsAlive, ignorePid });
     if (blockers.length) {
       const notice = activationBlockerNotice(current.pending.version, blockers);

--- a/packages/cli/src/managed-runtime/activation.mjs
+++ b/packages/cli/src/managed-runtime/activation.mjs
@@ -53,6 +53,44 @@ export async function listNativeHolds(root, { pidIsAlive = defaultPidIsAlive } =
   return holds;
 }
 
+/** Activation calls this under the admission mutex; diagnostics are a snapshot.
+ * The updater may ignore its own leases, never a native client's lifetime.
+ * Project only process facts: leases and bindings carry private owner tokens.
+ */
+export async function listActivationBlockers(root, { pidIsAlive = defaultPidIsAlive, ignorePid = null } = {}) {
+  const leases = (await listRuntimeHolds(root, { pidIsAlive })).filter(lease => lease.pid !== ignorePid);
+  const native = await listNativeHolds(root, { pidIsAlive });
+  const holds = [...leases.map(({ pid, kind }) => ({ pid, kind, nativeBindings: 0 })),
+    ...native.map(hold => ({ ...hold, nativeBindings: hold.reason === "unknown_workspace" ? 0 : 1 }))];
+  const byPid = new Map(), unidentified = [];
+  for (const hold of holds) {
+    const pid = hold.pid ?? null;
+    const nativeBindings = hold.nativeBindings;
+    if (pid === null) {
+      unidentified.push({ pid, kinds: [hold.kind], reason: hold.reason, nativeBindings });
+      continue;
+    }
+    const blocker = byPid.get(pid) ?? { pid, kinds: [], reason: "process_running", nativeBindings: 0 };
+    if (!blocker.kinds.includes(hold.kind)) blocker.kinds.push(hold.kind);
+    blocker.nativeBindings += nativeBindings;
+    byPid.set(pid, blocker);
+  }
+  return [...byPid.values()].sort((a, b) => a.pid - b.pid)
+    .map(blocker => ({ ...blocker, kinds: blocker.kinds.sort() })).concat(unidentified);
+}
+
+export function activationBlockerNotice(version, blockers) {
+  if (!blockers.length) return `ACC ${version} is ready; no active or unidentified processes are blocking activation.`;
+  const details = blockers.slice(0, 10).map(blocker => {
+    const facts = [blocker.kinds.map(safeText).join(", ")];
+    if (blocker.nativeBindings) facts.push(`${blocker.nativeBindings} native binding${blocker.nativeBindings === 1 ? "" : "s"}`);
+    if (blocker.pid === null) facts.push(blocker.reason.replaceAll("_", " "));
+    return `${blocker.pid === null ? "unidentified process" : `PID ${blocker.pid}`} (${facts.join("; ")})`;
+  });
+  return `ACC ${version} is ready; waiting for ${blockers.length} active or unidentified process(es): `
+    + details.join("; ") + (blockers.length > 10 ? `; and ${blockers.length - 10} more` : "") + ".";
+}
+
 async function prepareCandidate(control, root, env) {
   const file = path.join(control.pending.root, "node_modules", "@agents-can-communicate", "cli",
     "src", "managed-runtime", "refresh.mjs");
@@ -79,12 +117,11 @@ export async function activatePending(root, { prepare = prepareCandidate, env = 
   return withManagerLock(root, async () => {
     const current = await readControl(root);
     if (!current || recipe(current) !== recipe(before)) return { activated: false, reason: "state_changed" };
-    const holds = (await listRuntimeHolds(root, { pidIsAlive })).filter(lease => lease.pid !== ignorePid);
-    holds.push(...await listNativeHolds(root, { pidIsAlive }));
-    if (holds.length) {
-      const notice = `ACC ${current.pending.version} is ready; waiting for ${holds.length} active or unidentified process(es).`;
+    const blockers = await listActivationBlockers(root, { pidIsAlive, ignorePid });
+    if (blockers.length) {
+      const notice = activationBlockerNotice(current.pending.version, blockers);
       await writeControl(root, { ...current, notice });
-      return { activated: false, reason: "processes_active", holds: holds.length, notice };
+      return { activated: false, reason: "processes_active", holds: blockers.length, blockers, notice };
     }
     const activating = { ...current, phase: "activating", notice: "Finishing integration refresh." };
     await writeControl(root, activating);

--- a/packages/cli/src/managed-runtime/command.mjs
+++ b/packages/cli/src/managed-runtime/command.mjs
@@ -4,8 +4,13 @@ import { withManagerLock } from "./mutex.mjs";
 import { scheduleWorker } from "./schedule.mjs";
 import { readControl, writeControl } from "./state.mjs";
 import { performUpdate, runWorker } from "./worker.mjs";
+import { requestMaintenance } from "./maintenance.mjs";
+import { retireLegacyUpdateWorker, stageNewerManagementRuntime } from "./management-recovery.mjs";
 
 export function validateUpdateOptions(options) {
+  if (options.yes && (options.check || options.auto !== undefined || options.pin !== undefined)) {
+    throw new AccError(EXIT.USAGE, "--yes only consents to client maintenance during acc update");
+  }
   if (options.auto !== undefined && !["on", "off"].includes(options.auto)) {
     throw new AccError(EXIT.USAGE, "--auto expects on or off");
   }
@@ -40,9 +45,15 @@ export async function runManagedUpdate({ options, runtime }) {
       return { data: { auto: control.auto, pin: control.pin, running: control.active.version },
         text: `Automatic updates ${control.auto ? "on" : "off"}. ${control.pin ? `Pinned to ${control.pin}.` : "Following stable releases."}` };
     }
+    if (!options.check) await stageNewerManagementRuntime(root, runtime);
     const result = options.check
       ? await performUpdate(root, { check: true, env })
       : await runWorker(root, { force: true, env, ignorePid: process.pid });
+    if (!options.check && (result.reason === "processes_active" || result.reason === "maintenance_pending"
+      || result.activated || result.checked && !result.newer)) {
+      const maintenance = await requestMaintenance({ root, control: await readControl(root), options, runtime });
+      if (maintenance) return maintenance;
+    }
     const text = result.activated ? `Updated ACC to ${result.version}; integrations refreshed.`
       : result.notice && result.reason === "processes_active" ? result.notice
         : result.reason === "refresh_failed" ? [result.notice,
@@ -57,6 +68,10 @@ export async function runManagedUpdate({ options, runtime }) {
       ...(result.reason === "refresh_failed" ? { error: new AccError(EXIT.DATA, text) } : {}) };
   } catch (error) {
     if (/manager lock held/.test(error.message)) {
+      if (!options.check && options.auto === undefined && options.pin === undefined && !runtime.legacyWorkerRetried
+        && await retireLegacyUpdateWorker(root).catch(() => false)) {
+        return runManagedUpdate({ options, runtime: { ...runtime, legacyWorkerRetried: true } });
+      }
       return { data: { inProgress: true }, text: "An update is already in progress; ACC will activate it when running clients exit." };
     }
     throw error instanceof AccError ? error : new AccError(EXIT.DATA, error.message);

--- a/packages/cli/src/managed-runtime/diagnostics.mjs
+++ b/packages/cli/src/managed-runtime/diagnostics.mjs
@@ -1,0 +1,35 @@
+import { activationBlockerNotice, listActivationBlockers } from "./activation.mjs";
+import { MAINTENANCE_ACTIVE, maintenanceNotice, maintenanceReport, readMaintenance } from "./maintenance-state.mjs";
+import { readControl } from "./state.mjs";
+
+/** Available when workspace admission is fenced, and from a newer management
+ * implementation before activation. Never opens a workspace or probes clients.
+ */
+export async function runManagementDoctor({ runtime }) {
+  const manager = await readControl(runtime.managerRoot);
+  if (!manager) throw new Error("managed update state is unavailable; run acc update to recover");
+  const update = await managedUpdateDiagnostic(runtime.managerRoot, manager, manager.active.version);
+  return { data: { scope: "update", workspaceInspection: "unavailable_during_update", update,
+    remediation: ["acc update"] },
+  text: ["Update diagnostics only; workspace and integrations were not inspected.",
+    update.notice ?? `ACC ${manager.active.version}; update phase ${manager.phase}.`,
+    "Run acc update to finish, then acc doctor for the full workspace report."].join("\n") };
+}
+
+export async function managedUpdateDiagnostic(root, manager, running) {
+  const blockers = manager.pending ? await listActivationBlockers(root, { ignorePid: process.pid }) : null;
+  const update = { checked: false, running, latest: manager.pending?.version ?? null,
+    newer: manager.pending !== null, auto: manager.auto, pin: manager.pin,
+    pending: manager.pending?.version ?? null, phase: manager.phase,
+    notice: blockers === null ? manager.notice : manager.phase === "activating" && !blockers.length
+      ? "Integration refresh is incomplete; run acc update to recover."
+      : activationBlockerNotice(manager.pending.version, blockers),
+    ...(blockers === null ? {} : { holds: blockers.length, blockers }) };
+  const maintenance = await readMaintenance(root);
+  if (maintenance && (maintenance.target.root === (manager.pending ?? manager.active).root
+    || MAINTENANCE_ACTIVE.includes(maintenance.status))) {
+    update.maintenance = maintenanceReport(maintenance);
+    update.notice = maintenanceNotice(maintenance);
+  }
+  return update;
+}

--- a/packages/cli/src/managed-runtime/entry.mjs
+++ b/packages/cli/src/managed-runtime/entry.mjs
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { scheduleWorker } from "./schedule.mjs";
 import { acquireRuntime } from "./leases.mjs";
-import { canonicalManagerRoot, readControl } from "./state.mjs";
+import { canonicalManagerRoot, readControl, readManagedJson } from "./state.mjs";
 
 export const ENTRY_KINDS = Object.freeze([
   "acc", "acc-hook", "acc-mcp", "acc-bootstrap", "acc-claude-channel",
@@ -53,6 +53,31 @@ function unavailable(kind) {
   }
 }
 
+const stableVersion = value => typeof value === "string" && /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(value);
+function newerVersion(left, right) {
+  if (!stableVersion(left) || !stableVersion(right)) return false;
+  const a = left.split(".").map(BigInt), b = right.split(".").map(BigInt);
+  for (let index = 0; index < 3; index++) if (a[index] !== b[index]) return a[index] > b[index];
+  return false;
+}
+
+/** Pending means downloaded and verified. Older packages do not advertise this
+ * management-only protocol; never load them speculatively for workspace work.
+ */
+async function updateImplementation(packageRoot, control) {
+  let selected = null;
+  for (const candidate of [{ root: packageRoot }, control.pending].filter(candidate => candidate?.root)) {
+    try {
+      const manifest = await readManagedJson(path.join(candidate.root, "package.json"));
+      if (manifest?.name !== "agents-can-communicate" || manifest.accManagedUpdateProtocol !== 2
+        || candidate.version !== undefined && manifest.version !== candidate.version
+        || !newerVersion(manifest.version, selected?.version ?? control.active.version)) continue;
+      selected = { root: candidate.root, version: manifest.version };
+    } catch { /* Unreadable alternatives leave the active implementation available. */ }
+  }
+  return selected?.root ?? null;
+}
+
 /** The lease lasts until OS process death, including callbacks after main returns. */
 export async function runEntry({ kind, packageRoot, managerRoot, managedRequired = false }) {
   if (!ENTRY_KINDS.includes(kind)) throw new Error("unknown ACC entry point");
@@ -66,6 +91,7 @@ export async function runEntry({ kind, packageRoot, managerRoot, managedRequired
   }
   let selected = packageRoot;
   let managed = null;
+  let managementOnly = false;
   let root;
   try {
     const requestedDataHome = bootstrapOptions === null ? null : await canonicalManagerRoot(bootstrapOptions.dataHome);
@@ -81,12 +107,18 @@ export async function runEntry({ kind, packageRoot, managerRoot, managedRequired
     if (control !== null) {
       selected = control.active.root;
       managed = root;
-      const lease = await acquireRuntime(root, { pid: process.pid, kind });
-      selected = lease.runtime.root;
-      managed = root;
-      const quiet = kind === "acc" && ["update", "install", "uninstall", "help", "version",
-        "--help", "-h", "--version", "-v", "-V"].includes(process.argv[2]);
-      if (!quiet) await scheduleWorker(root, control);
+      const update = kind === "acc" && ["update", "doctor"].includes(process.argv[2])
+        ? await updateImplementation(packageRoot, control) : null;
+      if (update !== null) {
+        selected = update;
+        managementOnly = true;
+      } else {
+        const lease = await acquireRuntime(root, { pid: process.pid, kind });
+        selected = lease.runtime.root;
+        const quiet = kind === "acc" && ["update", "install", "uninstall", "help", "version",
+          "--help", "-h", "--version", "-v", "-V"].includes(process.argv[2]);
+        if (!quiet) await scheduleWorker(root, control);
+      }
     } else if (managedRequired) throw new Error("managed runtime is not initialized");
   } catch {
     // Help and update recovery must remain reachable when state cannot admit a
@@ -106,5 +138,5 @@ export async function runEntry({ kind, packageRoot, managerRoot, managedRequired
     return;
   }
   const runtime = await import(pathToFileURL(path.join(selected, "bin", "entrypoints", `${kind}.mjs`)).href);
-  await runtime.main({ managerRoot: managed, packageRoot: selected });
+  await runtime.main({ managerRoot: managed, packageRoot: selected, ...(managementOnly ? { managementOnly } : {}) });
 }

--- a/packages/cli/src/managed-runtime/legacy-maintenance.mjs
+++ b/packages/cli/src/managed-runtime/legacy-maintenance.mjs
@@ -1,0 +1,47 @@
+import { realpath } from "node:fs/promises";
+import path from "node:path";
+import { askConfirmation } from "../confirm.mjs";
+import { ALL_ADAPTERS } from "../install-command.mjs";
+import { MAINTENANCE_ACTIVE, readMaintenance } from "./maintenance-state.mjs";
+
+const inspectServices = async options => (await import("./maintenance.mjs")).inspectMaintenanceServices(options);
+const request = async options => (await import("./maintenance.mjs")).requestMaintenance(options);
+const handoff = () => Object.assign(new Error("ACC maintenance needs confirmation or recovery; run acc update."),
+  { code: "ACC_LEGACY_MAINTENANCE_HANDOFF" });
+
+async function isLegacyWorker(argv, control, root) {
+  if (argv.length !== 3) return false;
+  try {
+    return await realpath(argv[1]) === await realpath(path.join(control.active.root, "bin", "acc-update-worker.mjs"))
+      && await realpath(argv[2]) === await realpath(root);
+  } catch { return false; }
+}
+
+/** Old activation imports this candidate before taking its admission fence.
+ * Only request/schedule here: the detached job waits for this process to exit.
+ * Throwing in the old background worker unwinds its idle-loop lock normally.
+ */
+export async function bridgeLegacyMaintenance({ control, root, env = process.env, callerProtocol = 1 }, {
+  argv = process.argv, input = process.stdin, output = process.stdout,
+  inspect = inspectServices, requestMaintenance = request,
+} = {}) {
+  if (callerProtocol >= 2) return null;
+  const worker = await isLegacyWorker(argv, control, root);
+  const interactive = argv[2] === "update" && !argv.includes("--json")
+    && input.isTTY === true && output.isTTY === true;
+  if (!worker && !interactive) return null;
+  const existing = await readMaintenance(root);
+  let services;
+  if (!MAINTENANCE_ACTIVE.includes(existing?.status)) {
+    if (!control.pending) return null;
+    services = await inspect({ root, control, env, adapters: ALL_ADAPTERS() });
+    if (!services.length) return null;
+    if (worker) throw handoff();
+  }
+  const result = await requestMaintenance({ root, control, options: { json: false }, services,
+    runtime: { env, input, output, confirm: askConfirmation,
+      isInteractive: () => interactive, packageRoot: control.pending?.root ?? control.active.root } });
+  if (worker) throw handoff();
+  if (result?.text) output.write(`${result.text}\n`);
+  return result;
+}

--- a/packages/cli/src/managed-runtime/maintenance-state.mjs
+++ b/packages/cli/src/managed-runtime/maintenance-state.mjs
@@ -1,0 +1,57 @@
+import path from "node:path";
+import { managedDirectory, readManagedJson, validateRuntime, writeManagedJson } from "./state.mjs";
+
+export const MAINTENANCE_ACTIVE = ["waiting", "stopping", "refreshing", "restarting", "recovery"];
+const statuses = [...MAINTENANCE_ACTIVE, "completed", "failed", "cancelled"];
+export const maintenanceRecipe = c => JSON.stringify([c.active, c.pending, c.home, c.targets, c.auto, c.pin]);
+
+export async function readMaintenance(root) {
+  if (!await managedDirectory(root)) return null;
+  const value = await readManagedJson(path.join(root, "maintenance.json"));
+  if (value === undefined) return null;
+  if (value.schemaVersion !== 1 || typeof value.id !== "string" || !/^[a-f0-9-]{36}$/.test(value.id)
+    || !statuses.includes(value.status) || typeof value.recipe !== "string"
+    || typeof value.workerRoot !== "string" || !path.isAbsolute(value.workerRoot)
+    || !Number.isFinite(value.deadline) || !Number.isSafeInteger(value.callerPid) || value.callerPid < 1
+    || !(value.workerPid === null || Number.isSafeInteger(value.workerPid) && value.workerPid > 0)
+    || !Array.isArray(value.services) || value.services.length !== 1
+    || !value.services.every(s => typeof s.adapterId === "string" && s.snapshot
+      && Number.isSafeInteger(s.snapshot.pid) && s.snapshot.pid > 0)
+    || !Array.isArray(value.attempted) || !value.attempted.every(id => value.services.some(s => s.adapterId === id))) {
+    throw new Error("invalid update maintenance record");
+  }
+  await validateRuntime(root, value.target);
+  return value;
+}
+
+/** Caller holds the admission mutex or the exclusive maintenance-worker lock. */
+export async function writeMaintenance(root, job) {
+  await writeManagedJson(path.join(root, "maintenance.json"), job);
+  return job;
+}
+
+export function maintenanceReport(job) {
+  return { id: job.id, status: job.status, version: job.target.version,
+    reasonCode: job.reasonCode ?? null, workerPid: job.workerPid,
+    ...(job.status === "waiting" && job.waiting ? { waiting: job.waiting } : {}),
+    services: job.services.map(({ adapterId, snapshot }) => ({ adapterId,
+      serviceId: snapshot.serviceId, pid: snapshot.pid, clientVersion: snapshot.cliVersion,
+      serverVersion: snapshot.serverVersion })) };
+}
+
+export function maintenanceNotice(job) {
+  const version = job.target.version;
+  if (job.status === "completed") return `ACC ${version} update maintenance completed; the client service was restarted and verified.`;
+  if (job.status === "cancelled") return `Update maintenance cancelled (${job.reasonCode}); no client service was stopped.`;
+  if (job.status === "failed") return `Update maintenance failed (${job.reasonCode}); run acc update to retry.`;
+  if (job.status === "recovery") return `Client service recovery is pending (${job.reasonCode}); run acc update to retry recovery.`;
+  if (job.status === "waiting") {
+    const waiting = job.waiting?.reason === "service_busy" ? `idle client work (${job.waiting.busyThreads ?? "unknown"} active turns, ${job.waiting.queuedRequests ?? "unknown"} queued requests)`
+      : job.waiting?.reason === "other_processes" ? `${job.waiting.processes} other or unidentified process(es) to exit`
+        : job.waiting?.reason === "caller_exit" ? "the requesting command to exit"
+          : job.waiting?.reason === "update_worker" ? "another ACC updater"
+            : "idle clients and other ACC processes to exit";
+    return `ACC ${version} update maintenance is scheduled; waiting for ${waiting}. Open clients will disconnect during restart. Check acc doctor for progress.`;
+  }
+  return `ACC ${version} update maintenance: ${job.status}. Check acc doctor for the result.`;
+}

--- a/packages/cli/src/managed-runtime/maintenance-worker.mjs
+++ b/packages/cli/src/managed-runtime/maintenance-worker.mjs
@@ -1,0 +1,110 @@
+import { ALL_ADAPTERS } from "../install-command.mjs";
+import { activatePending, listActivationBlockers } from "./activation.mjs";
+import { confirmedDead, defaultPidIsAlive, withManagerLock } from "./mutex.mjs";
+import { readControl } from "./state.mjs";
+import { maintenanceContext } from "./maintenance.mjs";
+import { MAINTENANCE_ACTIVE, maintenanceRecipe, readMaintenance, writeMaintenance } from "./maintenance-state.mjs";
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+const deferred = waiting => Object.assign(new Error("maintenance waiting"), { code: "MAINTENANCE_WAIT", waiting });
+const refused = reasonCode => Object.assign(new Error("maintenance refused"), { reasonCode });
+
+/** No runtime lease: this worker must outlive the client that requested it.
+ * Its own mutex serializes checkpoints; admission remains separately fenced.
+ */
+export async function runMaintenance(root, { jobId, env = process.env, adapters = ALL_ADAPTERS(),
+  pidIsAlive = defaultPidIsAlive, pause = sleep, now = Date.now, activate = activatePending } = {}) {
+  return withManagerLock(`${root}/maintenance-worker`, async () => {
+    let job;
+    // Publication owns admission until spawn's PID is durable. Wait for it
+    // before writing checkpoints, including when recovering an older job.
+    await withManagerLock(root, async () => {
+      job = await readMaintenance(root);
+      if (job && (!jobId || job.id === jobId) && MAINTENANCE_ACTIVE.includes(job.status)) {
+        job = await writeMaintenance(root, { ...job, workerPid: process.pid });
+      }
+    });
+    if (!job || jobId && job.id !== jobId || !MAINTENANCE_ACTIVE.includes(job.status)) return job;
+    const save = async changes => { job = await writeMaintenance(root, { ...job, ...changes }); return job; };
+    const waitFor = async waiting => {
+      if (JSON.stringify(job.waiting) !== JSON.stringify(waiting)) await save({ waiting });
+      await pause(1000);
+    };
+    const adapter = adapters.find(a => a.id === job.services[0].adapterId);
+    if (!adapter?.stopForMaintenance || !adapter.startAfterMaintenance) return save({ status: "failed", reasonCode: "maintenance_adapter_unavailable" });
+    const expected = job.services[0].snapshot;
+    let control = await readControl(root);
+    const context = maintenanceContext(control, env);
+
+    async function restore(result, reasonCode = null) {
+      await save({ status: "restarting", reasonCode });
+      let restarted;
+      try { restarted = await adapter.startAfterMaintenance({ context, expected }); }
+      catch { restarted = { ok: false, reasonCode: "service_start_failed" }; }
+      if (!restarted?.ok) return save({ status: "recovery", reasonCode: restarted?.reasonCode ?? "service_start_failed" });
+      return save({ status: result?.activated ? "completed" : "failed",
+        reasonCode: result?.activated ? null : reasonCode ?? result?.reason ?? "update_incomplete" });
+    }
+
+    // A crash after the stop checkpoint can mean either side of the command.
+    // Never repeat it. Forward repair still obeys native/ACC lifetime fences,
+    // then the idempotent adapter start restores the already-approved service.
+    if (job.attempted.length) {
+      let result;
+      try {
+        control = await readControl(root);
+        if (!control.pending && control.active.root === job.target.root && control.phase === "ready") result = { activated: true };
+        else if (maintenanceRecipe(control) === job.recipe) {
+          result = await withManagerLock(`${root}/worker`, () => activate(root, { env, pidIsAlive }));
+        }
+      } catch { /* Restoration still runs when forward repair is unavailable. */ }
+      return restore(result, result?.reason ?? "maintenance_interrupted");
+    }
+
+    for (;;) {
+      control = await readControl(root);
+      if (maintenanceRecipe(control) !== job.recipe) return save({ status: "cancelled", reasonCode: "update_state_changed" });
+      if (now() > job.deadline) return save({ status: "cancelled", reasonCode: "idle_wait_expired" });
+      if (!await confirmedDead(job.callerPid, pidIsAlive)) { await waitFor({ reason: "caller_exit" }); continue; }
+      let result;
+      try {
+        result = await withManagerLock(`${root}/worker`, async () => {
+          const beforeActivation = async current => {
+            if (maintenanceRecipe(current) !== job.recipe) throw refused("update_state_changed");
+            const blockers = await listActivationBlockers(root, { pidIsAlive });
+            const others = blockers.filter(b => b.pid !== expected.pid || b.kinds.some(kind => kind !== "native"));
+            if (others.length) throw deferred({ reason: "other_processes", processes: others.length });
+            const snapshot = await adapter.inspectMaintenance(context);
+            if (snapshot?.state === "busy") throw deferred({ reason: "service_busy",
+              busyThreads: snapshot.busyThreads, queuedRequests: snapshot.queuedRequests });
+            if (snapshot?.state !== "ready") throw refused("service_readiness_changed");
+            // Durable before the vendor command: recovery restores without
+            // assuming whether the previous worker reached the actual stop.
+            await save({ status: "stopping", attempted: [adapter.id], waiting: null });
+            const stopped = await adapter.stopForMaintenance({ context, expected });
+            if (stopped?.ok === false && stopped.stopAttempted === false) {
+              await save({ status: "waiting", attempted: [] });
+              if (stopped.reasonCode === "service_busy") throw deferred({ reason: "service_busy",
+                busyThreads: stopped.snapshot?.busyThreads, queuedRequests: stopped.snapshot?.queuedRequests });
+            }
+            if (!stopped?.ok) throw refused(stopped?.reasonCode ?? "service_stop_failed");
+            await save({ status: "refreshing" });
+          };
+          if (control.pending) return activate(root, { env, pidIsAlive, beforeActivation });
+          return withManagerLock(root, async () => {
+            await beforeActivation(await readControl(root));
+            return { activated: true, version: control.active.version };
+          });
+        }, { timeoutMs: 100 });
+      } catch (error) {
+        if (!job.attempted.length && (error.code === "MAINTENANCE_WAIT" || /manager lock held/.test(error.message))) {
+          await waitFor(error.waiting ?? { reason: "update_worker" }); continue;
+        }
+        if (job.attempted.length) return restore(null, error.reasonCode ?? "maintenance_failed");
+        return save({ status: "failed", reasonCode: error.reasonCode ?? "maintenance_failed" });
+      }
+      if (job.attempted.length) return restore(result);
+      return save({ status: "cancelled", reasonCode: result?.reason ?? "update_state_changed" });
+    }
+  }, { timeoutMs: 100, pidIsAlive });
+}

--- a/packages/cli/src/managed-runtime/maintenance.mjs
+++ b/packages/cli/src/managed-runtime/maintenance.mjs
@@ -1,0 +1,92 @@
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { ALL_ADAPTERS } from "../install-command.mjs";
+import { listActivationBlockers } from "./activation.mjs";
+import { confirmedDead, withManagerLock } from "./mutex.mjs";
+import { readControl, readManagedJson } from "./state.mjs";
+import { MAINTENANCE_ACTIVE, maintenanceNotice, maintenanceRecipe, maintenanceReport,
+  readMaintenance, writeMaintenance } from "./maintenance-state.mjs";
+
+export function maintenanceContext(control, env) {
+  return { home: control.home, env, platform: `${process.platform}-${process.arch}` };
+}
+
+export async function inspectMaintenanceServices({ control, env = process.env, root, adapters = ALL_ADAPTERS() }) {
+  const blockers = await listActivationBlockers(root, { ignorePid: process.pid });
+  const services = [];
+  for (const adapter of adapters.filter(a => control.targets.includes(a.id) && a.inspectMaintenance)) {
+    const snapshot = await adapter.inspectMaintenance(maintenanceContext(control, env));
+    if (!snapshot || !["ready", "busy"].includes(snapshot.state)) continue;
+    if (snapshot.serverVersion !== snapshot.cliVersion
+      || blockers.some(b => b.pid === snapshot.pid && b.kinds.includes("native"))) {
+      services.push({ adapterId: adapter.id, snapshot });
+    }
+  }
+  return services;
+}
+
+export async function spawnMaintenance({ root, job, packageRoot, env }) {
+  packageRoot = job.workerRoot ?? packageRoot;
+  const manifest = await readManagedJson(path.join(packageRoot, "package.json"));
+  if (manifest?.name !== "agents-can-communicate" || manifest.accManagedUpdateProtocol !== 2) {
+    throw new Error("maintenance worker implementation is unavailable");
+  }
+  const child = spawn(process.execPath, [path.join(packageRoot, "bin", "acc-maintenance-worker.mjs"), root, job.id],
+    { env, cwd: root, detached: true, stdio: "ignore" });
+  await new Promise((resolve, reject) => { child.once("spawn", resolve); child.once("error", reject); });
+  child.unref();
+  return child.pid;
+}
+
+const response = job => ({ data: { reason: "maintenance_pending", maintenance: maintenanceReport(job) }, text: maintenanceNotice(job) });
+
+async function launch(root, job, runtime) {
+  if (job.workerPid !== null && !await confirmedDead(job.workerPid)) return job;
+  try {
+    // The child reads after publication; a separate lifetime lock prevents a
+    // second command from creating two workers or overwriting its checkpoint.
+    const workerPid = await (runtime.spawnMaintenance ?? spawnMaintenance)({ root, job,
+      packageRoot: runtime.packageRoot, env: runtime.env ?? process.env });
+    return writeMaintenance(root, { ...job, workerPid });
+  } catch {
+    return writeMaintenance(root, { ...job, status: job.attempted.length ? "recovery" : "failed",
+      reasonCode: "maintenance_worker_start_failed" });
+  }
+}
+
+/** Explicit command only. Background inspection never grants restart consent. */
+export async function requestMaintenance({ root, control, options, runtime, services }) {
+  const existing = await readMaintenance(root);
+  if (existing && MAINTENANCE_ACTIVE.includes(existing.status)) {
+    return withManagerLock(root, async () => {
+      const latest = await readMaintenance(root);
+      if (!latest || !MAINTENANCE_ACTIVE.includes(latest.status)) return latest ? response(latest) : null;
+      return response(await launch(root, latest, runtime));
+    });
+  }
+  services ??= await inspectMaintenanceServices({ root, control, env: runtime.env, adapters: runtime.adapters });
+  if (services.length !== 1) return null; // More than one service needs a separate captured contract.
+  const names = services.map(s => s.snapshot.serviceId).join(", ");
+  if (!options.yes) {
+    if (options.json || runtime.isInteractive?.() !== true) return {
+      data: { reason: "confirmation_required", services: services.map(s => ({ adapterId: s.adapterId, serviceId: s.snapshot.serviceId })) },
+      text: `Finishing the update requires restarting ${names}, disconnecting open clients. Run acc update in a terminal to confirm, or acc update --yes to consent explicitly.` };
+    const approved = await runtime.confirm?.(`Restart ${names} to finish updating ACC? Open clients will disconnect; ACC will wait for idle turns, refresh integrations, restart the service and verify it. A turn started during the final restart check can be interrupted.`,
+      { input: runtime.input, output: runtime.output });
+    if (approved !== true) return { data: { reason: "maintenance_declined" },
+      text: "Client restart declined; the update remains pending until running clients exit." };
+  }
+  return withManagerLock(root, async () => {
+    const current = await readControl(root), previous = await readMaintenance(root);
+    if (previous && MAINTENANCE_ACTIVE.includes(previous.status)) return response(previous);
+    if (maintenanceRecipe(current) !== maintenanceRecipe(control)) return {
+      data: { reason: "state_changed" }, text: "Update settings changed before confirmation; run acc update again." };
+    const job = await writeMaintenance(root, { schemaVersion: 1, id: randomUUID(), status: "waiting",
+      target: current.pending ?? current.active, recipe: maintenanceRecipe(current), services,
+      workerRoot: runtime.packageRoot,
+      approvedAt: new Date().toISOString(), deadline: Date.now() + 15 * 60_000,
+      callerPid: process.pid, workerPid: null, attempted: [], reasonCode: null });
+    return response(await launch(root, job, runtime));
+  });
+}

--- a/packages/cli/src/managed-runtime/management-recovery.mjs
+++ b/packages/cli/src/managed-runtime/management-recovery.mjs
@@ -1,0 +1,71 @@
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { promisify } from "node:util";
+import { newerVersion } from "./download.mjs";
+import { stageOwnGeneration } from "./generation.mjs";
+import { verifyGeneration } from "./install.mjs";
+import { confirmedDead, withManagerLock } from "./mutex.mjs";
+import { readControl, readManagedJson, writeControl } from "./state.mjs";
+
+/** A newly installed global CLI can supersede an older pending release locally.
+ * No workspace code or integration is admitted until normal activation passes.
+ */
+export async function stageNewerManagementRuntime(root, { packageRoot, env }) {
+  if (!packageRoot) return false;
+  const before = await readControl(root);
+  const manifest = await readManagedJson(path.join(packageRoot, "package.json"));
+  if (before?.phase !== "ready" || manifest?.name !== "agents-can-communicate"
+    || manifest.accManagedUpdateProtocol !== 2 || before.pin && before.pin !== manifest.version
+    || !newerVersion(manifest.version, before.pending?.version ?? before.active.version)) return false;
+  const candidate = await stageOwnGeneration({ packageRoot, managerRoot: root });
+  await verifyGeneration(candidate, { env });
+  return withManagerLock(root, async () => {
+    const current = await readControl(root);
+    if (current.phase !== "ready" || current.pin !== before.pin
+      || JSON.stringify([current.active, current.pending]) !== JSON.stringify([before.active, before.pending])) return false;
+    await writeControl(root, { ...current, pending: { root: candidate.root, version: candidate.version },
+      notice: `ACC ${candidate.version} is verified and ready to activate.` });
+    return true;
+  });
+}
+
+async function inspectWorker(pid) {
+  try {
+    const { stdout } = await promisify(execFile)("/bin/ps", ["-p", String(pid), "-o", "uid=,lstart=,command="],
+      { timeout: 2000, maxBuffer: 16384 });
+    const match = /^\s*(\d+)\s+(.{24})\s+(.+)\s*$/.exec(stdout);
+    return match ? { uid: Number(match[1]), start: match[2], command: match[3] } : null;
+  } catch { return null; }
+}
+
+/** 0.4.2/0.4.3 kept this ACC-owned worker lock while sleeping indefinitely.
+ * Retire only an exactly identified old helper, under the admission mutex in
+ * ready phase. Never interrupt integration writes, a client, or an unknown PID.
+ */
+export async function retireLegacyUpdateWorker(root, { inspect = inspectWorker,
+  signal = pid => process.kill(pid, "SIGTERM"), pause = ms => new Promise(resolve => setTimeout(resolve, ms)) } = {}) {
+  return withManagerLock(root, async () => {
+    const control = await readControl(root);
+    if (control?.phase !== "ready") return false;
+    const manifest = await readManagedJson(path.join(control.active.root, "package.json"));
+    if (manifest?.accManagedUpdateProtocol === 2) return false;
+    const ownerFile = path.join(root, "worker", "manager.lock", "owner.json");
+    const owner = await readManagedJson(ownerFile);
+    if (!Number.isSafeInteger(owner?.pid) || owner.pid < 2 || owner.pid === process.pid
+      || typeof owner.token !== "string" || !Number.isFinite(Date.parse(owner.acquiredAt))) return false;
+    const observed = await inspect(owner.pid);
+    const suffix = ` ${path.join(control.active.root, "bin", "acc-update-worker.mjs")} ${root}`;
+    const executable = observed?.command.endsWith(suffix) ? observed.command.slice(0, -suffix.length) : null;
+    const elapsed = Date.parse(owner.acquiredAt) - Date.parse(observed?.start);
+    if (!executable || !path.isAbsolute(executable) || path.basename(executable) !== "node"
+      || observed.uid !== process.getuid?.() || !Number.isFinite(elapsed) || elapsed < 0 || elapsed > 60_000) return false;
+    if (JSON.stringify(await readManagedJson(ownerFile)) !== JSON.stringify(owner)
+      || JSON.stringify(await inspect(owner.pid)) !== JSON.stringify(observed)) return false;
+    signal(owner.pid);
+    for (let attempt = 0; attempt < 40; attempt++) {
+      if (await confirmedDead(owner.pid)) return true;
+      await pause(50);
+    }
+    return false; // Normal mutex reclamation still requires confirmed death.
+  });
+}

--- a/packages/cli/src/managed-runtime/refresh.mjs
+++ b/packages/cli/src/managed-runtime/refresh.mjs
@@ -16,12 +16,9 @@ export async function prepareRefresh({ control, root, env = process.env }) {
   const detected = await detectInstallation({ adapters, context, probeTimeoutMs: probeTimeout(env) });
   const deliveryByAdapter = Object.fromEntries(adapters.map(adapter => [adapter.id,
     livePolicyOf(recorded.find(record => record.adapterId === adapter.id))]));
-  // An unavailable probe cannot silently revoke an existing native opt-in.
-  for (const detection of detected) {
-    if (deliveryByAdapter[detection.adapterId] !== "off" && detection.nativeDelivery?.state !== "eligible") {
-      throw new Error("native integration could not be verified; update remains pending");
-    }
-  }
+  // Refresh configuration even when the client's service is temporarily absent.
+  // The installer preserves consent and existing activation; readiness stays a
+  // separate, current probe result rather than an update prerequisite.
   const plan = planInstallation({ adapters, detected, context, recorded,
     accVersion: control.pending.version, requested: control.targets, deliveryByAdapter });
   if (plan.skipped.length || plan.operations.length !== wanted.size) {

--- a/packages/cli/src/managed-runtime/refresh.mjs
+++ b/packages/cli/src/managed-runtime/refresh.mjs
@@ -3,9 +3,11 @@ import { applyPlan, detectInstallation, livePolicyOf, loadOwnership, planInstall
   from "@agents-can-communicate/installer";
 import { ALL_ADAPTERS, clientContext, probeTimeout } from "../install-command.mjs";
 import { stablePaths, writeLaunchers } from "./launchers.mjs";
+import { bridgeLegacyMaintenance } from "./legacy-maintenance.mjs";
 
 /** Loaded from the candidate, so its own adapters supply its integration bytes. */
-export async function prepareRefresh({ control, root, env = process.env }) {
+export async function prepareRefresh({ control, root, env = process.env, callerProtocol = 1 }) {
+  await bridgeLegacyMaintenance({ control, root, env, callerProtocol });
   const dataHome = path.dirname(path.dirname(root));
   const wanted = new Set(control.targets);
   const adapters = ALL_ADAPTERS().filter(adapter => wanted.has(adapter.id));

--- a/packages/cli/src/managed-runtime/schedule.mjs
+++ b/packages/cli/src/managed-runtime/schedule.mjs
@@ -8,8 +8,10 @@ import { checkDue, networkDisabled } from "./policy.mjs";
 export async function scheduleWorker(root, control, { env = process.env } = {}) {
   if (!control?.auto || networkDisabled(env) || !control.pending && !checkDue(control)) return false;
   try {
-    const owner = await readManagedJson(path.join(root, "worker", "manager.lock", "owner.json"));
-    if (Number.isSafeInteger(owner?.pid) && !await confirmedDead(owner.pid)) return false;
+    for (const directory of [path.join(root, "worker"), path.join(root, "worker", "poller")]) {
+      const owner = await readManagedJson(path.join(directory, "manager.lock", "owner.json"));
+      if (Number.isSafeInteger(owner?.pid) && !await confirmedDead(owner.pid)) return false;
+    }
     const child = spawn(process.execPath,
       [path.join(control.active.root, "bin", "acc-update-worker.mjs"), root], {
         env, detached: true, stdio: "ignore", cwd: root,

--- a/packages/cli/src/managed-runtime/worker.mjs
+++ b/packages/cli/src/managed-runtime/worker.mjs
@@ -2,6 +2,8 @@ import { activatePending } from "./activation.mjs";
 import { downloadRelease, fetchRelease, newerVersion } from "./download.mjs";
 import { withManagerLock } from "./mutex.mjs";
 import { readControl, writeControl } from "./state.mjs";
+import { MAINTENANCE_ACTIVE, maintenanceNotice, maintenanceReport, readMaintenance } from "./maintenance-state.mjs";
+import { requestMaintenance } from "./maintenance.mjs";
 
 import { checkDue, networkDisabled } from "./policy.mjs";
 export { CHECK_INTERVAL_MS, networkDisabled } from "./policy.mjs";
@@ -14,6 +16,14 @@ export async function performUpdate(root, { force = false, check = false, env = 
   if (initial === null) throw new Error("ACC is not enrolled; run acc install first");
   const data = { running: initial.active.version, auto: initial.auto, pin: initial.pin,
     pending: initial.pending?.version ?? null, notice: initial.notice };
+  const maintenance = await readMaintenance(root);
+  if (MAINTENANCE_ACTIVE.includes(maintenance?.status)) {
+    if (check) return { ...data, checked: false, reason: "maintenance_pending",
+      maintenance: maintenanceReport(maintenance), notice: maintenanceNotice(maintenance) };
+    const response = await requestMaintenance({ root, control: initial, options: {},
+      runtime: { env, packageRoot: initial.pending?.root ?? initial.active.root, isInteractive: () => false } });
+    return { ...data, checked: false, ...response.data, notice: response.text };
+  }
   if (!force && !check && !initial.auto) return { ...data, checked: false, reason: "auto_off" };
   // Recovery is local; the hard no-network override must not strand a partial refresh.
   if (initial.pending && !check && (force || !networkDisabled(env))) {
@@ -42,16 +52,18 @@ export async function performUpdate(root, { force = false, check = false, env = 
   return { ...checked, pending: generation.version, ...await activate(root, { env, ignorePid }) };
 }
 
-/** A single detached worker may wait cheaply for native clients to exit. */
+/** One poller may wait; the update lock stays available between its passes. */
 export async function runWorker(root, { force = false, env = process.env, wait = false, ignorePid = null } = {}) {
-  return withManagerLock(`${root}/worker`, async () => {
+  const poll = async () => {
     for (;;) {
-      const result = await performUpdate(root, { force, env, ignorePid });
+      const result = await withManagerLock(`${root}/worker`,
+        () => performUpdate(root, { force, env, ignorePid }), { timeoutMs: 100 });
       if (!wait || result.reason !== "processes_active") return result;
       await new Promise(resolve => setTimeout(resolve, 60_000));
       if (!(await readControl(root))?.auto || networkDisabled(env)) return result;
     }
-  }, { timeoutMs: 100 });
+  };
+  return wait ? withManagerLock(`${root}/worker/poller`, poll, { timeoutMs: 100 }) : poll();
 }
 
 export async function recordWorkerFailure(root, error) {

--- a/packages/cli/test/managed-runtime-blockers.test.mjs
+++ b/packages/cli/test/managed-runtime-blockers.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { activatePending } from "../src/managed-runtime/activation.mjs";
+import { acquireRuntime } from "../src/managed-runtime/leases.mjs";
+import { readControl, writeControl } from "../src/managed-runtime/state.mjs";
+
+async function fixture(t) {
+  const data = await realpath(await mkdtemp(path.join(tmpdir(), "acc-update-blockers-")));
+  t.after(() => rm(data, { recursive: true, force: true }));
+  const root = path.join(data, "acc", "runtime");
+  const active = { version: "0.4.2", root: path.join(root, "generations", "old") };
+  const pending = { version: "0.4.3", root: path.join(root, "generations", "new") };
+  await mkdir(active.root, { recursive: true });
+  await mkdir(pending.root, { recursive: true });
+  await writeControl(root, { schemaVersion: 1, active, pending, phase: "ready", auto: true,
+    pin: null, checkedAt: null, home: path.join(data, "home"), targets: [], notice: null });
+  const bindings = path.join(data, "acc", "workspaces", "fixture", "bindings");
+  await mkdir(bindings, { recursive: true });
+  const bind = (name, fields = {}) => writeFile(path.join(bindings, `${name}.json`), JSON.stringify({
+    schemaVersion: 1, harnessSessionId: name, accSessionId: `session_${name}`,
+    generation: `generation_${name}`, ...fields }));
+  return { root, bindings, bind, data, active };
+}
+
+// Counting each binding/lease as a process made one long-lived daemon look
+// like several clients; the result must name the actual process once.
+test("update reports one process for multiple native bindings and an ACC lease with the same PID", async t => {
+  const f = await fixture(t);
+  await f.bind("first", { clientPid: process.pid });
+  await f.bind("second", { clientPid: process.pid });
+  await acquireRuntime(f.root, { kind: "cli" });
+  await acquireRuntime(f.root, { kind: "cli" });
+  await acquireRuntime(f.root, { kind: "acc-mcp" });
+  const result = await activatePending(f.root, { prepare: async () => async () => {
+    assert.fail("a live process still prevents activation");
+  } });
+  assert.equal(result.activated, false);
+  assert.equal(result.holds, 1);
+  assert.equal(result.blockers.length, 1);
+  assert.equal(result.blockers[0].pid, process.pid);
+  assert.deepEqual(result.blockers[0].kinds, ["acc-mcp", "cli", "native"]);
+  assert.equal(result.blockers[0].nativeBindings, 2);
+  assert.match(result.notice, new RegExp(`\\b${process.pid}\\b`));
+});
+
+// Missing PIDs are not all the same process. They stay separate conservative
+// holds, and diagnostic output must not disclose generation credentials.
+test("unidentified bindings remain separate blockers without exposing owner credentials", async t => {
+  const f = await fixture(t);
+  await f.bind("unknown_one");
+  await f.bind("unknown_two");
+  const result = await activatePending(f.root, { pidIsAlive: () => false,
+    prepare: async () => async () => assert.fail("unknown ownership is still a hold") });
+  assert.equal(result.holds, 2);
+  assert.ok(Array.isArray(result.blockers), "pending updates expose their concrete blockers");
+  assert.equal(result.blockers.length, 2);
+  assert.ok(result.blockers.every(b => b.pid === null && b.reason === "unknown_client_pid"));
+  assert.doesNotMatch(JSON.stringify(result), /generation_unknown|session_unknown/);
+  assert.equal(JSON.parse(await readFile(path.join(f.root, "control.json"), "utf8")).active.version, "0.4.2");
+});
+
+test("ignoring the updating process excludes its leases but preserves its native bindings", async t => {
+  const f = await fixture(t);
+  await acquireRuntime(f.root, { kind: "acc" });
+  await acquireRuntime(f.root, { kind: "acc" });
+  await f.bind("native", { clientPid: process.pid });
+  const result = await activatePending(f.root, { ignorePid: process.pid,
+    prepare: async () => async () => assert.fail("native lifetime is not the updater's lease") });
+  assert.equal(result.holds, 1);
+  assert.deepEqual(result.blockers?.map(({ pid, kinds, nativeBindings }) => ({ pid, kinds, nativeBindings })),
+    [{ pid: process.pid, kinds: ["native"], nativeBindings: 1 }]);
+});
+
+// The real command must replace a stored count with current observations and
+// exclude its own diagnostic lease; removing the fresh read makes this fail.
+test("doctor reports current blockers in JSON and human output instead of a stale notice", async t => {
+  const f = await fixture(t);
+  await f.bind("first", { clientPid: process.pid });
+  await f.bind("second", { clientPid: process.pid });
+  await acquireRuntime(f.root, { kind: "acc-mcp" });
+  await acquireRuntime(f.root, { kind: "acc-mcp" });
+  await writeControl(f.root, { ...await readControl(f.root), notice: "old opaque notice: 99 processes" });
+  const home = path.join(f.data, "home"), project = path.join(f.data, "project");
+  await mkdir(home); await mkdir(project);
+  const entrypoints = path.join(f.active.root, "bin", "entrypoints");
+  await mkdir(entrypoints, { recursive: true });
+  await writeFile(path.join(entrypoints, "acc.mjs"),
+    `export { main } from ${JSON.stringify(new URL("../../../bin/entrypoints/acc.mjs", import.meta.url).href)};\n`);
+  const run = async (...args) => (await promisify(execFile)(process.execPath,
+    [fileURLToPath(new URL("../../../bin/acc.mjs", import.meta.url)), "doctor", "--cwd", project, ...args],
+    { cwd: home, env: { ...process.env, HOME: home, ACC_DATA_HOME: f.data, PATH: path.join(f.data, "empty-bin"),
+      ACC_NO_UPDATE_CHECK: "1", GIT_DIR: "", GIT_WORK_TREE: "" } })).stdout;
+  const report = JSON.parse(await run("--json"));
+  assert.equal(report.ok, true);
+  assert.equal(report.data.update.holds, 1);
+  assert.deepEqual(report.data.update.blockers.map(({ pid, kinds, nativeBindings }) => ({ pid, kinds, nativeBindings })),
+    [{ pid: process.pid, kinds: ["acc-mcp", "native"], nativeBindings: 2 }]);
+  const human = await run();
+  assert.match(human, new RegExp(`PID ${process.pid}\\b`));
+  assert.match(human, /acc-mcp.*native.*2 native bindings/);
+  assert.doesNotMatch(human, /old opaque notice|99 processes/);
+  assert.doesNotMatch(JSON.stringify(report), /generation_first|session_first/);
+  await rm(path.join(f.bindings, "second.json"));
+  assert.equal(JSON.parse(await run("--json")).data.update.blockers[0].nativeBindings, 1);
+});

--- a/packages/cli/test/managed-runtime-legacy-maintenance.test.mjs
+++ b/packages/cli/test/managed-runtime-legacy-maintenance.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import test from "node:test";
+import { bridgeLegacyMaintenance as bridge } from "../src/managed-runtime/legacy-maintenance.mjs";
+
+async function fixture(t) {
+  const root = await realpath(await mkdtemp(path.join(tmpdir(), "acc-legacy-maintenance-")));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const active = { version: "0.4.2", root: path.join(root, "generations", "old") };
+  const pending = { version: "0.4.4", root: path.join(root, "generations", "new") };
+  const script = path.join(active.root, "bin", "acc-update-worker.mjs");
+  await mkdir(path.dirname(script), { recursive: true }); await writeFile(script, "// installed legacy worker\n");
+  const input = new PassThrough(), output = new PassThrough();
+  input.isTTY = true; output.isTTY = true;
+  t.after(() => { input.destroy(); output.destroy(); });
+  let printed = ""; output.on("data", bytes => { printed += bytes; });
+  const services = [{ adapterId: "codex", snapshot: { state: "ready", pid: 123,
+    cliVersion: "0.153.4", serverVersion: "0.153.3", managedVersion: "0.153.4" } }];
+  return { root, script, input, output, services, printed: () => printed,
+    control: { active, pending, targets: ["codex"] } };
+}
+
+test("legacy worker handoff requires the actual active worker script and an eligible service", async t => {
+  const f = await fixture(t);
+  const ports = { argv: [process.execPath, f.script, f.root], input: f.input, output: f.output,
+    inspect: async () => f.services, requestMaintenance: async () => assert.fail("a background worker cannot request consent") };
+  await assert.rejects(bridge(f, ports), error => error.code === "ACC_LEGACY_MAINTENANCE_HANDOFF");
+  assert.equal(await bridge(f, { ...ports, inspect: async () => [] }), null);
+  const unrelated = path.join(f.root, "acc-update-worker.mjs"); await writeFile(unrelated, "// unrelated\n");
+  assert.equal(await bridge(f, { ...ports, argv: [process.execPath, unrelated, f.root] }), null);
+  assert.equal(f.printed(), "");
+});
+
+test("legacy interactive update asks through candidate ports and prints only scheduled status", async t => {
+  const f = await fixture(t);
+  const pending = bridge(f, { argv: [process.execPath, "acc", "update"], input: f.input, output: f.output,
+    inspect: async () => f.services, requestMaintenance: async ({ root, control, options, runtime, services }) => {
+      assert.equal(root, f.root); assert.equal(control, f.control);
+      assert.equal(options.json, false); assert.equal(runtime.isInteractive(), true);
+      assert.equal(runtime.packageRoot, f.control.pending.root); assert.equal(services, f.services);
+      const confirmed = await runtime.confirm("Restart the selected service?", { input: runtime.input, output: runtime.output });
+      return confirmed ? { data: { scheduled: true }, text: "Maintenance scheduled; waiting for this command to exit." } : null;
+    } });
+  pending.catch(() => {});
+  for (let attempt = 0; attempt < 100 && !f.printed().includes("[y/N]"); attempt++) {
+    await new Promise(resolve => setTimeout(resolve, 5));
+  }
+  f.input.write("yes\n");
+  assert.equal((await pending).data.scheduled, true);
+  assert.match(f.printed(), /Maintenance scheduled; waiting/);
+  assert.doesNotMatch(f.printed(), /updated|complete/i);
+});
+
+test("protocol-two, noninteractive, and JSON calls never enter the legacy prompt", async t => {
+  const f = await fixture(t);
+  const blocked = async () => assert.fail("this invocation must not inspect or request legacy maintenance");
+  const ports = { argv: [process.execPath, "acc", "update"], input: f.input, output: f.output,
+    inspect: blocked, requestMaintenance: blocked };
+  assert.equal(await bridge({ ...f, callerProtocol: 2 }, ports), null);
+  assert.equal(await bridge(f, { ...ports, argv: [...ports.argv, "--json"] }), null);
+  f.input.isTTY = false;
+  assert.equal(await bridge(f, ports), null);
+});
+
+test("an approved recovery resumes before service inspection and releases a verified legacy worker", async t => {
+  const f = await fixture(t);
+  await writeFile(path.join(f.root, "maintenance.json"), JSON.stringify({ schemaVersion: 1, status: "recovery",
+    id: "11111111-1111-1111-1111-111111111111", recipe: "fixture", deadline: Date.now() + 60_000,
+    callerPid: process.pid, workerPid: null, workerRoot: f.control.pending.root,
+    target: f.control.pending, attempted: ["codex"], services: f.services }));
+  let resumed = 0;
+  const ports = { argv: [process.execPath, f.script, f.root], input: f.input, output: f.output,
+    inspect: async () => assert.fail("a stopped service must not hide approved recovery"),
+    requestMaintenance: async ({ runtime }) => {
+      assert.equal(runtime.packageRoot, f.control.pending.root); resumed++;
+      return { data: { reason: "maintenance_pending" }, text: "Recovery scheduled." };
+    } };
+  await assert.rejects(bridge(f, ports), error => error.code === "ACC_LEGACY_MAINTENANCE_HANDOFF");
+  const result = await bridge(f, { ...ports, argv: [process.execPath, "acc", "update"] });
+  assert.equal(result.data.reason, "maintenance_pending");
+  assert.equal(resumed, 2);
+});

--- a/packages/cli/test/managed-runtime-legacy-worker.test.mjs
+++ b/packages/cli/test/managed-runtime-legacy-worker.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import nodeTest from "node:test";
+const test = (name, fn) => nodeTest(name, { skip: process.platform === "win32" ? "Unix process identity and signals" : false }, fn);
+import { retireLegacyUpdateWorker } from "../src/managed-runtime/management-recovery.mjs";
+import { readControl, writeControl } from "../src/managed-runtime/state.mjs";
+
+async function fixture(t, name = "acc-update-worker.mjs") {
+  const root = await realpath(await mkdtemp(path.join(tmpdir(), "acc-legacy-retire-")));
+  const active = { version: "0.4.3", root: path.join(root, "generations/old") };
+  await mkdir(path.join(active.root, "bin"), { recursive: true });
+  await writeFile(path.join(active.root, "package.json"), JSON.stringify({ name: "agents-can-communicate", version: "0.4.3" }));
+  await writeControl(root, { schemaVersion: 1, active, pending: null, phase: "ready", auto: true,
+    pin: null, checkedAt: null, home: root, targets: [], notice: null });
+  const script = path.join(active.root, "bin", name);
+  await writeFile(script, `import { withManagerLock } from ${JSON.stringify(new URL("../src/managed-runtime/mutex.mjs", import.meta.url).href)};
+await withManagerLock(process.argv[2] + '/worker', async () => {
+  console.log('ready'); await new Promise(() => { setInterval(() => {}, 10000); });
+});\n`);
+  const child = spawn(process.execPath, [script, root], { stdio: ["ignore", "pipe", "pipe"] });
+  const exit = once(child, "exit");
+  t.after(async () => { if (child.exitCode === null && child.signalCode === null) child.kill(); await exit; await rm(root, { recursive: true, force: true }); });
+  await once(child.stdout, "data");
+  return { root, child, exit, active };
+}
+
+test("explicit update retires its verified legacy ACC helper and leaves lock reclamation to the mutex", async t => {
+  const f = await fixture(t);
+  assert.equal(await retireLegacyUpdateWorker(f.root), true);
+  assert.deepEqual(await f.exit, [null, "SIGTERM"]);
+  assert.equal((await readControl(f.root)).phase, "ready");
+});
+
+test("legacy recovery never interrupts integration writes or an unrelated process", async t => {
+  const f = await fixture(t);
+  await writeControl(f.root, { ...await readControl(f.root), phase: "activating" });
+  assert.equal(await retireLegacyUpdateWorker(f.root), false);
+  assert.equal(f.child.signalCode, null);
+  const unrelated = await fixture(t, "unrelated.mjs");
+  assert.equal(await retireLegacyUpdateWorker(unrelated.root), false);
+  assert.equal(unrelated.child.signalCode, null);
+});
+
+test("a changed observed process identity cannot receive the termination signal", async t => {
+  const f = await fixture(t);
+  let reads = 0, signalled = false;
+  assert.equal(await retireLegacyUpdateWorker(f.root, { inspect: async () => ({ uid: process.getuid(),
+    start: new Date(Date.now() - (reads++ ? 60_000 : 0)).toString().slice(0, 24),
+    command: `${process.execPath} ${path.join(f.active.root, "bin/acc-update-worker.mjs")} ${f.root}` }),
+    signal: () => { signalled = true; } }), false);
+  assert.equal(signalled, false);
+});

--- a/packages/cli/test/managed-runtime-maintenance.test.mjs
+++ b/packages/cli/test/managed-runtime-maintenance.test.mjs
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { activatePending } from "../src/managed-runtime/activation.mjs";
+import { runManagedUpdate } from "../src/managed-runtime/command.mjs";
+import { requestMaintenance } from "../src/managed-runtime/maintenance.mjs";
+import { runMaintenance } from "../src/managed-runtime/maintenance-worker.mjs";
+import { readMaintenance } from "../src/managed-runtime/maintenance-state.mjs";
+import { acquireRuntime } from "../src/managed-runtime/leases.mjs";
+import { managedUpdateDiagnostic } from "../src/managed-runtime/diagnostics.mjs";
+import { readControl, writeControl } from "../src/managed-runtime/state.mjs";
+
+async function fixture(t) {
+  const data = await realpath(await mkdtemp(path.join(tmpdir(), "acc-maintenance-")));
+  t.after(() => rm(data, { recursive: true, force: true }));
+  const root = path.join(data, "acc", "runtime");
+  const active = { version: "0.4.3", root: path.join(root, "generations", "old") };
+  const pending = { version: "0.4.4", root: path.join(root, "generations", "new") };
+  await mkdir(active.root, { recursive: true }); await mkdir(pending.root, { recursive: true });
+  const control = { schemaVersion: 1, active, pending, phase: "ready", auto: true,
+    pin: null, checkedAt: null, home: data, targets: ["fixture"], notice: null };
+  await writeControl(root, control);
+  const bindings = path.join(data, "acc", "workspaces", "project", "bindings");
+  await mkdir(bindings, { recursive: true });
+  await writeFile(path.join(bindings, "native.json"), JSON.stringify({ schemaVersion: 1, clientPid: 123456 }));
+  const service = { serviceId: "fixture-service", state: "ready", reasonCode: null, pid: 123456,
+    processStartTime: "start", codexHome: data, cliPath: "/fixture/client", cliVersion: "2.0.0",
+    serverVersion: "1.0.0", managedPath: "/fixture/client", managedVersion: "2.0.0",
+    socketPath: path.join(data, "service.sock"), busyThreads: 0, queuedRequests: 0 };
+  const calls = [];
+  let alive = true, busy = false;
+  const adapter = { id: "fixture", displayName: "Fixture Client",
+    inspectMaintenance: async () => alive ? { ...service, state: busy ? "busy" : "ready", busyThreads: busy ? 2 : 0 } : null,
+    stopForMaintenance: async () => { calls.push("stop"); alive = false; return { ok: true }; },
+    startAfterMaintenance: async () => { calls.push("start"); return { ok: true }; } };
+  const runtime = { env: {}, packageRoot: pending.root, adapters: [adapter],
+    isInteractive: () => true, confirm: async () => { calls.push("confirm"); return true; },
+    spawnMaintenance: async () => { calls.push("spawn"); return 987654; } };
+  const activate = (root, options) => activatePending(root, { ...options,
+    prepare: async () => async () => { calls.push("refresh"); return { failed: [] }; } });
+  return { root, control, service, adapter, runtime, calls, activate,
+    pidIsAlive: pid => pid === service.pid && alive,
+    setBusy: value => { busy = value; } };
+}
+const approve = f => requestMaintenance({ root: f.root, control: f.control, options: {}, runtime: f.runtime });
+const execute = (f, options = {}) => runMaintenance(f.root, { env: {}, adapters: [f.adapter],
+  pidIsAlive: f.pidIsAlive, activate: f.activate, pause: async () => {}, ...options });
+
+test("update asks once, records exact approval, and detaches without stopping the caller's service", async t => {
+  const f = await fixture(t);
+  const result = await approve(f);
+  assert.equal(result.data.reason, "maintenance_pending");
+  assert.deepEqual(f.calls, ["confirm", "spawn"]);
+  const job = await readMaintenance(f.root);
+  assert.equal(job.target.version, "0.4.4");
+  assert.equal(job.services[0].snapshot.pid, f.service.pid);
+  assert.equal(job.status, "waiting");
+  await approve(f);
+  assert.equal(f.calls.filter(c => c === "confirm").length, 1);
+  await execute(f);
+  assert.deepEqual(f.calls.filter(c => !["confirm", "spawn"].includes(c)), ["stop", "refresh", "start"]);
+  assert.equal((await readControl(f.root)).active.version, "0.4.4");
+  assert.equal((await readMaintenance(f.root)).status, "completed");
+});
+
+test("decline and noninteractive JSON never restart or persist consent; --yes is explicit consent", async t => {
+  for (const mode of ["decline", "json", "noninteractive"]) {
+    const f = await fixture(t);
+    f.runtime.confirm = async () => { f.calls.push("confirm"); return false; };
+    if (mode === "noninteractive") f.runtime.isInteractive = () => false;
+    const result = await requestMaintenance({ root: f.root, control: f.control,
+      options: mode === "json" ? { json: true } : {}, runtime: f.runtime });
+    assert.equal(result.data.reason, mode === "decline" ? "maintenance_declined" : "confirmation_required");
+    assert.equal(await readMaintenance(f.root), null);
+    assert.deepEqual(f.calls, mode === "decline" ? ["confirm"] : []);
+  }
+  const f = await fixture(t);
+  f.runtime.isInteractive = () => false;
+  await requestMaintenance({ root: f.root, control: f.control, options: { yes: true, json: true }, runtime: f.runtime });
+  assert.deepEqual(f.calls, ["spawn"]);
+});
+
+test("changing a pinned candidate after approval cancels maintenance before any stop", async t => {
+  const f = await fixture(t); await approve(f);
+  await writeControl(f.root, { ...await readControl(f.root), pin: "0.4.4" });
+  await execute(f);
+  assert.equal((await readMaintenance(f.root)).status, "cancelled");
+  assert.ok(!f.calls.includes("stop"));
+  assert.equal((await readControl(f.root)).active.version, "0.4.3");
+});
+
+test("busy service is waited for without stopping it", async t => {
+  const f = await fixture(t); f.setBusy(true); await approve(f);
+  let waited = 0;
+  await execute(f, { pause: async () => {
+    assert.ok(!f.calls.includes("stop"));
+    const diagnostic = await managedUpdateDiagnostic(f.root, await readControl(f.root), "0.4.3");
+    assert.equal(diagnostic.maintenance.waiting.busyThreads, 2);
+    assert.match(diagnostic.notice, /2 active turns, 0 queued requests/);
+    waited++; f.setBusy(false);
+  } });
+  assert.equal(waited, 1);
+  assert.equal((await readMaintenance(f.root)).status, "completed");
+});
+
+test("unrelated live ACC processes keep the fence even after daemon consent", async t => {
+  const f = await fixture(t); await approve(f);
+  await acquireRuntime(f.root, { pid: 234567, kind: "acc-mcp" });
+  let unrelatedAlive = true, waited = 0;
+  await execute(f, { pidIsAlive: pid => pid === 234567 ? unrelatedAlive : f.pidIsAlive(pid),
+    pause: async () => { assert.ok(!f.calls.includes("stop")); unrelatedAlive = false; waited++; } });
+  assert.equal(waited, 1);
+  assert.equal((await readMaintenance(f.root)).status, "completed");
+});
+
+test("a turn racing the final stop check waits again under the same confirmation", async t => {
+  const f = await fixture(t); await approve(f);
+  const stop = f.adapter.stopForMaintenance;
+  let checks = 0;
+  f.adapter.stopForMaintenance = async () => ++checks === 1
+    ? { ok: false, reasonCode: "service_busy", stopAttempted: false } : stop();
+  await execute(f, { pause: async () => {
+    assert.equal((await readMaintenance(f.root)).status, "waiting");
+    assert.ok(!f.calls.includes("start"));
+  } });
+  assert.equal(checks, 2);
+  assert.equal(f.calls.filter(c => c === "confirm").length, 1);
+  assert.equal((await readMaintenance(f.root)).status, "completed");
+});
+
+test("expired approval and a failed stop cannot refresh integrations", async t => {
+  const f = await fixture(t); await approve(f);
+  await execute(f, { now: () => Date.now() + 16 * 60_000 });
+  assert.equal((await readMaintenance(f.root)).reasonCode, "idle_wait_expired");
+  assert.ok(!f.calls.includes("stop"));
+  const g = await fixture(t); await approve(g);
+  g.adapter.stopForMaintenance = async () => ({ ok: false, reasonCode: "service_identity_changed" });
+  await execute(g);
+  assert.ok(!g.calls.includes("refresh"));
+  assert.ok(g.calls.includes("start"), "restore is attempted even if the stop result is ambiguous");
+  assert.equal((await readControl(g.root)).active.version, "0.4.3");
+  assert.equal((await readMaintenance(g.root)).reasonCode, "service_identity_changed");
+});
+
+test("integration failure restores the service and keeps the runtime fenced for recovery", async t => {
+  const f = await fixture(t); await approve(f);
+  await execute(f, { activate: (root, options) => activatePending(root, { ...options,
+    prepare: async () => async () => { f.calls.push("refresh"); return { failed: [{ adapterId: "fixture", error: "denied" }] }; } }) });
+  assert.deepEqual(f.calls.slice(-3), ["stop", "refresh", "start"]);
+  assert.equal((await readControl(f.root)).phase, "activating");
+  const job = await readMaintenance(f.root);
+  assert.equal(job.status, "failed");
+  assert.equal(job.reasonCode, "refresh_failed");
+});
+
+test("restart failure is reported instead of claiming complete maintenance", async t => {
+  const f = await fixture(t); await approve(f);
+  f.adapter.startAfterMaintenance = async () => ({ ok: false, reasonCode: "service_start_failed" });
+  await execute(f);
+  const job = await readMaintenance(f.root);
+  assert.equal(job.status, "recovery");
+  assert.equal(job.reasonCode, "service_start_failed");
+  f.adapter.startAfterMaintenance = async () => { f.calls.push("start"); return { ok: true }; };
+  await execute(f);
+  assert.equal(f.calls.filter(c => c === "stop").length, 1, "recovery never repeats an approved stop");
+  assert.equal((await readMaintenance(f.root)).status, "completed");
+});
+
+test("successful ACC activation still offers maintenance for a stale unbound daemon", async t => {
+  const f = await fixture(t);
+  const directory = path.join(f.control.pending.root, "node_modules/@agents-can-communicate/cli/src/managed-runtime");
+  await mkdir(directory, { recursive: true });
+  await writeFile(path.join(directory, "refresh.mjs"),
+    "export async function prepareRefresh() { return async () => ({ failed: [] }); }\n");
+  const result = await runManagedUpdate({ options: {}, runtime: { ...f.runtime, managerRoot: f.root,
+    env: { ACC_NO_UPDATE_CHECK: "1" } } });
+  assert.equal((await readControl(f.root)).active.version, "0.4.4");
+  assert.equal(result.data.reason, "maintenance_pending");
+  assert.deepEqual(f.calls, ["confirm", "spawn"]);
+});

--- a/packages/cli/test/managed-runtime-management-entry.test.mjs
+++ b/packages/cli/test/managed-runtime-management-entry.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readdir, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+import { writeControl } from "../src/managed-runtime/state.mjs";
+
+const entry = new URL("../src/managed-runtime/entry.mjs", import.meta.url).href;
+async function fixture(t) {
+  const data = await realpath(await mkdtemp(path.join(tmpdir(), "acc-management-entry-")));
+  t.after(() => rm(data, { recursive: true, force: true }));
+  const root = path.join(data, "acc", "runtime");
+  async function runtime(label, version, directory, protocol = 2) {
+    await mkdir(path.join(directory, "bin", "entrypoints"), { recursive: true });
+    await writeFile(path.join(directory, "package.json"), JSON.stringify({ name: "agents-can-communicate",
+      version, accManagedUpdateProtocol: protocol }));
+    await writeFile(path.join(directory, "bin", "entrypoints", "acc.mjs"),
+      `export async function main(options) { process.stdout.write(JSON.stringify({ label: ${JSON.stringify(label)}, options })); }`);
+    return { root: directory, version };
+  }
+  const active = await runtime("active", "0.4.2", path.join(root, "generations", "old"), 1);
+  const pending = await runtime("pending", "0.4.4", path.join(root, "generations", "new"));
+  const installed = await runtime("installed", "0.4.5", path.join(data, "installed"));
+  const control = { schemaVersion: 1, active, pending, phase: "ready", auto: false,
+    pin: null, checkedAt: null, home: path.join(data, "home"), targets: [], notice: null };
+  await writeControl(root, control);
+  const run = async (args, packageRoot = installed.root) => {
+    const code = `process.argv = [process.execPath, "acc", ...${JSON.stringify(args)}];
+      const { runEntry } = await import(${JSON.stringify(entry)});
+      await runEntry(${JSON.stringify({ kind: "acc", managerRoot: root, packageRoot })});`;
+    const { stdout } = await promisify(execFile)(process.execPath, ["--input-type=module", "-e", code],
+      { env: { ...process.env, HOME: control.home, ACC_DATA_HOME: data, ACC_NO_UPDATE_CHECK: "1" } });
+    return JSON.parse(stdout);
+  };
+  return { root, run, active, pending, installed, control };
+}
+
+test("explicit update enters the newer installed management implementation without workspace admission", async t => {
+  const f = await fixture(t);
+  const result = await f.run(["update"]);
+  assert.equal(result.label, "installed");
+  assert.equal(result.options.managementOnly, true);
+  assert.equal(result.options.managerRoot, f.root);
+  assert.equal((await readdir(f.root)).includes("leases"), false);
+});
+
+test("a verified protocol-two pending candidate provides update recovery even while activation is fenced", async t => {
+  const f = await fixture(t);
+  await writeControl(f.root, { ...f.control, phase: "activating" });
+  const result = await f.run(["update"], f.active.root);
+  assert.equal(result.label, "pending");
+  assert.equal(result.options.managementOnly, true);
+  assert.equal((await readdir(f.root)).includes("leases"), false);
+});
+
+test("candidate management dispatch requires matching package identity and the advertised protocol", async t => {
+  for (const manifest of [
+    { name: "foreign", version: "0.4.4", accManagedUpdateProtocol: 2 },
+    { name: "agents-can-communicate", version: "9.0.0", accManagedUpdateProtocol: 2 },
+    { name: "agents-can-communicate", version: "0.4.4", accManagedUpdateProtocol: 1 },
+  ]) {
+    const f = await fixture(t);
+    await writeFile(path.join(f.pending.root, "package.json"), JSON.stringify(manifest));
+    const result = await f.run(["update"], f.active.root);
+    assert.equal(result.label, "active");
+    assert.notEqual(result.options.managementOnly, true);
+  }
+});
+
+test("update and help appearing as argument values never bypass active workspace admission", async t => {
+  const f = await fixture(t);
+  for (const args of [["status"], ["message", "--body", "update"], ["message", "--body", "--help"]]) {
+    const result = await f.run(args);
+    assert.equal(result.label, "active");
+    assert.notEqual(result.options.managementOnly, true);
+  }
+  assert.equal((await readdir(path.join(f.root, "leases"))).some(name => name.endsWith(".json")), true);
+});

--- a/packages/cli/test/managed-runtime-worker.test.mjs
+++ b/packages/cli/test/managed-runtime-worker.test.mjs
@@ -1,10 +1,15 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { tmpdir } from "node:os";
 import test from "node:test";
 import { performUpdate } from "../src/managed-runtime/worker.mjs";
 import { readControl, writeControl } from "../src/managed-runtime/state.mjs";
+import { acquireRuntime } from "../src/managed-runtime/leases.mjs";
+import { withManagerLock } from "../src/managed-runtime/mutex.mjs";
+import { scheduleWorker } from "../src/managed-runtime/schedule.mjs";
 
 async function fixture(t, changes = {}) {
   const root = await realpath(await mkdtemp(path.join(tmpdir(), "acc-worker-")));
@@ -57,4 +62,62 @@ test("failed downloads keep the working runtime and concurrent opt-out prevents 
   } });
   assert.equal(g.calls.some(([name]) => name === "activate"), false);
   assert.equal((await readControl(g.root)).pending, null);
+});
+
+test("a background poll releases the update lock while waiting for clients", async t => {
+  const f = await fixture(t);
+  const pending = { version: "0.4.1", root: path.join(f.root, "generations", "new") };
+  const modules = path.join(pending.root, "node_modules", "@agents-can-communicate", "cli", "src", "managed-runtime");
+  await mkdir(modules, { recursive: true });
+  const marker = path.join(f.root, "prepared");
+  await writeFile(path.join(modules, "refresh.mjs"), `import { writeFile } from 'node:fs/promises';
+    export async function prepareRefresh() { await writeFile(${JSON.stringify(marker)}, 'ready');
+      return async () => ({ failed: [] }); }`);
+  await writeControl(f.root, { ...await readControl(f.root), pending });
+  await acquireRuntime(f.root, { kind: "acc-mcp" });
+  const source = `import { runWorker } from ${JSON.stringify(new URL("../src/managed-runtime/worker.mjs", import.meta.url).href)};
+    await runWorker(${JSON.stringify(f.root)}, { wait: true, env: {} });`;
+  const child = spawn(process.execPath, ["--input-type=module", "-e", source], { stdio: "ignore" });
+  const exited = once(child, "exit");
+  t.after(async () => { if (child.exitCode === null) child.kill("SIGKILL"); await exited; });
+  for (let attempt = 0; attempt < 100 && !await readFile(marker).catch(() => false); attempt++) {
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+  assert.equal(await readFile(marker, "utf8"), "ready");
+  assert.equal(await withManagerLock(path.join(f.root, "worker"), async () => "foreground admitted",
+    { timeoutMs: 500 }), "foreground admitted");
+  assert.equal(await scheduleWorker(f.root, await readControl(f.root), { env: {} }), false,
+    "the existing idle poller prevents duplicate background workers");
+});
+
+test("an active maintenance job pauses ordinary update work without changing control", async t => {
+  for (const status of ["waiting", "stopping", "refreshing", "restarting", "recovery"]) {
+    const f = await fixture(t);
+    await writeFile(path.join(f.root, "maintenance.json"), JSON.stringify({ schemaVersion: 1, status,
+      id: "11111111-1111-1111-1111-111111111111", recipe: "fixture", deadline: Date.now() + 60_000,
+      callerPid: process.pid, workerPid: process.pid, workerRoot: f.active.root, target: f.active, attempted: [],
+      services: [{ adapterId: "codex", snapshot: { pid: process.pid } }] }));
+    const original = await readControl(f.root);
+    const result = await performUpdate(f.root, { ...f.ports, force: true });
+    assert.equal(result.reason, "maintenance_pending");
+    assert.deepEqual(await readControl(f.root), original);
+    assert.deepEqual(f.calls, []);
+  }
+});
+
+test("read-only update check reports an approved job without restarting its missing worker", async t => {
+  const f = await fixture(t);
+  await mkdir(path.join(f.active.root, "bin"), { recursive: true });
+  await writeFile(path.join(f.active.root, "bin", "acc-maintenance-worker.mjs"), "process.exit(0);\n");
+  const file = path.join(f.root, "maintenance.json");
+  const bytes = JSON.stringify({ schemaVersion: 1, status: "recovery",
+    id: "11111111-1111-1111-1111-111111111111", recipe: "fixture", deadline: Date.now() + 60_000,
+    callerPid: process.pid, workerPid: null, workerRoot: f.active.root, target: f.active, attempted: ["codex"],
+    services: [{ adapterId: "codex", snapshot: { pid: process.pid } }] });
+  await writeFile(file, bytes);
+  const result = await performUpdate(f.root, { ...f.ports, check: true });
+  assert.equal(result.reason, "maintenance_pending");
+  assert.equal(result.maintenance.status, "recovery");
+  assert.equal(await readFile(file, "utf8"), bytes, "--check must leave the missing worker untouched");
+  assert.deepEqual(f.calls, []);
 });

--- a/packages/cli/test/managed-runtime-worker.test.mjs
+++ b/packages/cli/test/managed-runtime-worker.test.mjs
@@ -70,8 +70,11 @@ test("a background poll releases the update lock while waiting for clients", asy
   const modules = path.join(pending.root, "node_modules", "@agents-can-communicate", "cli", "src", "managed-runtime");
   await mkdir(modules, { recursive: true });
   const marker = path.join(f.root, "prepared");
+  // A file is visible before writeFile finishes; expose that publication window.
   await writeFile(path.join(modules, "refresh.mjs"), `import { writeFile } from 'node:fs/promises';
-    export async function prepareRefresh() { await writeFile(${JSON.stringify(marker)}, 'ready');
+    export async function prepareRefresh() { await writeFile(${JSON.stringify(marker)}, '');
+      await new Promise(resolve => setTimeout(resolve, 100));
+      await writeFile(${JSON.stringify(marker)}, 'ready');
       return async () => ({ failed: [] }); }`);
   await writeControl(f.root, { ...await readControl(f.root), pending });
   await acquireRuntime(f.root, { kind: "acc-mcp" });
@@ -80,7 +83,8 @@ test("a background poll releases the update lock while waiting for clients", asy
   const child = spawn(process.execPath, ["--input-type=module", "-e", source], { stdio: "ignore" });
   const exited = once(child, "exit");
   t.after(async () => { if (child.exitCode === null) child.kill("SIGKILL"); await exited; });
-  for (let attempt = 0; attempt < 100 && !await readFile(marker).catch(() => false); attempt++) {
+  for (let attempt = 0; attempt < 100
+    && await readFile(marker, "utf8").catch(() => null) !== "ready"; attempt++) {
     await new Promise(resolve => setTimeout(resolve, 10));
   }
   assert.equal(await readFile(marker, "utf8"), "ready");

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/delivery-router/package.json
+++ b/packages/delivery-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/delivery-router",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/src/apply.mjs
+++ b/packages/installer/src/apply.mjs
@@ -37,7 +37,7 @@ export async function applyPlan({ plan, adapters, context, dataHome, dryRun = fa
         const installContext = { ...context,
           clientVersion: operation.clientVersion, platform: operation.platform,
           requestedLivePolicy: operation.livePolicy ?? "off",
-          livePolicy: operation.effectiveLivePolicy ?? "off" };
+          livePolicy: operation.configuredLivePolicy ?? operation.effectiveLivePolicy ?? "off" };
         const outcome = await adapter.install(installContext);
         // A consented activation is applied after the adapter's own wiring, in
         // a fixed order; an explicit off takes a recorded one back first so the
@@ -50,7 +50,7 @@ export async function applyPlan({ plan, adapters, context, dataHome, dryRun = fa
           notes.push(...describeTeardown(report));
           retainedMechanisms = report.retainedMechanisms;
         }
-        let native = null;
+        let native = operation.retainedNativeActivation ?? null;
         let appendedRcBlock = false;
         if (operation.nativeActivation !== undefined) {
           const applied = await applyNativeActivation({ adapter,

--- a/packages/installer/src/plan.mjs
+++ b/packages/installer/src/plan.mjs
@@ -108,6 +108,10 @@ export function planInstallation({ adapters, detected, context, action = "instal
     const liveDeliverySupported = native?.state === "eligible"
       && native.activationPlan?.eligible === true;
     const effectiveLivePolicy = liveDeliverySupported ? delivery : "off";
+    const previous = recordedById.get(entry.adapterId)?.nativeActivation ?? null;
+    const retainedActivation = action === "install" && delivery !== "off"
+      && !liveDeliverySupported && previous?.livePolicy === delivery ? previous : null;
+    const configuredLivePolicy = retainedActivation ? delivery : effectiveLivePolicy;
     const deliveryDiagnostic = action === "install" && delivery !== "off"
       && !liveDeliverySupported
       ? entry.deliveryDiagnostic ?? adapter.deliveryFallback?.diagnostic
@@ -117,20 +121,21 @@ export function planInstallation({ adapters, detected, context, action = "instal
     const deliverySummary = action === "install"
       ? describeInstallDelivery(entry, delivery, effectiveLivePolicy) : null;
     const installContext = { ...context, requestedLivePolicy: delivery,
-      livePolicy: effectiveLivePolicy, clientVersion: entry.version, platform: entry.platform };
+      livePolicy: configuredLivePolicy, clientVersion: entry.version, platform: entry.platform };
     const setupNotes = action === "install" && delivery !== "off"
       ? [entry.outgoingDelivery?.setup, entry.nativeSetup].filter(note => typeof note === "string") : [];
     // A consented activation that this run keeps, activates, or takes back.
     // Only an explicit off or an uninstall removes one; an absent record never
     // creates one.
-    const previous = recordedById.get(entry.adapterId)?.nativeActivation ?? null;
     const nativeActivation = action === "install" && effectiveLivePolicy !== "off"
       ? { livePolicy: effectiveLivePolicy, protocolContract: native.eligibility.protocolContract,
         shell: context?.shell ?? null, rcFile: rcFileFor(context?.home, context?.shell),
         shimDir: typeof context?.stateRoot === "string" ? shimDirFor(context.stateRoot) : null,
         mechanisms: native.activationPlan.mechanisms }
       : null;
-    const retirements = planActivationRetirements({ previous, desired: nativeActivation });
+    // A failed readiness probe is not revocation. Keep existing guarded launch
+    // setup without applying service commands or claiming it is available.
+    const retirements = retainedActivation ? [] : planActivationRetirements({ previous, desired: nativeActivation });
     const deactivation = retirements.length > 0 ? { ...previous, mechanisms: retirements } : null;
     const artifacts = (record?.artifacts ?? adapter.planInstall(installContext))
       .map(artifact => ({ path: artifact.path, kind: artifact.kind ?? "file" }))
@@ -149,6 +154,7 @@ export function planInstallation({ adapters, detected, context, action = "instal
       alreadyInstalled: entry.installed === true,
       livePolicy: delivery,
       effectiveLivePolicy,
+      ...(retainedActivation ? { configuredLivePolicy, retainedNativeActivation: retainedActivation } : {}),
       ...(deliveryDiagnostic === null ? {} : { deliveryDiagnostic }),
       ...(deliverySummary === null ? {} : { deliverySummary }),
       ...(setupNotes.length ? { setupNotes } : {}),
@@ -161,6 +167,7 @@ export function planInstallation({ adapters, detected, context, action = "instal
         ...(entry.present ? [] : [`${adapter.displayName ?? adapter.id} is no longer on `
           + "this machine; removing what ACC recorded writing"]),
         ...(deliverySummary === null ? [] : [deliverySummary]),
+        ...(retainedActivation ? ["keep existing native delivery setup; current readiness is unverified"] : []),
         ...setupNotes,
         ...artifacts.filter(a => a.kind === "tree")
           .map(a => `${action === "install" ? "create" : "remove"} ${a.path}`),

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/tests/acceptance/managed-review-fixes-packed.test.mjs
+++ b/tests/acceptance/managed-review-fixes-packed.test.mjs
@@ -153,7 +153,12 @@ test("packed manual update explains a failed integration and repairs forward aft
   const partial = await stateOf(f);
   assert.equal(partial.phase, "activating");
   assert.deepEqual(partial.active, before.active);
-  assert.equal((await f.accError(["doctor"])).code, 4);
+  const diagnosis = await f.acc(["doctor"]);
+  assert.equal(diagnosis.scope, "update");
+  assert.equal(diagnosis.workspaceInspection, "unavailable_during_update");
+  assert.equal(diagnosis.update.phase, "activating");
+  assert.match(diagnosis.update.notice, /incomplete.*acc update/);
+  assert.equal((await f.accError(["doctor", "--repair"])).code, 4);
   await writeFile(settings, original);
   const fixed = await f.acc(["update"], { ACC_NO_UPDATE_CHECK: "1" });
   assert.equal(fixed.activated, true);

--- a/tests/acceptance/managed-update-degraded-packed.test.mjs
+++ b/tests/acceptance/managed-update-degraded-packed.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+import { createPackedAcc } from "../helpers/packed-acc.mjs";
+import { createUpdateRegistry } from "../helpers/update-registry.mjs";
+
+const run = promisify(execFile);
+const captured = process.platform === "darwin" && process.arch === "arm64";
+const ownership = f => readFile(path.join(f.dataHome, "acc", "installs.json"), "utf8").then(JSON.parse);
+const updateEnv = (f, registry) => ({ ...f.env, ACC_NO_UPDATE_CHECK: "0",
+  npm_config_registry: registry.url, npm_config_cache: path.join(f.root, "update-cache") });
+
+// The refresh's native eligibility gate stranded a real opted-in Codex installation
+// without a service, and policies recorded for inbox-only adapters stranded it too.
+test("packed update retains delivery consent while native services and capabilities are unavailable", async t => {
+  const f = await createPackedAcc(t);
+  f.env.CODEX_HOME = path.join(f.clientHome, ".codex");
+  f.env.SHELL = "/bin/zsh";
+  await f.setClientVersions({ codex: "0.154.0", gemini: "0.59.0", grok: "1.0.25" });
+  const installed = await f.acc(["install", "--adapter", "codex", "--adapter", "gemini_cli",
+    "--adapter", "grok", "--delivery", "actionable"]);
+  assert.deepEqual(installed.failed, []);
+  await f.acc(["update", "--auto", "off"]);
+  const registry = await createUpdateRegistry(t, f);
+  const updated = await f.acc(["update"], updateEnv(f, registry));
+  assert.equal(updated.activated, true);
+  assert.equal((await f.acc(["version"])).version, registry.version);
+  const doctor = await f.acc(["doctor"]);
+  assert.equal(doctor.update.auto, false, "an update must keep the user's explicit opt-out");
+  for (const id of ["codex", "gemini_cli", "grok"]) {
+    const adapter = doctor.adapters.find(item => item.adapterId === id);
+    assert.equal(adapter.bundleVersion, registry.version);
+    assert.equal(adapter.nativeDelivery.policy, "actionable");
+    assert.notEqual(adapter.nativeDelivery.runtime, "active");
+    assert.deepEqual(adapter.nativeDelivery.modes, []);
+  }
+  if (captured) assert.equal(doctor.adapters.find(a => a.adapterId === "codex").outgoingDelivery.state, "configured");
+  for (const record of (await ownership(f)).installs) assert.equal(record.deliveryPolicy, "actionable");
+});
+
+async function writeClaude(f, channelAvailable) {
+  await writeFile(path.join(f.clientBin, "claude"), `#!${process.execPath}\n`
+    + (channelAvailable ? "// notifications/claude/channel\n" : "// protocol temporarily unavailable\n")
+    + 'console.log(process.argv.includes("--version") ? "2.1.267 (Claude Code)" : JSON.stringify(process.argv.slice(2)));\n',
+  { mode: 0o700 });
+}
+
+// Removing only the updater's gate would silently tear down the existing shim
+// and channel MCP entry. The installed shim must fail open, then recover by itself.
+test("packed update preserves Claude activation through a failed probe and recovers on ordinary launch",
+  { skip: !captured }, async t => {
+    const f = await createPackedAcc(t);
+    f.env.SHELL = "/bin/zsh";
+    await writeClaude(f, true);
+    assert.deepEqual((await f.acc(["install", "--adapter", "claude_code", "--delivery", "actionable"])).failed, []);
+    await f.acc(["update", "--auto", "off"]);
+    const shim = path.join(f.dataHome, "acc", "bin", "claude");
+    const rc = await readFile(path.join(f.clientHome, ".zshrc"), "utf8");
+    const shimBytes = await readFile(shim, "utf8");
+    const previous = (await ownership(f)).installs.find(a => a.adapterId === "claude_code").nativeActivation;
+    assert.ok(previous);
+    const registry = await createUpdateRegistry(t, f);
+    await writeClaude(f, false);
+    const updated = await f.acc(["update"], updateEnv(f, registry));
+    assert.equal(updated.activated, true);
+    assert.equal(await readFile(shim, "utf8"), shimBytes);
+    assert.equal(await readFile(path.join(f.clientHome, ".zshrc"), "utf8"), rc);
+    const record = (await ownership(f)).installs.find(a => a.adapterId === "claude_code");
+    assert.deepEqual(record.nativeActivation, previous);
+    assert.equal(record.deliveryPolicy, "actionable");
+    const mcp = JSON.parse(await readFile(path.join(f.clientHome, ".claude", "plugins",
+      "marketplaces", "acc-local", "agents-can-communicate", ".mcp.json"), "utf8"));
+    assert.ok(mcp.mcpServers["acc-channel"]);
+    const diagnostic = (await f.acc(["doctor"])).adapters.find(a => a.adapterId === "claude_code");
+    assert.equal(diagnostic.bundleVersion, registry.version);
+    assert.equal(diagnostic.nativeDelivery.policy, "actionable");
+    assert.notEqual(diagnostic.nativeDelivery.eligibility, "eligible");
+    assert.notEqual(diagnostic.nativeDelivery.runtime, "active");
+    assert.deepEqual(diagnostic.owned.modified, []);
+    const launch = () => run(shim, ["resume", "fixture-thread"], { cwd: f.project, env: f.env });
+    assert.deepEqual(JSON.parse((await launch()).stdout), ["resume", "fixture-thread"]);
+    await writeClaude(f, true);
+    assert.deepEqual(JSON.parse((await launch()).stdout), ["--dangerously-load-development-channels",
+      "plugin:agents-can-communicate@acc-local", "resume", "fixture-thread"]);
+    await f.acc(["install", "--adapter", "claude_code", "--delivery", "off"]);
+    await assert.rejects(readFile(shim), { code: "ENOENT" });
+    assert.equal((await ownership(f)).installs[0].deliveryPolicy, "off");
+  });

--- a/tests/acceptance/managed-update-diagnostics-packed.test.mjs
+++ b/tests/acceptance/managed-update-diagnostics-packed.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { createPackedAcc } from "../helpers/packed-acc.mjs";
+import { createUpdateRegistry } from "../helpers/update-registry.mjs";
+
+test("installed doctor reports update recovery while workspace admission is fenced", async t => {
+  const f = await createPackedAcc(t);
+  await f.setClientVersions({ grok: "1.0.25" });
+  await f.acc(["install", "--adapter", "grok"]);
+  const file = path.join(f.dataHome, "acc/runtime/control.json");
+  const control = JSON.parse(await readFile(file));
+  await writeFile(file, JSON.stringify({ ...control, pending: control.active, phase: "activating" }));
+  await writeFile(path.join(f.project, "acc.workspace.json"), "invalid workspace bytes");
+  const doctor = await f.acc(["doctor"]);
+  assert.equal(doctor.scope, "update");
+  assert.equal(doctor.workspaceInspection, "unavailable_during_update");
+  assert.equal(doctor.update.phase, "activating");
+  assert.match(doctor.update.notice, /incomplete.*acc update/);
+  assert.equal((await f.accError(["doctor", "--repair"])).code, 4);
+  assert.equal((await f.accError(["status"])).code, 4);
+  assert.equal((await readFile(file, "utf8")).includes('"phase":"activating"'), true);
+});
+
+test("installed doctor uses the newer management reader for pending maintenance", async t => {
+  const f = await createPackedAcc(t);
+  await f.setClientVersions({ grok: "1.0.25" });
+  await f.acc(["install", "--adapter", "grok"]);
+  const root = path.join(f.dataHome, "acc/runtime");
+  const bindings = path.join(f.dataHome, "acc/workspaces/fixture/bindings");
+  await mkdir(bindings, { recursive: true });
+  await writeFile(path.join(bindings, "native.json"), JSON.stringify({ schemaVersion: 1, clientPid: process.pid }));
+  const registry = await createUpdateRegistry(t, f);
+  await f.acc(["update"], { ...f.env, ACC_NO_UPDATE_CHECK: "0", npm_config_registry: registry.url,
+    npm_config_cache: path.join(f.root, "update-cache") });
+  const control = JSON.parse(await readFile(path.join(root, "control.json")));
+  assert.equal(control.pending.version, registry.version);
+  await writeFile(path.join(root, "maintenance.json"), JSON.stringify({ schemaVersion: 1,
+    id: "11111111-1111-4111-a111-111111111111", status: "waiting", target: control.pending,
+    workerRoot: control.pending.root, recipe: "fixture", deadline: Date.now() + 10000,
+    callerPid: process.pid, workerPid: process.pid, attempted: [], reasonCode: null,
+    waiting: { reason: "service_busy", busyThreads: 2, queuedRequests: 1 },
+    services: [{ adapterId: "codex", snapshot: { pid: process.pid, serviceId: "codex-app-server",
+      cliVersion: "0.154.0", serverVersion: "0.153.4" } }] }));
+  await writeFile(path.join(f.project, "acc.workspace.json"), "invalid workspace bytes");
+  const doctor = await f.acc(["doctor"]);
+  assert.equal(doctor.scope, "update");
+  assert.equal(doctor.update.running, control.active.version);
+  assert.equal(doctor.update.maintenance.status, "waiting");
+  assert.match(doctor.update.notice, /2 active turns, 1 queued requests/);
+});

--- a/tests/process/doctor-reports.test.mjs
+++ b/tests/process/doctor-reports.test.mjs
@@ -40,7 +40,7 @@ async function machine(t) {
   // and every test here failed on a machine that had it.
   const env = { ...process.env, PATH: `${bin}${path.delimiter}${process.env.PATH}`,
     HOME: home, ACC_DATA_HOME: dataHome, ACC_PROBE_TIMEOUT_MS: "30000",
-    GIT_DIR: "", GIT_WORK_TREE: "" };
+    ACC_NO_UPDATE_CHECK: "1", GIT_DIR: "", GIT_WORK_TREE: "" };
 
   // Nothing here asks the registry: the check is switched off, except where a
   // test seeds an answer that is still fresh so none is needed.


### PR DESCRIPTION
ACC updates could remain pending behind a long-lived Codex daemon, lose existing native activation after a temporary feature-probe failure, and report several processes when the same daemon owned multiple bindings.

This patch adds a separately confirmed maintenance flow to `acc update`. A detached worker waits for idle work, verifies the exact Codex service identity, completes integration refresh, restores the service even after a failed refresh, and records progress for `acc doctor`. It keeps ordinary background discovery and `--check` from authorizing restarts. Delivery consent and update preferences are preserved.

Diagnostics now name actual blocking processes and remain available in an update-only mode while workspace admission is fenced. The new management entry can recover an older pending runtime and retire an exactly identified obsolete ACC updater. README and current product docs describe the interaction, first-hop bootstrap and captured limits.

Validation:

- npm ci and syntax check: passed.
- Exact 0.4.4 archive: installed-package verification passed; all 269 file bytes match source and activated runtime.
- Published 0.4.2 + already-pending 0.4.3 + old waiting updater → sealed 0.4.4: passed with one real-terminal confirmation, private Codex daemon restart, completed doctor state and preserved delivery-off policy.
- Focused failures and exact mutations cover consent, identity, leases, settings changes, failed refresh, restoration, late busy work, read-only checks and fenced diagnostics.
- The first macOS CI run exposed a readiness-file race in the new worker test. The empty publication window is now exercised deliberately, the wait requires complete content, and all six worker tests pass. Repacking after this test-only fix produces the exact same sealed archive.
- Full candidate suite: 2,018 tests, 2,017 passed, zero failures, one environment-dependent skip (Gemini CLI is installed, so the existing absent-client uninstall case does not apply).

Maintenance capture is macOS arm64, Codex CLI 0.154.0, pid backend. Codex exposes no atomic turn-drain fence; open clients disconnect and UI reconnection is not claimed. An entirely old launcher+active+pending installation needs the documented one-time launcher bootstrap. No delivery capability declarations were expanded.

Candidate evidence: docs/release-evidence/v0.4.4.md. Maintainer merges; no tag or publication performed.
