### PR TITLE
Bind to the version that serves, and report what can be delivered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,24 @@
   now apply to the reported serving version on the capability probe, the session
   handshake, the Codex receiver's own version check, and the delivery router's offer
   path, so a service that restarted onto a different build no longer turns delivery off
-  by version identity alone. A version below the minimum reports `below_minimum_version`
-  naming that version instead of a generic probe failure.
+  by version identity alone. The delivery binding a session publishes records that same
+  serving version, so the record the router reads and the receiver record the adapter
+  keeps name one version rather than two, and the Codex receiver resolves a binding by
+  its opaque endpoint reference alone — the last comparison of two stored version
+  snapshots is gone. Without that, a client whose background service had updated under
+  its CLI published one version and recorded another, and every send fell back to
+  durable on the difference. A version below the minimum reports `below_minimum_version`
+  naming that version instead of a generic probe failure, and a service that drops below
+  it while a binding is open is reported as a version mismatch rather than as a protocol
+  mismatch.
+- `acc doctor` reports what can be delivered rather than what was bound. A binding that
+  looks live is re-verified through its own adapter — bounded, read-only, renewing no
+  lease and writing no record — so a session whose receiver can no longer take a push
+  reads as degraded and names both the condition and something to do about it, instead
+  of the lease alone answering `local transport active`. The client's own line stops
+  claiming an active transport when none of its bound sessions can take one. A receiver
+  serving a different version than its binding recorded is named rather than hidden, and
+  a client with nothing to re-verify is reported exactly as before.
 - `acc uninstall` retires the binding records and pins its own install produced instead
   of leaving them to block the next install, when the removal leaves no client installed.
   Runtime leases are deliberately left alone: a lease also protects the generation its
@@ -53,13 +69,13 @@
 
 | Candidate artifact | Value |
 |---|---|
-| Built from | `9fef5d2cbcab35fdae91d1c532be91bd30a9abf7` |
-| Tarball | `agents-can-communicate-0.5.0.tgz`, 379,955 bytes, 272 files |
-| sha256 | `231916c18ff3e0e4b1422e9ca9404b8cf15c0edfb6b97bd1efeccb27fdfd5e9a` |
+| Built from | `99737db899d92b2d26bea2016571cf1878b4c84a` |
+| Tarball | `agents-can-communicate-0.5.0.tgz`, 382,589 bytes, 272 files |
+| sha256 | `8be810cf1f85eca96c63f79325c13ace80cfa5e34b7bc999b09abe1ea03bf62b` |
 
 The exact archive passed installed-package verification and all 27 packed managed-runtime
 checks, covering install, bootstrap, reinstall, update, degraded update and diagnostics.
-The full suite passed with 2,106 tests, 2,105 passes, zero failures and one skip, which is
+The full suite passed with 2,115 tests, 2,114 passes, zero failures and one skip, which is
 a machine fact rather than a result: the Gemini CLI is installed on the release machine, so
 the case that requires it to be absent cannot run there. This candidate has not been tagged
 or published.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -238,6 +238,13 @@ sessionId · generation · adapterId · clientVersion · availableModes
 livePolicy · opaqueEndpointRef · leaseUntil
 ```
 
+`clientVersion` is the version that answered the handshake and was admitted by the
+adapter's captured contract — the process that will serve this binding's live pushes,
+which is not always the version the client's own executable reports. A background
+service that updated under its CLI serves the updated build, and the binding names that
+build. The version the executable reported is recorded separately, beside the session's
+owner record.
+
 The recipient owns `livePolicy` because native push may start a model turn:
 
 - `off`: inbox and normal next-turn paths only;

--- a/docs/release-evidence/v0.5.0.md
+++ b/docs/release-evidence/v0.5.0.md
@@ -1,0 +1,97 @@
+# ACC 0.5.0 candidate evidence
+
+This candidate is prepared for review. It has not been tagged or published.
+It closes the activation gate and native delivery eligibility on a declared
+contract instead of on the identity of a process version, pins a session to the
+generation it started with, reclaims generations nothing references, and retires
+the holds `acc uninstall` leaves behind.
+
+| Measurement | Value |
+|---|---|
+| Built from | `99737db899d92b2d26bea2016571cf1878b4c84a` |
+| Archive | `agents-can-communicate-0.5.0.tgz`, 382,589 bytes, 272 files |
+| SHA-256 | `8be810cf1f85eca96c63f79325c13ace80cfa5e34b7bc999b09abe1ea03bf62b` |
+| Platform / Node | macOS arm64 / 26.5.1 |
+| Packed managed checks | 27/27 |
+
+The exact archive passed `scripts/verify-package.mjs`. The root and all bundled
+packages are aligned to 0.5.0. The full suite passed with 2,115 tests, 2,114
+passes, zero failures and one skip; the skipped uninstall case requires Gemini
+CLI to be absent and it is installed on the capture machine.
+
+## Live client verification
+
+Two independently opened clients in one workspace, `/private/tmp/acc-live-050`,
+on macOS arm64:
+
+| Client | Version | Participant |
+|---|---|---|
+| Claude Code | 2.1.268 | `claude_code-tgSdrM` |
+| Codex CLI | 0.154.0, served by an `app-server` daemon running 0.153.4 | `codex-OozX9O` |
+
+The version difference between the Codex CLI and the daemon serving it is the
+condition this release exists to tolerate. It was present throughout, and no
+daemon restart and no change to how either client is launched was required.
+
+A complete exchange between the two clients, read back from the store rather
+than from either client's screen:
+
+| From | To | Kind | Receipt |
+|---|---|---|---|
+| `claude_code-tgSdrM` | `codex-OozX9O` | question | acknowledged |
+| `codex-OozX9O` | `claude_code-tgSdrM` | answer | offered |
+
+Both legs were delivered natively: `codex-app-server` into Codex and
+`claude-channel` into Claude Code. A manually attached participant with no
+native adapter received its messages over `durable` with
+`recipient_unavailable`, which is the correct outcome for a participant that
+has no channel.
+
+## A defect this capture found, and the suite did not
+
+The first live capture failed. Every send into Codex fell back to `durable`
+with `recipient_unavailable` while `acc doctor` reported
+`local transport active`.
+
+The cause was one surviving identity comparison, one layer above the four this
+release replaced. `receiverFor` in the Codex adapter required the native
+endpoint's `clientVersion` to equal the delivery binding's. This release had
+begun persisting the daemon's serving version into the endpoint, while the hook
+runner still published the detected CLI version onto the binding, so the two
+records disagreed by construction in exactly the case the release was meant to
+support: endpoint `0.153.4`, binding `0.154.0`.
+
+Eligibility, the binding lease, presence, thread location and openai/codex#42457
+were each ruled out by measurement before the cause was found. The counterfactual
+settled it: with only the binding's recorded version corrected, a live push
+reached the running Codex session and it took a turn.
+
+The fix makes both records carry the version the handshake reported and the
+contract admitted, which is what will serve. `receiverFor`'s comparison was
+removed rather than converted to a contract check: the endpoint identifier
+already settles identity, and a contract check there would judge a bind-time
+snapshot rather than the process answering. The cross-record comparison moved to
+`acc doctor`, where the condition is named instead of silently refusing.
+
+`acc doctor` was reporting handshake state rather than deliverability, which is
+why it showed health while every send fell back. It now verifies the receiver
+and reports `receiver verified` for a session that can actually be delivered to.
+
+This defect passed 2,097 unit and acceptance tests and a whole-branch review,
+because every layer was correct in isolation and the disagreement lived at the
+seam between them. A seam test now covers it: a real store, service, hook runner,
+Codex adapter, router and socket, with the daemon and CLI versions deliberately
+different. That test fails against the unfixed tree with the reported symptom.
+
+## Limits
+
+The first update after this release still waits for every live process to exit.
+The holds it must judge were written before the contract field existed, so they
+declare no contract and remain conservative holds. Updates after that do not.
+
+A `STORE_VERSION` change still requires every live process to exit. That is the
+case the activation gate exists for, and this release does not weaken it.
+
+Native delivery binds at a session's first turn. A session that has just opened
+and has not taken a turn holds no live channel, and messages to it are recorded
+durably until it does.

--- a/packages/adapter-codex/src/native-delivery.mjs
+++ b/packages/adapter-codex/src/native-delivery.mjs
@@ -74,8 +74,15 @@ export async function verifyReceiver(peer, endpoint, { probe = probeCodexQueue,
   locate = locateCodexThread } = {}) {
   const result = await probe(peer, { threadId: endpoint.threadId });
   if (!result.supported) {
-    return { reasonCode: result.reasonCode === "probe_timeout" ? "handshake_timeout" : "protocol_mismatch",
-      servingVersion: null };
+    // probeCodexQueue applies the same floor and answers first, so a daemon
+    // serving below the minimum arrives here as a refused probe rather than
+    // reaching the explicit check below. Reporting that as a protocol
+    // mismatch named the wrong condition everywhere it surfaced - doctor,
+    // the offer's safe error code, the recorded failure - and left the
+    // version answer this function already knows how to give unreachable.
+    return { reasonCode: result.reasonCode === "probe_timeout" ? "handshake_timeout"
+      : result.reasonCode === "below_minimum_version" ? "handshake_version_mismatch"
+        : "protocol_mismatch", servingVersion: null };
   }
   if (compareStableVersions(result.serverVersion, CODEX_QUEUE_MINIMUM) < 0) {
     return { reasonCode: "handshake_version_mismatch", servingVersion: null };
@@ -117,10 +124,26 @@ export async function bindNativeSession({ event, clientPid, clientVersion, runti
   }
 }
 
+// Resolving the binding's opaque reference is the whole of the identity check:
+// the endpoint id is 128 random bits minted per bind, readNativeEndpoint
+// re-checks that the record it read carries that exact id, and no two bindings
+// can name the same record.
+//
+// The two records' clientVersion snapshots used to be compared here as well.
+// That was never identity - the id already settles that - it was a third
+// version rule, and the only one applied to a stored snapshot rather than to
+// the process now answering. It is deliberately gone. It cannot refuse
+// anything verifyReceiver does not refuse better two lines on, against the
+// version that actually answers, with the thread and cwd, before anything is
+// queued; and against the snapshot it could only ever be vacuous, because a
+// record is written solely from a serving version that already cleared
+// CODEX_QUEUE_MINIMUM. What it did do was fire on the case 0.5.0 exists to
+// support: the endpoint records what the daemon serves, the binding recorded
+// what `codex --version` printed, and a daemon that had updated under its CLI
+// was refused here on that difference alone.
 async function receiverFor(binding, runtimeDir) {
   const endpoint = await readNativeEndpoint({ runtimeDir, endpointId: binding?.opaqueEndpointRef });
-  return endpoint?.clientVersion === binding?.clientVersion
-    && await socketIsReady(endpoint?.socketPath) ? endpoint : null;
+  return endpoint !== null && await socketIsReady(endpoint.socketPath) ? endpoint : null;
 }
 
 export async function refreshNativeSession({ binding, runtimeDir, timeoutMs = 750,

--- a/packages/adapter-codex/test/native-delivery.test.mjs
+++ b/packages/adapter-codex/test/native-delivery.test.mjs
@@ -68,6 +68,35 @@ test("bind persists and returns the daemon's served version, not the caller's st
     assert.equal(endpoint.clientVersion, "0.154.0");
   });
 
+test("the endpoint reference alone resolves the receiver; a stored version never gates it",
+  async t => {
+    const h = await nativeFixture(t);
+    const handshake = await native.bindNativeSession(h);
+    assert.equal(handshake.supported, true);
+    // A binding that names this exact endpoint but records a different
+    // version. That is what a binding published by an older generation looks
+    // like during an in-place update, when the hook code still running in one
+    // session records the detected CLI while this adapter records what the
+    // daemon serves. The endpoint id settles identity; the live check settles
+    // compatibility. A stored snapshot decides neither, and refusing on it
+    // was what turned every send in exactly that case into a durable
+    // fallback.
+    const stale = { opaqueEndpointRef: handshake.opaqueEndpointRef, clientVersion: "0.154.0" };
+    const offer = await native.offerMessage({ ...h, binding: stale, message });
+    assert.equal(offer.accepted, true);
+    assert.equal(offer.clientVersion, "0.152.1", "the version that answered decides, and is reported");
+    assert.equal(h.state.queue.length, 1);
+    // Refusal still comes from the live rule: a daemon below the captured
+    // minimum is refused no matter what either record remembers.
+    h.state.version = "0.151.0";
+    const refused = await native.offerMessage({ ...h,
+      binding: { ...stale, clientVersion: "0.151.0" },
+      message: { ...message, messageId: "message_2" } });
+    assert.equal(refused.accepted, false);
+    assert.equal(refused.safeErrorCode, "unsupported_client_version");
+    assert.equal(h.state.queue.length, 1);
+  });
+
 test("sender environment cannot replace the bound receiver socket or thread", async t => {
   const h = await nativeFixture(t);
   const handshake = await native.bindNativeSession(h);

--- a/packages/adapter-sdk/src/native-delivery.mjs
+++ b/packages/adapter-sdk/src/native-delivery.mjs
@@ -221,6 +221,15 @@ function validateNativeHandshakeShape(handshake) {
 
 // The per-session half: the same static rule again, then the adapter's live
 // handshake facts. The launch-time executable fingerprint stays probe-only.
+//
+// An admitted verdict reports the version it admitted as `clientVersion`. That
+// is the whole point of returning it: the caller publishes a binding, and the
+// binding must record the version the admission actually rests on - the one
+// that will serve - rather than the caller's own detected-CLI claim. 0.5.0
+// judged the serving version here and left the caller publishing its claim, so
+// the two records disagreed on every machine where a daemon had updated under
+// its CLI, which is exactly the case the release exists to support. A refused
+// verdict admits nothing and carries null.
 export function validateNativeHandshake(adapter, { clientVersion, platform, handshake }) {
   // Same rationale as the probe: the handshake names the session that will
   // actually serve, so the static rule is judged against that version. Only
@@ -228,7 +237,8 @@ export function validateNativeHandshake(adapter, { clientVersion, platform, hand
   // a malformed handshake still returns a closed result rather than throwing.
   const serving = isText(handshake?.clientVersion) ? handshake.clientVersion : clientVersion;
   const rule = evaluateVersionContract(adapter, { clientVersion: serving, platform });
-  const base = { ok: false, reasonCode: null, protocolContract: rule.protocolContract, modes: [],
+  const base = { ok: false, reasonCode: null, clientVersion: null,
+    protocolContract: rule.protocolContract, modes: [],
     opaqueEndpointRef: null, leaseUntil: null };
   const closedResult = reasonCode => deepFreeze({ ...base, reasonCode });
   if (rule.reasonCode !== null) return closedResult(rule.reasonCode);
@@ -238,6 +248,9 @@ export function validateNativeHandshake(adapter, { clientVersion, platform, hand
   if (facts.protocolContract !== rule.protocolContract) return closedResult("protocol_mismatch");
   const modes = orderedModes(facts.modes);
   if (!modes.includes("livePush")) return closedResult("handshake_failed");
-  return deepFreeze({ ok: true, reasonCode: null, protocolContract: rule.protocolContract, modes,
+  // `serving` is a text version whenever the rule admitted it: every other
+  // shape leaves evaluateVersionContract at "version_unavailable" above.
+  return deepFreeze({ ok: true, reasonCode: null, clientVersion: serving,
+    protocolContract: rule.protocolContract, modes,
     opaqueEndpointRef: facts.opaqueEndpointRef, leaseUntil: facts.leaseUntil });
 }

--- a/packages/adapter-sdk/test/native-delivery.test.mjs
+++ b/packages/adapter-sdk/test/native-delivery.test.mjs
@@ -267,11 +267,13 @@ test("a declaration that is not a contract answers with a reason code rather tha
 test("the session handshake rechecks the static rule and publishes only adapter facts", () => {
   const ok = validateNativeHandshake(adapter(), { clientVersion: "2.1.259", platform: "darwin-arm64",
     handshake: handshake({ clientVersion: "2.1.259" }) });
-  assert.deepEqual(ok, { ok: true, reasonCode: null, protocolContract: "fixture-native-v1",
+  assert.deepEqual(ok, { ok: true, reasonCode: null, clientVersion: "2.1.259",
+    protocolContract: "fixture-native-v1",
     modes: ["livePush", "idleWake", "busyQueue", "replyRoute"],
     opaqueEndpointRef: "adapter-owned-endpoint-id", leaseUntil: "2026-09-02T12:01:00.000Z" });
   assert.equal(Object.isFrozen(ok), true);
-  const closed = reasonCode => ({ ok: false, reasonCode, protocolContract: "fixture-native-v1",
+  const closed = reasonCode => ({ ok: false, reasonCode, clientVersion: null,
+    protocolContract: "fixture-native-v1",
     modes: [], opaqueEndpointRef: null, leaseUntil: null });
   const check = (clientVersion, patch, platform = "darwin-arm64") => validateNativeHandshake(adapter(),
     { clientVersion, platform, handshake: handshake({ clientVersion, ...patch }) });
@@ -285,10 +287,20 @@ test("the session handshake rechecks the static rule and publishes only adapter 
     leaseUntil: null, reasonCode: "handshake_timeout", clientVersion: null }),
   closed("handshake_timeout"));
   // The handshake names the session that will actually serve; a build newer
-  // than the detected binary is admitted by that version, not refused for it.
+  // than the detected binary is admitted by that version, not refused for it -
+  // and the verdict reports that version, because it is the one the admission
+  // rests on and the one a caller must record on the binding it publishes.
+  // Reporting the detected 2.1.258 here would put a version on the binding
+  // that nothing ever verified.
   assert.deepEqual(check("2.1.258", { clientVersion: "2.1.260" }), { ok: true, reasonCode: null,
+    clientVersion: "2.1.260",
     protocolContract: "fixture-native-v1", modes: ["livePush", "idleWake", "busyQueue", "replyRoute"],
     opaqueEndpointRef: "adapter-owned-endpoint-id", leaseUntil: "2026-09-02T12:01:00.000Z" });
+  // A handshake that names no version at all is judged by the detected one, so
+  // that is what the verdict admitted and what it reports.
+  assert.equal(validateNativeHandshake(adapter(), { clientVersion: "2.1.258",
+    platform: "darwin-arm64", handshake: handshake({ clientVersion: null }) }).clientVersion,
+  "2.1.258");
   // The rule is applied to the serving version, so a serving version below
   // the minimum is refused even when the detected binary is newer.
   assert.deepEqual(check("2.1.999", { clientVersion: "2.1.257" }), closed("below_minimum_version"));

--- a/packages/cli/src/doctor-command.mjs
+++ b/packages/cli/src/doctor-command.mjs
@@ -232,7 +232,13 @@ export async function runDoctor({ options, context, runtime }) {
   const service = context.service ?? await context.openService();
   const status = await service.collectStatus({});
   updateNativeRuntime(adapters, status.deliveryBindings);
-  await updateNativeSessions(adapters, { service, status, root, now: clock.now() });
+  // The runtime state above is read from the binding records alone. The
+  // session pass then asks each adapter whether the receiver those records
+  // name can still take a push, and downgrades anything that only looked
+  // active. It needs the adapter objects to ask, which the diagnostic entries
+  // do not carry.
+  await updateNativeSessions(adapters, { service, status, root, now: clock.now(),
+    registry: ALL_ADAPTERS() });
   for (const adapter of adapters) {
     adapter.remediation.push(...nativeRemediation(adapter));
   }

--- a/packages/cli/src/native-session-diagnostics.mjs
+++ b/packages/cli/src/native-session-diagnostics.mjs
@@ -1,10 +1,45 @@
 import { listSessionBindings, loadNativeAttempt } from "@agents-can-communicate/adapter-sdk";
 import { describeNativeReason } from "@agents-can-communicate/installer";
 
+// One re-verification per bound session, well inside a doctor run's budget.
+const VERIFY_TIMEOUT_MS = 750;
+
+// A lease is not deliverability.
+//
+// Doctor used to answer "local transport active" from the binding record
+// alone: present, policy on, lease not yet expired. All three can hold while
+// every single send falls back to durable, because none of them says the
+// receiver that binding names can still be reached. Measured exactly that way
+// - `Codex CLI live delivery: available; enabled (actionable); local transport
+// active` on a machine where live delivery had never once worked.
+//
+// So ask the adapter the question the router asks: its own bounded
+// re-verification of this exact binding, which resolves the opaque reference
+// to the receiver record, checks the socket, and re-reads the version,
+// protocol, thread and workspace from the process that would actually serve
+// the push. Read-only - it writes no record and renews no lease - and it
+// answers in the closed reason-code vocabulary doctor already speaks. An
+// adapter with no such method gets no verdict and keeps the lease answer.
+async function verifyDelivery(adapter, { binding, runtimeDir }) {
+  if (typeof adapter?.refreshNativeSession !== "function") return null;
+  try {
+    const handshake = await adapter.refreshNativeSession({ binding, runtimeDir,
+      timeoutMs: VERIFY_TIMEOUT_MS });
+    return handshake?.supported === true
+      ? { deliverable: true, reasonCode: null, clientVersion: handshake.clientVersion ?? null }
+      : { deliverable: false, reasonCode: handshake?.reasonCode ?? "handshake_failed",
+        clientVersion: null };
+  } catch {
+    return { deliverable: false, reasonCode: "handshake_failed", clientVersion: null };
+  }
+}
+
 // Session diagnostics are read only here, never projected into agent context.
 // Verify the owner generation against core before attributing any last attempt.
-export async function updateNativeSessions(adapters, { service, status, root, now }) {
+export async function updateNativeSessions(adapters, { service, status, root, now,
+  registry = [] }) {
   const owners = await listSessionBindings({ runtimeDir: root }).catch(() => []);
+  const byAdapterId = new Map((registry ?? []).map(adapter => [adapter.id, adapter]));
   const transports = new Map();
   for (const entry of adapters) {
     const native = entry.nativeDelivery;
@@ -23,12 +58,27 @@ export async function updateNativeSessions(adapters, { service, status, root, no
       const binding = transports.get(peer.participantId).find(b => b.sessionId === peer.sessionId
         && b.generation === current.generation && b.adapterId === entry.adapterId
         && b.availableModes.includes("livePush"));
-      const runtime = native.policySource === "installation-record" && !native.configured
-        ? "inactive" : !binding ? "unbound"
-          : Date.parse(binding.leaseUntil) > Date.parse(now) ? "active" : "degraded";
+      const off = native.policySource === "installation-record" && !native.configured;
+      const leased = binding !== undefined && Date.parse(binding.leaseUntil) > Date.parse(now);
+      // Only where the old rule would have said "active": everywhere else the
+      // answer is already degraded or unbound, and a live check would buy
+      // nothing but a socket round trip.
+      const delivery = off || !leased ? null
+        : await verifyDelivery(byAdapterId.get(entry.adapterId), { binding, runtimeDir: root });
+      const runtime = off ? "inactive"
+        : binding === undefined ? "unbound"
+          : leased && (delivery === null || delivery.deliverable) ? "active" : "degraded";
       native.sessions.push({ sessionId: peer.sessionId, participantId: peer.participantId,
-        presence: peer.presence, runtime,
+        presence: peer.presence, runtime, clientVersion: binding?.clientVersion ?? null, delivery,
         lastAttempt: owner === null ? null : await loadNativeAttempt({ runtimeDir: root, ...owner }) });
+    }
+    // The adapter's own line is the one a reader sees first, and it was the
+    // one claiming health while nothing could be delivered. If this adapter
+    // has bound sessions in this workspace and not one of them can take a
+    // push, this is not an active transport.
+    if (native.runtime === "active" && native.sessions.length > 0
+      && !native.sessions.some(session => session.runtime === "active")) {
+      native.runtime = "degraded";
     }
   }
 }
@@ -37,8 +87,15 @@ const failures = {
   client_process_unknown: "the client process could not be identified; start a new client session",
   handshake_failed: "the session handshake failed; check the client's integration/channel setup",
   handshake_timeout: "the session handshake timed out; check the local channel and retry on the next turn",
-  handshake_version_mismatch: "the session and CLI versions differ; start a new client session",
+  // Since the contract gate shipped, this reason means the version now serving
+  // is below the captured minimum - not that two reported versions differ.
+  // A daemon serving an older build than its CLI is ordinary and admitted; the
+  // fix for this one is to restart the service onto the build the CLI has.
+  handshake_version_mismatch: "the version now serving is below the captured native delivery "
+    + "minimum; restart the client's local delivery service",
   session_generation_stale: "the session was replaced during the handshake",
+  workspace_identity_unavailable: "the bound client session is no longer in this workspace; "
+    + "start a new client session here",
 };
 
 function describeAttempt(attempt) {
@@ -56,9 +113,28 @@ function describeAttempt(attempt) {
   return `last attempt ${attempt.at}: ${detail}`;
 }
 
+// The two records this joins are the delivery binding core published and the
+// receiver the adapter privately holds. Naming a difference between them is
+// the point: one that still delivers is information about a service that
+// updated under its binding, and one that does not is the whole reason a send
+// falls back, said where a reader can act on it.
+function describeDelivery(session) {
+  const delivery = session.delivery;
+  if (delivery === null || delivery === undefined) return null;
+  if (!delivery.deliverable) {
+    return "no live delivery: "
+      + (failures[delivery.reasonCode] ?? describeNativeReason(delivery.reasonCode));
+  }
+  return delivery.clientVersion !== null && delivery.clientVersion !== session.clientVersion
+    ? `receiver verified, now serving ${delivery.clientVersion} `
+      + `where this binding recorded ${session.clientVersion}`
+    : "receiver verified";
+}
+
 export function nativeSessionLines(adapters) {
   return adapters.flatMap(entry => (entry.nativeDelivery.sessions ?? []).map(session =>
     `  ${entry.displayName} session ${session.participantId} (${session.sessionId}): `
     + `${session.runtime === "active" ? "local transport active" : session.runtime}; `
-    + describeAttempt(session.lastAttempt)));
+    + [describeDelivery(session), describeAttempt(session.lastAttempt)]
+      .filter(part => part !== null).join("; ")));
 }

--- a/packages/cli/test/native-session-deliverability.test.mjs
+++ b/packages/cli/test/native-session-deliverability.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { nativeRemediation } from "../src/native-delivery-status.mjs";
+import { describeNative } from "../src/doctor-command.mjs";
+import { nativeSessionLines, updateNativeSessions } from "../src/native-session-diagnostics.mjs";
+
+// Doctor's old answer came from the binding record alone: present, policy on,
+// lease not yet expired. That is handshake state, not deliverability, and on a
+// machine where every send fell back to durable it still read "local transport
+// active". These cases hold the report to what the receiver can actually take.
+
+const NOW = "2026-09-02T12:00:00.000Z";
+const LEASE = "2026-09-02T12:01:00.000Z";
+const BOUND = "0.153.4";
+
+async function runtimeDir(t) {
+  const dir = await mkdtemp(path.join(tmpdir(), "acc-doctor-deliverability-"));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+const entry = () => ({ adapterId: "codex", displayName: "Codex CLI", present: true, installed: true,
+  nativeDelivery: { eligibility: "eligible", configured: true, policy: "actionable",
+    policySource: "installation-record", runtime: "active", modes: ["livePush"],
+    reasonCode: null, minimumVersion: "0.152.1", activation: "not_required",
+    sessionPolicy: "actionable" } });
+
+const service = (leaseUntil = LEASE) => ({
+  locateSession: async sessionId => ({ record: { sessionId, state: "open",
+    generation: "generation_a" } }),
+  listDeliveryBindings: async () => [{ sessionId: "session_a", generation: "generation_a",
+    adapterId: "codex", clientVersion: BOUND, availableModes: ["livePush"],
+    livePolicy: "actionable", opaqueEndpointRef: "codex_endpoint_ref", leaseUntil }],
+});
+
+const status = { participants: [{ sessionId: "session_a", participantId: "reviewer",
+  harness: "codex", presence: "live" }] };
+
+const adapterThat = refreshNativeSession => ({ id: "codex", refreshNativeSession });
+
+async function report(t, adapter, { leaseUntil } = {}) {
+  const adapters = [entry()];
+  await updateNativeSessions(adapters, { service: service(leaseUntil), status,
+    root: await runtimeDir(t), now: NOW, registry: adapter === null ? [] : [adapter] });
+  return { adapters, lines: nativeSessionLines(adapters) };
+}
+
+test("a binding whose receiver refuses is reported degraded, not as an active transport",
+  async t => {
+    // Everything the old rule looked at still says healthy: the binding is
+    // there, livePush is offered, the policy is on and the lease has a minute
+    // left. The receiver is the only thing that knows better.
+    const { adapters, lines } = await report(t, adapterThat(async () => ({ supported: false,
+      clientVersion: null, protocolContract: "codex-app-server-thread-queue-v1", modes: [],
+      opaqueEndpointRef: null, leaseUntil: null, reasonCode: "handshake_version_mismatch" })));
+    const [session] = adapters[0].nativeDelivery.sessions;
+    assert.equal(session.runtime, "degraded");
+    assert.deepEqual(session.delivery, { deliverable: false,
+      reasonCode: "handshake_version_mismatch", clientVersion: null });
+    // The adapter's own line is what a reader sees first, so it must stop
+    // claiming health too.
+    assert.equal(adapters[0].nativeDelivery.runtime, "degraded");
+    assert.equal(describeNative(adapters[0].nativeDelivery),
+      "available; enabled (actionable); channel unreachable");
+    // The condition is named, in the vocabulary doctor already speaks, and so
+    // is something to do about it.
+    assert.match(lines[0], /no live delivery: the version now serving is below the captured/);
+    assert.match(lines[0], /restart the client's local delivery service/);
+    assert.match(nativeRemediation(adapters[0]).join("\n"),
+      /no verified live channel in this workspace/);
+  });
+
+test("an unreachable receiver is a refusal, not a crash, whatever the adapter does", async t => {
+  for (const refresh of [async () => { throw new Error("socket /secret/path refused"); },
+    async () => undefined]) {
+    const { adapters, lines } = await report(t, adapterThat(refresh));
+    assert.equal(adapters[0].nativeDelivery.sessions[0].runtime, "degraded");
+    assert.equal(adapters[0].nativeDelivery.sessions[0].delivery.reasonCode, "handshake_failed");
+    assert.equal(lines.join("\n").includes("secret"), false);
+  }
+});
+
+test("a verified receiver stays active and names a service that moved under its binding",
+  async t => {
+    const { adapters, lines } = await report(t, adapterThat(async () => ({ supported: true,
+      clientVersion: "0.154.0", protocolContract: "codex-app-server-thread-queue-v1",
+      modes: ["livePush", "idleWake", "busyQueue"], opaqueEndpointRef: "codex_endpoint_ref",
+      leaseUntil: LEASE, reasonCode: null })));
+    assert.equal(adapters[0].nativeDelivery.sessions[0].runtime, "active");
+    assert.equal(adapters[0].nativeDelivery.runtime, "active");
+    // The binding records the version admitted when it was published; the
+    // receiver answers with what is serving now. A difference the contract
+    // still admits is information, not a refusal - and saying it is how the
+    // two records stop being invisible to the person reading this.
+    assert.match(lines[0],
+      /local transport active; receiver verified, now serving 0\.154\.0 where this binding recorded 0\.153\.4/);
+  });
+
+test("an adapter that cannot re-verify keeps the lease answer rather than being refused",
+  async t => {
+    // Every adapter but Codex is in this position today. Reporting "degraded"
+    // because nothing could be asked would be a different false report.
+    const { adapters, lines } = await report(t, null);
+    assert.equal(adapters[0].nativeDelivery.sessions[0].delivery, null);
+    assert.equal(adapters[0].nativeDelivery.sessions[0].runtime, "active");
+    assert.equal(adapters[0].nativeDelivery.runtime, "active");
+    assert.doesNotMatch(lines[0], /receiver verified|no live delivery/);
+  });
+
+test("an expired lease is already degraded and is never re-verified over the wire", async t => {
+  let asked = 0;
+  const { adapters } = await report(t, adapterThat(async () => { asked += 1;
+    return { supported: true, clientVersion: BOUND, protocolContract: "x", modes: ["livePush"],
+      opaqueEndpointRef: "codex_endpoint_ref", leaseUntil: LEASE, reasonCode: null }; }),
+  { leaseUntil: "2026-09-02T11:59:00.000Z" });
+  assert.equal(adapters[0].nativeDelivery.sessions[0].runtime, "degraded");
+  assert.equal(adapters[0].nativeDelivery.sessions[0].delivery, null);
+  assert.equal(asked, 0);
+});

--- a/packages/hook-runner/src/native-binding.mjs
+++ b/packages/hook-runner/src/native-binding.mjs
@@ -75,8 +75,17 @@ export async function establishNativeBinding({ adapter, event, hookBinding, clie
     if (!(lease > now)) return outcome("degraded", "handshake_failed");
     const ceiling = now + 2 * heartbeatCadenceMs;
     const leaseUntil = lease > ceiling ? new Date(ceiling).toISOString() : verdict.leaseUntil;
+    // The binding's clientVersion is the version this binding's live pushes
+    // will be served by, as the handshake reported it and the contract
+    // admitted it - not the version `--version` printed. The two differ
+    // whenever a client's background service has updated under its CLI, and
+    // that is the case native delivery exists to survive. Publishing the
+    // detected CLI version instead made the binding disagree with the
+    // adapter's own endpoint record, which since 0.5.0 carries the serving
+    // version, and every send fell back to durable. The detected CLI version
+    // is not lost: the session-owner record beside this one still carries it.
     await service.publishDeliveryBinding({
-      sessionId, generation, adapterId: adapter.id, clientVersion,
+      sessionId, generation, adapterId: adapter.id, clientVersion: verdict.clientVersion,
       availableModes: [...verdict.modes], livePolicy: policy,
       opaqueEndpointRef: verdict.opaqueEndpointRef, leaseUntil,
     });

--- a/packages/hook-runner/test/native-binding.test.mjs
+++ b/packages/hook-runner/test/native-binding.test.mjs
@@ -168,6 +168,22 @@ test("a handshake reporting a different but eligible version activates, judged b
     assert.equal(service.calls.some(([name]) => name === "publish"), true);
   });
 
+test("the published binding carries the version that will serve, not the detected binary",
+  async () => {
+    // 2.1.258 is what `--version` printed and 2.1.259 is what answered the
+    // handshake. Both satisfy the contract, so activation says nothing about
+    // which one was recorded - only the published record does. The adapter
+    // writes its own endpoint record from the serving version, and every
+    // later read joins the two; publishing the detected version here left
+    // them naming different versions and turned every live send into a
+    // durable fallback.
+    const service = fakeService();
+    await establish(nativeAdapter(async () => ({ ...HANDSHAKE, clientVersion: "2.1.259" })),
+      service, { clientVersion: "2.1.258" });
+    const [, published] = service.calls.find(([name]) => name === "publish");
+    assert.equal(published.clientVersion, "2.1.259");
+  });
+
 test("a stale generation at publish time is reported, and the old binding is cleared", async () => {
   const service = fakeService({ publishError: new AccError(EXIT.CONFLICT, "stale") });
   const result = await establish(nativeAdapter(), service);

--- a/tests/process/native-binding-reaches-the-receiver.test.mjs
+++ b/tests/process/native-binding-reaches-the-receiver.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { createCodexAdapter } from "@agents-can-communicate/adapter-codex";
+import { createCoordinationService } from "@agents-can-communicate/core";
+import { createDeliveryRouter } from "@agents-can-communicate/delivery-router";
+import { openFilesystemStore } from "@agents-can-communicate/storage-filesystem";
+
+import { establishNativeBinding } from "../../packages/hook-runner/src/native-binding.mjs";
+import { controlledCodexDaemon, THREAD } from "../helpers/codex-daemon.mjs";
+import { createFakeIds } from "../helpers/memory-store.mjs";
+
+// The seam this file exists for: the hook runner publishes the delivery
+// binding, the Codex adapter writes the endpoint record, and the receiver
+// path reads both and compares them. Every layer here is the shipped one -
+// real store, real core service, real hook-runner publish, real adapter, real
+// router, real socket - because the defect this guards lived precisely
+// between two layers that each passed their own tests. The daemon serves a
+// version the detected CLI does not report, which is the case the whole
+// contract-gated release exists to support.
+const SERVING = "0.153.4";
+const DETECTED_CLI = "0.154.0";
+const CAPTURED = "darwin-arm64";
+const shortTmp = () => (process.platform === "win32" ? tmpdir() : "/tmp");
+
+async function directory(t, prefix) {
+  const created = await realpath(await mkdtemp(path.join(shortTmp(), prefix)));
+  t.after(() => rm(created, { recursive: true, force: true }));
+  return created;
+}
+
+async function seam(t) {
+  const cwd = await directory(t, "acc-seam-cwd-");
+  const root = await directory(t, "acc-seam-store-");
+  const daemon = await controlledCodexDaemon(t, { cwd });
+  daemon.state.version = SERVING;
+  const clock = { now: () => new Date().toISOString() };
+  const ids = createFakeIds();
+  const workspaceId = "workspace_seam";
+  const store = await openFilesystemStore({ root, clock, ids, workspaceId });
+  const service = createCoordinationService({ store, clock, ids, pidIsAlive: () => true });
+  const receiver = await service.openSession({ workspaceId, participantId: "receiver",
+    sessionId: "session_receiver", harness: "codex", heartbeatCadenceMs: 30_000 });
+  const sender = await service.openSession({ workspaceId, participantId: "sender",
+    sessionId: "session_sender", harness: "fixture", heartbeatCadenceMs: 30_000 });
+  const adapter = createCodexAdapter();
+  const outcome = await establishNativeBinding({
+    adapter,
+    event: { kind: "sessionStart", sessionId: THREAD, cwd },
+    hookBinding: { accSessionId: receiver.sessionId, generation: receiver.generation,
+      clientPid: process.pid },
+    // What `codex --version` answered. The daemon has since moved on, and
+    // only it can say what will actually serve the push.
+    clientVersion: DETECTED_CLI,
+    platform: CAPTURED, livePolicy: "actionable", service, runtimeDir: root,
+    clock, env: daemon.env, timeoutMs: 5_000,
+  });
+  const bindings = await service.listDeliveryBindings({ participantId: "receiver",
+    now: clock.now() });
+  return { adapter, bindings, clock, cwd, daemon, outcome, receiver, root, sender, service };
+}
+
+const message = { messageId: "message_seam", kind: "question", subject: "Seam",
+  body: "does the published binding reach the receiver" };
+
+test("a binding published by the hook runner is one the Codex receiver accepts", async t => {
+  const s = await seam(t);
+  assert.deepEqual(s.outcome, { state: "active", reasonCode: null,
+    modes: ["livePush", "idleWake", "busyQueue"] });
+  assert.equal(s.bindings.length, 1);
+  const [binding] = s.bindings;
+  // The record names the process that will serve the push, not the binary the
+  // hook happened to find on PATH.
+  assert.equal(binding.clientVersion, SERVING);
+
+  const offer = await s.adapter.offerMessage({ binding, message, runtimeDir: s.root });
+  assert.equal(offer.accepted, true,
+    "the receiver refused the binding its own hook runner published");
+  assert.equal(offer.clientVersion, SERVING);
+  assert.equal(s.daemon.state.queue.length, 1);
+  assert.equal(s.daemon.state.queue[0].threadId, THREAD);
+  assert.equal(s.daemon.state.queue[0].clientUserMessageId, message.messageId);
+});
+
+test("the router delivers live over that binding instead of falling back to durable", async t => {
+  const s = await seam(t);
+  const router = createDeliveryRouter({ service: s.service, adapters: { codex: s.adapter },
+    clock: s.clock, platform: CAPTURED, readLivePolicy: async () => "actionable" });
+  const sent = await s.service.sendMessage({ sessionId: s.sender.sessionId,
+    generation: s.sender.generation, clientMessageId: "client_seam",
+    toParticipantIds: ["receiver"], kind: "question", obligation: "reply",
+    subject: "Seam", body: "does the router reach the running client",
+    artifacts: [], inReplyTo: null, handoff: null });
+  const [delivery] = await router.offer(sent);
+  assert.deepEqual(delivery, { recipientParticipantId: "receiver", outcome: "offered",
+    transport: "codex-app-server" });
+  assert.equal(s.daemon.state.queue.length, 1);
+});


### PR DESCRIPTION
## What went wrong

0.5.0 replaced four version-identity comparisons with contract checks so that a vendor CLI which updates while its long-running service keeps the old build no longer loses live delivery. A fifth comparison survived one layer above, and the release made it fire in exactly the case it was meant to fix.

`receiverFor` in the Codex adapter required the native endpoint's `clientVersion` to equal the delivery binding's. 0.5.0 began persisting the daemon's **serving** version into the endpoint, while the hook runner still published the detected **CLI** version onto the binding. Whenever the two differ, which is the whole point of the release, the records disagree by construction, the receiver is refused, and the router falls back to durable.

Found by a live capture against real clients: endpoint `0.153.4`, binding `0.154.0`, socket ready, `verifyReceiver` returning no reason code, thread located. Eligibility, lease, presence, thread attribution and openai/codex#42457 were each ruled out by measurement first. The counterfactual settled it: with only the binding's recorded version corrected, a live push reached the running Codex session and it took a turn.

## What changes

Both records now carry the version the handshake reported and the contract admitted, which is the version that will serve. The detected CLI version keeps its place on the session-owner record. The intended meaning of each is written down in `docs/PROTOCOL.md`.

`receiverFor`'s comparison is removed rather than converted to a contract check. The endpoint identifier already settles identity, and a contract check there would judge a bind-time snapshot rather than the process answering, making it vacuous by construction. Left in place as an always-true comparison it would be a tripwire rather than a guard, which is the shape that produced this defect. The cross-record comparison moves to `acc doctor`, where the condition is named instead of silently refusing.

`acc doctor` was reporting handshake state rather than deliverability, so it showed `local transport active` while every send fell back. It now verifies the receiver and reports `receiver verified` for a session that can actually be delivered to.

One smaller correction: `verifyReceiver` maps a probe's `below_minimum_version` onto `handshake_version_mismatch`, because the probe answered first and left that branch unreachable. It changes a diagnostic, not a decision.

## Why the suite did not catch it

Every layer was correct in isolation, and the disagreement lived at the seam between them, so 2,097 tests and a whole-branch review passed over it. A seam test now covers that seam: a real store, service, hook runner, Codex adapter, router and socket, with the daemon and CLI versions deliberately different. It fails against `main` with the exact reported symptom.

## Verification

Full suite: 2,115 tests, 2,114 passing, zero failures, one environment-dependent skip.

Live, on macOS arm64, with Claude Code 2.1.268 and a Codex CLI 0.154.0 served by an `app-server` daemon running 0.153.4: a question from Claude Code to Codex and an answer back, both delivered natively over `codex-app-server` and `claude-channel`, read back from the store rather than from either client's screen. No daemon restart and no launch change were required.

Recorded in `docs/release-evidence/v0.5.0.md`.