### PR TITLE
fix: Codex permission ownership survives the client writing its own tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.5.1 — release candidate
+
+- Codex permission ownership survives the client writing its own tables. ACC appends its
+  permission block at end of file and records the TOML table that encloses it, then tells
+  the user to trust ACC's hooks in Codex — and Codex writes each trusted hook as a new
+  `hooks.state` table above that block, changing the enclosing table. ACC read its own
+  documented setup step as a third-party edit: `acc doctor` reported working sender
+  permissions as unverified and advised a reinstall that could not repair them, and
+  `acc uninstall` would have left the block behind for manual review. The enclosing table
+  is now compared only for a block whose first declaration is a bare assignment, because
+  only such an assignment takes its meaning from the table above it; a block that opens
+  with its own header states its full path and is unaffected by what precedes it. Live
+  delivery itself was never broken by this — only the reporting and the clean removal.
+- Tests no longer leave their fixtures behind. `node:test` exposes cleanup through
+  `t.after`, which a test declared without its context cannot reach, and seven files took
+  a bare `mkdtemp` instead; the reclamation race test alone built 200 fixture trees per
+  run. A full suite left gigabytes in the system temp directory, invisible to CI because
+  its runners are discarded. Disposable roots now come from one shared helper that
+  registers their removal, and the race test clears each trial as it goes so its peak
+  usage is one fixture rather than two hundred. One further fixture escaped for a
+  different reason: its cleanup rebuilt the directory name from the prefix it asked for,
+  which never matches the random suffix `mkdtempSync` actually appends, so every run
+  removed a path that did not exist and kept the one that did.
+
 ## 0.5.0 — release candidate
 
 - Activation of a new managed runtime generation no longer waits for every live process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,23 @@
   which never matches the random suffix `mkdtempSync` actually appends, so every run
   removed a path that did not exist and kept the one that did.
 
+| Candidate artifact | Value |
+|---|---|
+| Built from | `f438cf8de8f2daac16fe975413df1491f3f1f4ae` |
+| Tarball | `agents-can-communicate-0.5.1.tgz`, 382,983 bytes, 272 files |
+| sha256 | `ac2d466cafbb5d92f29c6d659b20c80575ef8baae478e2637452669aee2b1027` |
+
+The exact archive passed installed-package verification and all 27 packed managed-runtime
+checks, covering install, bootstrap, reinstall, update, degraded update and diagnostics.
+The full suite passed with 2,117 tests, 2,116 passes, zero failures and one skip, which
+is the uninstall case that requires Gemini CLI to be absent and it is installed on the
+capture machine.
+
+Live delivery between Claude Code 2.1.268 and Codex CLI 0.154.0 was captured on a machine
+wiped of every ACC trace beforehand, installing from the public registry. Both directions
+were served natively — `claude-channel` and `codex-app-server` — and the peer-to-peer leg
+took seven seconds from request to answer. See `docs/release-evidence/v0.5.1.md`.
+
 ## 0.5.0 — release candidate
 
 - Activation of a new managed runtime generation no longer waits for every live process

--- a/docs/release-evidence/v0.5.1.md
+++ b/docs/release-evidence/v0.5.1.md
@@ -1,0 +1,127 @@
+# ACC 0.5.1 candidate evidence
+
+This candidate is prepared for review. It has not been tagged or published.
+It repairs the Codex permission-ownership record, which ACC's own documented
+setup step invalidated, and stops the test suite leaving its fixtures behind.
+
+| Measurement | Value |
+|---|---|
+| Built from | `f438cf8de8f2daac16fe975413df1491f3f1f4ae` |
+| Archive | `agents-can-communicate-0.5.1.tgz`, 382,983 bytes, 272 files |
+| SHA-256 | `ac2d466cafbb5d92f29c6d659b20c80575ef8baae478e2637452669aee2b1027` |
+| Platform / Node | macOS arm64 / 26.5.1 |
+| Packed managed checks | 27/27 |
+
+The exact archive passed `scripts/verify-package.mjs`. The root and all bundled
+packages are aligned to 0.5.1. The full suite passed with 2,117 tests, 2,116
+passes, zero failures and one skip; the skipped uninstall case requires Gemini
+CLI to be absent and it is installed on the capture machine.
+
+## A clean-machine install, verified end to end
+
+Every ACC trace was removed from the capture machine first: no `acc` on `PATH`,
+no global module under either installed Node version, no data home, no ACC
+process, no channel socket, and client configuration files restored to their
+pre-ACC bytes. `agents-can-communicate@0.5.0` was then installed from the public
+registry and set up with `acc install --delivery actionable`.
+
+| Step | Result |
+|---|---|
+| `npm install -g` | launcher reports 0.5.0 |
+| `acc install` | 4 adapters wired; Kimi correctly skipped as absent |
+| Managed runtime bootstrap | one generation, phase `ready`, store healthy |
+| `acc doctor` | store healthy, 4 of 5 adapters installed |
+
+## Live client verification
+
+Two independently opened clients in one workspace,
+`/Users/mmykola87/work/automatis-tools/agents-can-communicate`, on macOS arm64:
+
+| Client | Version | Participant |
+|---|---|---|
+| Claude Code | 2.1.268 | `claude_code-Ih14Of` |
+| Codex CLI | 0.154.0, served by an `app-server` daemon running 0.153.4 | `codex-dZzged` |
+
+The exchange, read back from the store rather than from either client's screen:
+
+| From | To | Kind | Transport | Receipt |
+|---|---|---|---|---|
+| `live-test-operator` | `codex-dZzged` | request | `codex-app-server` | acknowledged |
+| `live-test-operator` | `claude_code-Ih14Of` | request | `claude-channel` | acknowledged |
+| `codex-dZzged` | `claude_code-Ih14Of` | request | `claude-channel` | acknowledged |
+| `claude_code-Ih14Of` | `codex-dZzged` | answer | `codex-app-server` | offered |
+
+The peer-to-peer leg took seven seconds from Codex's request to Claude Code's
+answer. Neither client polled `acc inbox`: each message arrived as an injected
+block carrying the full subject and body, and the only CLI call either client
+made was its own reply. The manually attached operator, which has no native
+adapter, received its answers `queued` with `recipient_unavailable`, the correct
+outcome for a participant that holds no channel.
+
+This capture exercised the installed 0.5.0 runtime. Delivery is unchanged by
+this release; what 0.5.1 changes is the ownership record described below, which
+governs reporting and removal rather than transport.
+
+## The defect this capture found
+
+With both channels live and delivery demonstrably working, `acc doctor` still
+reported `sender permissions unverified` for Codex and advised
+`acc install --adapter codex`, which could not have repaired anything.
+
+ACC appends its permission block at end of `config.toml` and records the TOML
+table enclosing it. It then instructs the user to open Codex and trust ACC's
+hooks — and Codex writes each trusted hook as a new `hooks.state` table, which
+lands above that block. On the capture machine the recorded table was
+`hooks.state."chrome@openai-bundled:…"` and the block's actual enclosing table
+had become `hooks.state."agents-can-communicate@acc-local:hooks.json:stop:0:0"`.
+
+`inspectPermissions` compared the two and answered `customized`, so ACC read its
+own documented setup step as a third-party edit. The consequences chained:
+`acc doctor` reported working permissions as unverified, `prepareLivePermissions`
+returned early and refused to repair them, and `acc uninstall` would have left
+the block behind for manual review rather than restoring the file.
+
+The enclosing table is now compared only for a block whose first declaration is a
+bare assignment. Only such an assignment takes its meaning from the table above
+it; a block that opens with its own header states its full path and is
+unaffected by what precedes it. Against the capture machine's real
+`config.toml`, ownership reads `owned` and the diagnostic reads
+`local socket permissions configured for new sessions`.
+
+The regression test asserts the state survives a client writing new tables above
+the block, and fails against the unfixed tree. A companion test asserts the
+strict comparison still applies to a block that opens with a bare assignment, so
+the relaxation cannot spread to the case it was never sound for.
+
+## A second defect, found by the cleanup
+
+Removing every ACC trace from the machine surfaced 16,578 entries and 3.4 GB of
+test fixtures in the system temporary directory, accumulated over two days of
+runs. `node:test` exposes cleanup through `t.after`, reachable only from a
+test's own context, and seven files declared their tests without that context
+and took a bare `mkdtemp` instead; the reclamation race test alone built 200
+fixture trees per run. One further fixture escaped for a different reason: its
+cleanup rebuilt the directory name from the prefix it asked for, which never
+matches the random suffix `mkdtempSync` appends, so every run removed a path
+that did not exist.
+
+CI never noticed because its runners are discarded. Disposable roots now come
+from one shared helper that registers their removal, and the race test clears
+each trial as it goes. A full suite after the change left one entry: the live
+channel socket directory of the running installation, which is not a fixture.
+
+## Limits
+
+The permission relaxation is scoped to the enclosing-table comparison. Every
+other ownership check is unchanged: the body hash, the restore metadata shape,
+the top-level requirement on the selection block, the refusal of foreign
+assignments under generated headers, and the scope verification performed before
+any byte is restored.
+
+A configuration whose ownership was already recorded before this change reads
+correctly without rewriting: the fix relaxes a comparison rather than altering
+what is written, so existing records stay valid.
+
+The limits recorded for 0.5.0 still apply. The first update after that release
+waits for every live process to exit, a `STORE_VERSION` change still requires
+every live process to exit, and native delivery binds at a session's first turn.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-can-communicate",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "bundleDependencies": [
         "@agents-can-communicate/adapter-claude-code",
         "@agents-can-communicate/adapter-codex",
@@ -114,59 +114,59 @@
     },
     "packages/adapter-claude-code": {
       "name": "@agents-can-communicate/adapter-claude-code",
-      "version": "0.5.0"
+      "version": "0.5.1"
     },
     "packages/adapter-codex": {
       "name": "@agents-can-communicate/adapter-codex",
-      "version": "0.5.0"
+      "version": "0.5.1"
     },
     "packages/adapter-gemini-cli": {
       "name": "@agents-can-communicate/adapter-gemini-cli",
-      "version": "0.5.0"
+      "version": "0.5.1"
     },
     "packages/adapter-grok": {
       "name": "@agents-can-communicate/adapter-grok",
-      "version": "0.5.0"
+      "version": "0.5.1"
     },
     "packages/adapter-kimi": {
       "name": "@agents-can-communicate/adapter-kimi",
-      "version": "0.5.0"
+      "version": "0.5.1"
     },
     "packages/adapter-sdk": {
       "name": "@agents-can-communicate/adapter-sdk",
-      "version": "0.5.0"
+      "version": "0.5.1"
     },
     "packages/cli": {
       "name": "@agents-can-communicate/cli",
-      "version": "0.5.0"
+      "version": "0.5.1"
     },
     "packages/core": {
       "name": "@agents-can-communicate/core",
-      "version": "0.5.0"
+      "version": "0.5.1"
     },
     "packages/delivery-router": {
       "name": "@agents-can-communicate/delivery-router",
-      "version": "0.5.0"
+      "version": "0.5.1"
     },
     "packages/hook-runner": {
       "name": "@agents-can-communicate/hook-runner",
-      "version": "0.5.0"
+      "version": "0.5.1"
     },
     "packages/installer": {
       "name": "@agents-can-communicate/installer",
-      "version": "0.5.0"
+      "version": "0.5.1"
     },
     "packages/mcp-server": {
       "name": "@agents-can-communicate/mcp-server",
-      "version": "0.5.0"
+      "version": "0.5.1"
     },
     "packages/protocol": {
       "name": "@agents-can-communicate/protocol",
-      "version": "0.5.0"
+      "version": "0.5.1"
     },
     "packages/storage-filesystem": {
       "name": "@agents-can-communicate/storage-filesystem",
-      "version": "0.5.0"
+      "version": "0.5.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "accManagedUpdateProtocol": 2,
   "accStoreVersion": 6,
   "type": "module",

--- a/packages/adapter-claude-code/package.json
+++ b/packages/adapter-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-claude-code",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-codex",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-codex/src/permission-ownership.mjs
+++ b/packages/adapter-codex/src/permission-ownership.mjs
@@ -11,6 +11,19 @@ const marker = (source, prefix) => source.startsWith(prefix) ? source.slice(pref
 // Permission selection, proxy and network grants form one ownership unit. If
 // any component changes, none can be removed independently: enabled networking
 // without its proxy has a different security meaning to Codex.
+//
+// A block records the table it was written inside, but that table only carries
+// meaning for a block whose first declaration is a bare assignment: such an
+// assignment belongs to whatever table precedes it, so a moved block would
+// silently mean something else. A block that opens with its own header states
+// its full path and is unaffected by what sits above it.
+//
+// The distinction is not theoretical. ACC appends the profile block at end of
+// file and then tells the user to trust ACC's hooks in Codex - and Codex writes
+// those trust entries as new `hooks.state` tables above the block. Comparing
+// the enclosing table unconditionally turned ACC's own documented setup step
+// into `customized`: doctor then reported working permissions as unverified,
+// install refused to repair them, and uninstall would not remove them.
 export function inspectPermissions(source) {
   const blocks = [];
   let open = null, metadata = null;
@@ -21,7 +34,8 @@ export function inspectPermissions(source) {
       if (open || !/^[a-z]+$/.test(start) || blocks.some(block => block.id === start)) {
         unsafe("duplicate or nested native permission marker");
       }
-      open = { id: start, start: entry.start, table: entry.table, contentStart: entry.end };
+      open = { id: start, start: entry.start, table: entry.table, contentStart: entry.end,
+        opens: null };
     } else if (comment.startsWith(META)) {
       if (!open || open.id !== "selection" || metadata !== null || entry.start !== open.contentStart) {
         unsafe("misplaced permission metadata");
@@ -29,6 +43,8 @@ export function inspectPermissions(source) {
       try { metadata = JSON.parse(comment.slice(META.length)); }
       catch { unsafe("invalid permission metadata"); }
       open.contentStart = entry.end;
+    } else if (open && entry.code && open.opens === null) {
+      open.opens = entry.header ? "table" : "assignment";
     } else if (end !== null) {
       if (!open || open.id !== end) unsafe("unmatched native permission marker");
       blocks.push({ ...open, end: entry.end, body: source.slice(open.contentStart, entry.start) });
@@ -45,7 +61,8 @@ export function inspectPermissions(source) {
     if (!record || Object.keys(record).sort().join() !== "before,hash,id,table"
       || typeof record.before !== "string" || record.hash !== hash(block.body, record)
       || (block.id === "selection" && block.table.length !== 0)
-      || JSON.stringify(block.table) !== JSON.stringify(record.table)) {
+      || (block.opens === "assignment"
+        && JSON.stringify(block.table) !== JSON.stringify(record.table))) {
       return { source, state: "customized" };
     }
   }

--- a/packages/adapter-codex/test/live-permissions-ownership.test.mjs
+++ b/packages/adapter-codex/test/live-permissions-ownership.test.mjs
@@ -84,3 +84,40 @@ test("restoring legacy tables cannot reparent a new foreign assignment", () => {
   assert.equal(removeLivePermissions(edited).state, "customized");
   assert.equal(removeLivePermissions(edited).source, edited);
 });
+
+// ACC appends its profile block at end of file and then tells the user to trust
+// ACC's hooks in Codex. Codex writes each trusted hook as a new `hooks.state`
+// table, and those land above the appended block, changing the table that
+// encloses it. Comparing that table unconditionally turned ACC's own documented
+// setup step into `customized`: doctor reported working permissions as
+// unverified, install refused to repair them, uninstall would not remove them.
+test("a client writing new tables above the appended block keeps ACC's ownership", () => {
+  const before = 'model = "mine"\n[features]\nother = true\n';
+  const source = prepareLivePermissions(before, context).source;
+  const trust = '[hooks.state."agents-can-communicate@acc-local:hooks.json:stop:0:0"]\n'
+    + 'trusted_hash = "sha256:abc"\n';
+  const marker = "# ACC native permissions begin profile";
+  const edited = source.replace(marker, trust + marker);
+
+  assert.notEqual(source.indexOf(marker), -1, "the profile block must exist to move");
+  assert.equal(removeLivePermissions(edited).state, "owned");
+  const restored = removeLivePermissions(edited).source;
+  assert.doesNotMatch(restored, /ACC native permissions/);
+  assert.match(restored, /agents-can-communicate@acc-local/);
+  assert.equal(restored, before + trust);
+});
+
+// The relaxation is only sound for a block that opens with its own header. A
+// block whose first declaration is a bare assignment belongs to whatever table
+// precedes it, so moving it changes what the assignment configures.
+test("a block opening with a bare assignment still depends on its enclosing table", () => {
+  const source = prepareLivePermissions('model = "mine"\n[features]\nother = true\n', context).source;
+  const proxy = "# ACC native permissions begin proxy";
+  const body = source.slice(source.indexOf(proxy));
+  assert.match(body.split("\n")[1], /^network_proxy = true$/,
+    "this test is only meaningful while the proxy block opens with a bare assignment");
+
+  const edited = source.replace(proxy, '[unrelated]\nkey = 1\n' + proxy);
+  assert.equal(removeLivePermissions(edited).state, "customized");
+  assert.equal(removeLivePermissions(edited).source, edited);
+});

--- a/packages/adapter-gemini-cli/extension/gemini-extension.json
+++ b/packages/adapter-gemini-cli/extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-can-communicate",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Coordinate this Gemini CLI session with other AI agent sessions working in the same workspace.",
   "contextFileName": "skills/acc/SKILL.md"
 }

--- a/packages/adapter-gemini-cli/package.json
+++ b/packages/adapter-gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-gemini-cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-grok/package.json
+++ b/packages/adapter-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-grok",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-kimi/package.json
+++ b/packages/adapter-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-kimi",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/adapter-sdk",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapter-sdk/test/session-binding-contract.test.mjs
+++ b/packages/adapter-sdk/test/session-binding-contract.test.mjs
@@ -1,17 +1,17 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 import { storeSessionBinding } from "../src/session-binding.mjs";
+import { fixtureRoot } from "../../../tests/helpers/temp-workspace.mjs";
 
 const bindingFile = (runtimeDir, harnessSessionId) => path.join(runtimeDir, "bindings",
   `${createHash("sha256").update(harnessSessionId).digest("hex").slice(0, 32)}.json`);
 
-test("a published binding declares the contract and generation that wrote it", async () => {
-  const runtimeDir = await mkdtemp(path.join(tmpdir(), "acc-binding-"));
+test("a published binding declares the contract and generation that wrote it", async t => {
+  const runtimeDir = await fixtureRoot(t, "acc-binding-");
   await storeSessionBinding({ runtimeDir, harnessSessionId: "harness-1",
     accSessionId: "session_aaaaaaaaaaaaaaaaaaaaaa", generation: "generation_bbbbbbbbbbbbbbbbbbbbbb",
     clientVersion: "2.1.267", platform: "darwin-arm64", clientPid: 4242,
@@ -23,8 +23,8 @@ test("a published binding declares the contract and generation that wrote it", a
   assert.equal(record.generation, "generation_bbbbbbbbbbbbbbbbbbbbbb");
 });
 
-test("a binding written without the contract stays readable", async () => {
-  const runtimeDir = await mkdtemp(path.join(tmpdir(), "acc-binding-"));
+test("a binding written without the contract stays readable", async t => {
+  const runtimeDir = await fixtureRoot(t, "acc-binding-");
   await storeSessionBinding({ runtimeDir, harnessSessionId: "harness-2",
     accSessionId: "session_aaaaaaaaaaaaaaaaaaaaaa", generation: "generation_bbbbbbbbbbbbbbbbbbbbbb",
     clientVersion: "2.1.267", platform: "darwin-arm64", clientPid: 4243 });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cli/test/hook-entrypoint-pin-fallback.test.mjs
+++ b/packages/cli/test/hook-entrypoint-pin-fallback.test.mjs
@@ -14,6 +14,7 @@ import { STORE_VERSION } from "@agents-can-communicate/storage-filesystem";
 import { writePin } from "../src/managed-runtime/pins.mjs";
 import { canonicalManagerRoot } from "../src/managed-runtime/state.mjs";
 import { main } from "../../../bin/entrypoints/acc-hook.mjs";
+import { fixtureRoot } from "../../../tests/helpers/temp-workspace.mjs";
 
 async function withArgv(args, fn) {
   const original = process.argv;
@@ -36,8 +37,8 @@ async function withDataHome(fn) {
   }
 }
 
-test("a pinned session's hook runs the pinned generation's own entrypoint", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-hook-pin-"));
+test("a pinned session's hook runs the pinned generation's own entrypoint", async t => {
+  const root = await fixtureRoot(t, "acc-hook-pin-");
   const managerRoot = path.join(root, "runtime");
   const pinned = path.join(managerRoot, "generations", "0.4.2-pinned");
   const active = path.join(managerRoot, "generations", "0.4.4-active");
@@ -65,9 +66,9 @@ test("a pinned session's hook runs the pinned generation's own entrypoint", asyn
   process.exitCode = 0;
 });
 
-test("a pinned generation that will not import falls back to the active generation without failing the client", async () => {
+test("a pinned generation that will not import falls back to the active generation without failing the client", async t => {
   await withDataHome(async () => {
-    const root = await mkdtemp(path.join(tmpdir(), "acc-hook-pin-broken-"));
+    const root = await fixtureRoot(t, "acc-hook-pin-broken-");
     const managerRoot = path.join(root, "runtime");
     const pinned = path.join(managerRoot, "generations", "0.4.2-broken");
     const active = path.join(managerRoot, "generations", "0.4.4-active");
@@ -90,9 +91,9 @@ test("a pinned generation that will not import falls back to the active generati
   });
 });
 
-test("a pinned generation whose entrypoint imports but whose main throws also falls back", async () => {
+test("a pinned generation whose entrypoint imports but whose main throws also falls back", async t => {
   await withDataHome(async () => {
-    const root = await mkdtemp(path.join(tmpdir(), "acc-hook-pin-throws-"));
+    const root = await fixtureRoot(t, "acc-hook-pin-throws-");
     const managerRoot = path.join(root, "runtime");
     const pinned = path.join(managerRoot, "generations", "0.4.2-throws");
     const active = path.join(managerRoot, "generations", "0.4.4-active");
@@ -112,9 +113,9 @@ test("a pinned generation whose entrypoint imports but whose main throws also fa
   });
 });
 
-test("no managerRoot or packageRoot (unmanaged invocation) never attempts delegation", async () => {
+test("no managerRoot or packageRoot (unmanaged invocation) never attempts delegation", async t => {
   await withDataHome(async () => {
-    const root = await mkdtemp(path.join(tmpdir(), "acc-hook-unmanaged-"));
+    const root = await fixtureRoot(t, "acc-hook-unmanaged-");
     const payload = { hook_event_name: "Notification", session_id: "session-unmanaged", cwd: root };
     process.exitCode = undefined;
     await withArgv(["claude_code", "Notification"], () => main({ payload }));
@@ -131,9 +132,9 @@ test("no managerRoot or packageRoot (unmanaged invocation) never attempts delega
 // the coincidence - the pin below still names a different, importable
 // generation, so if the guard were missing this hook would delegate again and
 // that second generation's own `main` would run and leave its own mark.
-test("a hook already running because it was delegated to never delegates again", async () => {
+test("a hook already running because it was delegated to never delegates again", async t => {
   await withDataHome(async () => {
-    const root = await mkdtemp(path.join(tmpdir(), "acc-hook-recursion-"));
+    const root = await fixtureRoot(t, "acc-hook-recursion-");
     const managerRoot = path.join(root, "runtime");
     const active = path.join(managerRoot, "generations", "0.4.4-active");
     const elsewhere = path.join(managerRoot, "generations", "0.4.9-elsewhere");
@@ -172,9 +173,9 @@ test("a hook already running because it was delegated to never delegates again",
 // value only, the contract its pin declares. The marker is the non-vacuousness
 // evidence: with a matching contract the first test asserts it is written, so
 // its absence here can only come from the gate, not from a broken fixture.
-test("a pinned generation declaring another store contract is never imported, and the client still proceeds", async () => {
+test("a pinned generation declaring another store contract is never imported, and the client still proceeds", async t => {
   await withDataHome(async () => {
-    const root = await mkdtemp(path.join(tmpdir(), "acc-hook-pin-contract-"));
+    const root = await fixtureRoot(t, "acc-hook-pin-contract-");
     const managerRoot = path.join(root, "runtime");
     const pinned = path.join(managerRoot, "generations", "0.4.2-other-contract");
     const active = path.join(managerRoot, "generations", "0.4.4-active");

--- a/packages/cli/test/hook-pin-delegation.test.mjs
+++ b/packages/cli/test/hook-pin-delegation.test.mjs
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtemp, mkdir, symlink, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 
@@ -9,9 +8,10 @@ import { STORE_VERSION } from "@agents-can-communicate/storage-filesystem";
 
 import { resolvePinnedGeneration, writePin } from "../src/managed-runtime/pins.mjs";
 import { canonicalManagerRoot } from "../src/managed-runtime/state.mjs";
+import { fixtureRoot } from "../../../tests/helpers/temp-workspace.mjs";
 
-test("a session pinned to another generation resolves that entrypoint", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-delegate-"));
+test("a session pinned to another generation resolves that entrypoint", async t => {
+  const root = await fixtureRoot(t, "acc-delegate-");
   const pinned = path.join(root, "generations", "0.4.2-abc");
   await mkdir(path.join(pinned, "bin", "entrypoints"), { recursive: true });
   await writeFile(path.join(pinned, "bin", "entrypoints", "acc-hook.mjs"), "export const main = () => {};");
@@ -22,8 +22,8 @@ test("a session pinned to another generation resolves that entrypoint", async ()
     await canonicalManagerRoot(pinned));
 });
 
-test("a session pinned to the active generation does not delegate", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-delegate-"));
+test("a session pinned to the active generation does not delegate", async t => {
+  const root = await fixtureRoot(t, "acc-delegate-");
   const active = path.join(root, "generations", "0.4.4-def");
   await mkdir(path.join(active, "bin", "entrypoints"), { recursive: true });
   await writeFile(path.join(active, "bin", "entrypoints", "acc-hook.mjs"), "export const main = () => {};");
@@ -32,16 +32,16 @@ test("a session pinned to the active generation does not delegate", async () => 
   assert.equal(await resolvePinnedGeneration({ root, harnessSessionId: "h2", active }), null);
 });
 
-test("a pinned generation removed from disk falls back to the active one", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-delegate-"));
+test("a pinned generation removed from disk falls back to the active one", async t => {
+  const root = await fixtureRoot(t, "acc-delegate-");
   await writePin({ root, harnessSessionId: "h3", runtimeRoot: path.join(root, "generations", "gone"),
     version: "0.4.2", storeVersion: STORE_VERSION, clientPid: process.pid });
   const active = path.join(root, "generations", "0.4.4-def");
   assert.equal(await resolvePinnedGeneration({ root, harnessSessionId: "h3", active }), null);
 });
 
-test("no pin falls back to the active generation", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-delegate-"));
+test("no pin falls back to the active generation", async t => {
+  const root = await fixtureRoot(t, "acc-delegate-");
   assert.equal(await resolvePinnedGeneration({ root, harnessSessionId: "absent",
     active: path.join(root, "generations", "0.4.4-def") }), null);
 });
@@ -59,8 +59,8 @@ test("no pin falls back to the active generation", async () => {
 // runner rather than about the code, and fails on Linux for a reason that
 // has nothing to do with the fix. A real directory plus a symlink this test
 // creates and uses as the data home makes the divergence exist everywhere.
-test("a pin written under the runner's raw data-home root is found by the hook's canonicalised root", async () => {
-  const container = await mkdtemp(path.join(tmpdir(), "acc-datahome-"));
+test("a pin written under the runner's raw data-home root is found by the hook's canonicalised root", async t => {
+  const container = await fixtureRoot(t, "acc-datahome-");
   const base = path.join(container, "real");
   const dataHome = path.join(container, "link");
   await mkdir(base, { recursive: true });
@@ -96,9 +96,9 @@ test("a pin written under the runner's raw data-home root is found by the hook's
 // run is that checkout). A later managed hook must refuse to import it, the
 // same way validateRuntime already refuses a control record's generation
 // pointer that lands outside <root>/generations.
-test("a pin naming a generation outside the manager's own generations directory is refused", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-delegate-"));
-  const outside = await mkdtemp(path.join(tmpdir(), "acc-outside-"));
+test("a pin naming a generation outside the manager's own generations directory is refused", async t => {
+  const root = await fixtureRoot(t, "acc-delegate-");
+  const outside = await fixtureRoot(t, "acc-outside-");
   await mkdir(path.join(outside, "bin", "entrypoints"), { recursive: true });
   // A real, importable entrypoint - proves refusal comes from containment,
   // not merely from the file being unreachable.
@@ -112,8 +112,8 @@ test("a pin naming a generation outside the manager's own generations directory 
 // Minor: covers the resolve level directly rather than leaning on Task 7's
 // readPin tests alone - every failure path this task owns should be pinned by
 // a test at the level this task added.
-test("an unreadable pin record falls back to the active generation", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-delegate-"));
+test("an unreadable pin record falls back to the active generation", async t => {
+  const root = await fixtureRoot(t, "acc-delegate-");
   const canonicalRoot = await canonicalManagerRoot(root);
   await mkdir(path.join(canonicalRoot, "pins"), { recursive: true });
   const file = path.join(canonicalRoot, "pins",
@@ -138,9 +138,9 @@ test("an unreadable pin record falls back to the active generation", async () =>
 // and differ in exactly one value, the pin's declared contract. The first is
 // the control and must delegate; if the gate were removed the others would
 // answer the same way and the test would fail.
-test("a pin declaring a store contract other than this generation's is not delegated to", async () => {
+test("a pin declaring a store contract other than this generation's is not delegated to", async t => {
   const fixture = async (harnessSessionId, storeVersion) => {
-    const root = await mkdtemp(path.join(tmpdir(), "acc-delegate-contract-"));
+    const root = await fixtureRoot(t, "acc-delegate-contract-");
     const pinned = path.join(root, "generations", "0.4.2-abc");
     await mkdir(path.join(pinned, "bin", "entrypoints"), { recursive: true });
     await writeFile(path.join(pinned, "bin", "entrypoints", "acc-hook.mjs"),
@@ -169,8 +169,8 @@ test("a pin declaring a store contract other than this generation's is not deleg
 // root manifest declares none, carries null. Unknown cannot be proved equal,
 // and this function's answer to every pin it cannot honour is the active
 // generation.
-test("a pin declaring no store contract at all is not delegated to", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-delegate-nocontract-"));
+test("a pin declaring no store contract at all is not delegated to", async t => {
+  const root = await fixtureRoot(t, "acc-delegate-nocontract-");
   const pinned = path.join(root, "generations", "0.4.2-abc");
   await mkdir(path.join(pinned, "bin", "entrypoints"), { recursive: true });
   await writeFile(path.join(pinned, "bin", "entrypoints", "acc-hook.mjs"), "export const main = () => {};");

--- a/packages/cli/test/managed-runtime-pins.test.mjs
+++ b/packages/cli/test/managed-runtime-pins.test.mjs
@@ -1,41 +1,39 @@
 import assert from "node:assert/strict";
-import { mkdtemp } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import path from "node:path";
 import test from "node:test";
 
 import { clearPin, readPin, reapPins, writePin } from "../src/managed-runtime/pins.mjs";
+import { fixtureRoot } from "../../../tests/helpers/temp-workspace.mjs";
 
-const root = () => mkdtemp(path.join(tmpdir(), "acc-pins-"));
+const root = t => fixtureRoot(t, "acc-pins-");
 const pin = { harnessSessionId: "harness-1", runtimeRoot: "/generations/0.4.2-abc",
   version: "0.4.2", storeVersion: 6, clientPid: 4242 };
 
-test("a pin round-trips by harness session id", async () => {
-  const dir = await root();
+test("a pin round-trips by harness session id", async t => {
+  const dir = await root(t);
   await writePin({ root: dir, ...pin });
   assert.equal((await readPin({ root: dir, harnessSessionId: "harness-1" })).version, "0.4.2");
 });
 
-test("an unknown session has no pin", async () => {
-  assert.equal(await readPin({ root: await root(), harnessSessionId: "absent" }), null);
+test("an unknown session has no pin", async t => {
+  assert.equal(await readPin({ root: await root(t), harnessSessionId: "absent" }), null);
 });
 
-test("clearing removes it", async () => {
-  const dir = await root();
+test("clearing removes it", async t => {
+  const dir = await root(t);
   await writePin({ root: dir, ...pin });
   await clearPin({ root: dir, harnessSessionId: "harness-1" });
   assert.equal(await readPin({ root: dir, harnessSessionId: "harness-1" }), null);
 });
 
-test("a pin whose client is confirmed dead is reaped", async () => {
-  const dir = await root();
+test("a pin whose client is confirmed dead is reaped", async t => {
+  const dir = await root(t);
   await writePin({ root: dir, ...pin });
   await reapPins({ root: dir, pidIsAlive: () => false });
   assert.equal(await readPin({ root: dir, harnessSessionId: "harness-1" }), null);
 });
 
-test("a pin whose client is alive survives a reap", async () => {
-  const dir = await root();
+test("a pin whose client is alive survives a reap", async t => {
+  const dir = await root(t);
   await writePin({ root: dir, ...pin });
   await reapPins({ root: dir, pidIsAlive: () => true });
   assert.notEqual(await readPin({ root: dir, harnessSessionId: "harness-1" }), null);

--- a/packages/cli/test/managed-runtime-retention.test.mjs
+++ b/packages/cli/test/managed-runtime-retention.test.mjs
@@ -11,6 +11,7 @@ import { writePin } from "../src/managed-runtime/pins.mjs";
 import { attachStagingTemp, holdStagedGeneration, reapStagingHolds, releaseStagingHold }
   from "../src/managed-runtime/staging.mjs";
 import { readControl, writeControl, writeManagedJson } from "../src/managed-runtime/state.mjs";
+import { fixtureRoot } from "../../../tests/helpers/temp-workspace.mjs";
 
 // Every scenario below runs against a real, written control.json: an absent
 // one now postpones the whole pass (Finding 4), so a test that wants to
@@ -30,8 +31,8 @@ async function writeLease(root, name, runtimeRoot) {
     createdAt: new Date().toISOString() });
 }
 
-test("an unreferenced generation is removed and a pinned one is kept", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-retain-"));
+test("an unreferenced generation is removed and a pinned one is kept", async t => {
+  const root = await fixtureRoot(t, "acc-retain-");
   for (const name of ["0.4.0-a", "0.4.2-b", "0.4.4-c"]) {
     await mkdir(path.join(root, "generations", name), { recursive: true });
   }
@@ -44,8 +45,8 @@ test("an unreferenced generation is removed and a pinned one is kept", async () 
   assert.deepEqual((await readdir(path.join(root, "generations"))).sort(), ["0.4.2-b", "0.4.4-c"]);
 });
 
-test("a generation held only by a live pin survives reclamation", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-retain-livepin-"));
+test("a generation held only by a live pin survives reclamation", async t => {
+  const root = await fixtureRoot(t, "acc-retain-livepin-");
   for (const name of ["0.3.9-orphan", "0.4.0-pinned-only", "0.4.1-active"]) {
     await mkdir(path.join(root, "generations", name), { recursive: true });
   }
@@ -60,8 +61,8 @@ test("a generation held only by a live pin survives reclamation", async () => {
     ["0.4.0-pinned-only", "0.4.1-active"]);
 });
 
-test("a pin whose client is confirmed dead does not save its generation", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-retain-deadpin-"));
+test("a pin whose client is confirmed dead does not save its generation", async t => {
+  const root = await fixtureRoot(t, "acc-retain-deadpin-");
   for (const name of ["0.4.0-dead-pin-only", "0.4.1-active"]) {
     await mkdir(path.join(root, "generations", name), { recursive: true });
   }
@@ -75,8 +76,8 @@ test("a pin whose client is confirmed dead does not save its generation", async 
   assert.deepEqual(await readdir(path.join(root, "generations")), ["0.4.1-active"]);
 });
 
-test("a pin that cannot be read is an unknown holder and reclaim removes nothing", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-retain-badpin-"));
+test("a pin that cannot be read is an unknown holder and reclaim removes nothing", async t => {
+  const root = await fixtureRoot(t, "acc-retain-badpin-");
   await mkdir(path.join(root, "generations", "0.4.0-would-be-orphan"), { recursive: true });
   await mkdir(path.join(root, "generations", "0.4.1-active"), { recursive: true });
   await fixtureControl(root, { active: path.join(root, "generations", "0.4.1-active") });
@@ -89,8 +90,8 @@ test("a pin that cannot be read is an unknown holder and reclaim removes nothing
     ["0.4.0-would-be-orphan", "0.4.1-active"]);
 });
 
-test("an unreadable lease is an unknown holder and reclaim removes nothing", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-retain-badlease-"));
+test("an unreadable lease is an unknown holder and reclaim removes nothing", async t => {
+  const root = await fixtureRoot(t, "acc-retain-badlease-");
   await mkdir(path.join(root, "generations", "0.4.0-would-be-orphan"), { recursive: true });
   await mkdir(path.join(root, "generations", "0.4.1-active"), { recursive: true });
   await fixtureControl(root, { active: path.join(root, "generations", "0.4.1-active") });
@@ -103,8 +104,8 @@ test("an unreadable lease is an unknown holder and reclaim removes nothing", asy
     ["0.4.0-would-be-orphan", "0.4.1-active"]);
 });
 
-test("control's own active and pending pointers protect their generations without an explicit active override", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-retain-control-"));
+test("control's own active and pending pointers protect their generations without an explicit active override", async t => {
+  const root = await fixtureRoot(t, "acc-retain-control-");
   for (const name of ["0.3.0-orphan", "0.4.0-active-from-control", "0.4.1-pending-from-control"]) {
     await mkdir(path.join(root, "generations", name), { recursive: true });
   }
@@ -116,8 +117,8 @@ test("control's own active and pending pointers protect their generations withou
     ["0.4.0-active-from-control", "0.4.1-pending-from-control"]);
 });
 
-test("a generation held only by a live runtime lease survives reclamation", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-retain-livelease-"));
+test("a generation held only by a live runtime lease survives reclamation", async t => {
+  const root = await fixtureRoot(t, "acc-retain-livelease-");
   for (const name of ["0.3.9-orphan", "0.4.0-leased-only", "0.4.1-active"]) {
     await mkdir(path.join(root, "generations", name), { recursive: true });
   }
@@ -129,8 +130,8 @@ test("a generation held only by a live runtime lease survives reclamation", asyn
     ["0.4.0-leased-only", "0.4.1-active"]);
 });
 
-test("activatePending reclaims the superseded generation once the new one is active", async () => {
-  const dataHome = await realpath(await mkdtemp(path.join(tmpdir(), "acc-retain-wiring-")));
+test("activatePending reclaims the superseded generation once the new one is active", async t => {
+  const dataHome = await realpath(await fixtureRoot(t, "acc-retain-wiring-"));
   const root = path.join(dataHome, "acc", "runtime");
   const active = { version: "0.4.0", root: path.join(root, "generations", "old-gen") };
   const pending = { version: "0.4.1", root: path.join(root, "generations", "new-gen") };
@@ -143,16 +144,16 @@ test("activatePending reclaims the superseded generation once the new one is act
   assert.deepEqual((await readdir(path.join(root, "generations"))).sort(), ["new-gen"]);
 });
 
-test("a manager root with generations but no control.json is an unknown state and reclaim removes nothing", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-retain-nocontrol-"));
+test("a manager root with generations but no control.json is an unknown state and reclaim removes nothing", async t => {
+  const root = await fixtureRoot(t, "acc-retain-nocontrol-");
   await mkdir(path.join(root, "generations", "0.4.0-orphan"), { recursive: true });
   const result = await reclaimGenerations({ root, active: null, pidIsAlive: () => true });
   assert.deepEqual(result.removed, []);
   assert.deepEqual(await readdir(path.join(root, "generations")), ["0.4.0-orphan"]);
 });
 
-test("a generation held only by a live staging hold survives reclamation", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-retain-staginghold-"));
+test("a generation held only by a live staging hold survives reclamation", async t => {
+  const root = await fixtureRoot(t, "acc-retain-staginghold-");
   for (const name of ["0.3.9-orphan", "0.4.5-staged-only", "0.4.0-active"]) {
     await mkdir(path.join(root, "generations", name), { recursive: true });
   }
@@ -165,8 +166,8 @@ test("a generation held only by a live staging hold survives reclamation", async
     ["0.4.0-active", "0.4.5-staged-only"]);
 });
 
-test("a staging hold whose process is confirmed dead does not save its generation", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-retain-deadstaging-"));
+test("a staging hold whose process is confirmed dead does not save its generation", async t => {
+  const root = await fixtureRoot(t, "acc-retain-deadstaging-");
   for (const name of ["0.4.5-abandoned", "0.4.0-active"]) {
     await mkdir(path.join(root, "generations", name), { recursive: true });
   }
@@ -178,8 +179,8 @@ test("a staging hold whose process is confirmed dead does not save its generatio
   assert.deepEqual(await readdir(path.join(root, "generations")), ["0.4.0-active"]);
 });
 
-test("a staging hold that cannot be read is an unknown holder and reclaim removes nothing", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-retain-badstaging-"));
+test("a staging hold that cannot be read is an unknown holder and reclaim removes nothing", async t => {
+  const root = await fixtureRoot(t, "acc-retain-badstaging-");
   await mkdir(path.join(root, "generations", "0.4.0-would-be-orphan"), { recursive: true });
   await mkdir(path.join(root, "generations", "0.4.1-active"), { recursive: true });
   await fixtureControl(root, { active: path.join(root, "generations", "0.4.1-active") });
@@ -192,8 +193,8 @@ test("a staging hold that cannot be read is an unknown holder and reclaim remove
     ["0.4.0-would-be-orphan", "0.4.1-active"]);
 });
 
-test("an in-flight staging temp is never touched by reclaim", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-retain-stagingtemp-"));
+test("an in-flight staging temp is never touched by reclaim", async t => {
+  const root = await fixtureRoot(t, "acc-retain-stagingtemp-");
   const activeRoot = path.join(root, "generations", "0.4.0-active");
   await mkdir(activeRoot, { recursive: true });
   const stagingTemp = path.join(root, "generations", ".staging-abc123");
@@ -205,8 +206,8 @@ test("an in-flight staging temp is never touched by reclaim", async () => {
   assert.equal(await readFile(path.join(stagingTemp, "partial.txt"), "utf8"), "still being written");
 });
 
-test("a generation staged but not yet published is not deleted out from under the process staging it", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-retain-realstaging-"));
+test("a generation staged but not yet published is not deleted out from under the process staging it", async t => {
+  const root = await fixtureRoot(t, "acc-retain-realstaging-");
   const managerRoot = path.join(root, "manager");
   const packageRoot = path.join(root, "source");
   await mkdir(path.join(packageRoot, "bin"), { recursive: true });
@@ -242,8 +243,8 @@ test("a generation staged but not yet published is not deleted out from under th
 // four (no scheduleWorker, no apply callback) - through an actual staging,
 // verification (a real spawned subprocess, matching verifyGeneration's own
 // contract), and publish, and asserts the hold is gone afterward.
-test("stageNewerManagementRuntime releases its staging hold once the attempt resolves", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-retain-recovery-release-"));
+test("stageNewerManagementRuntime releases its staging hold once the attempt resolves", async t => {
+  const root = await fixtureRoot(t, "acc-retain-recovery-release-");
   const managerRoot = path.join(root, "manager");
   const packageRoot = path.join(root, "source");
   await mkdir(path.join(packageRoot, "bin"), { recursive: true });
@@ -267,8 +268,8 @@ test("stageNewerManagementRuntime releases its staging hold once the attempt res
   assert.deepEqual(await readdir(stagingDir).catch(() => []), []);
 });
 
-test("stageOwnGeneration's fast path (already matching, no rename) still returns a hold that protects the generation", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-retain-faststage-"));
+test("stageOwnGeneration's fast path (already matching, no rename) still returns a hold that protects the generation", async t => {
+  const root = await fixtureRoot(t, "acc-retain-faststage-");
   const managerRoot = path.join(root, "manager");
   const packageRoot = path.join(root, "source");
   await mkdir(path.join(packageRoot, "bin"), { recursive: true });
@@ -292,8 +293,8 @@ test("stageOwnGeneration's fast path (already matching, no rename) still returns
   assert.equal((await readdir(path.join(managerRoot, "generations"))).includes(path.basename(second.root)), true);
 });
 
-test("an abandoned staging temp is swept once its owner is confirmed dead", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-retain-abandoned-"));
+test("an abandoned staging temp is swept once its owner is confirmed dead", async t => {
+  const root = await fixtureRoot(t, "acc-retain-abandoned-");
   const activeRoot = path.join(root, "generations", "0.4.0-active");
   await mkdir(activeRoot, { recursive: true });
   await fixtureControl(root, { active: activeRoot });
@@ -311,8 +312,8 @@ test("an abandoned staging temp is swept once its owner is confirmed dead", asyn
   await assert.rejects(readFile(hold), { code: "ENOENT" });
 });
 
-test("a live staging temp survives both reclaim and reap", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-retain-livetemp-"));
+test("a live staging temp survives both reclaim and reap", async t => {
+  const root = await fixtureRoot(t, "acc-retain-livetemp-");
   const activeRoot = path.join(root, "generations", "0.4.0-active");
   await mkdir(activeRoot, { recursive: true });
   await fixtureControl(root, { active: activeRoot });
@@ -328,8 +329,8 @@ test("a live staging temp survives both reclaim and reap", async () => {
   assert.equal(JSON.parse(await readFile(hold, "utf8")).stagingRoot, stagingTemp);
 });
 
-test("attachStagingTemp records the temp path onto a live hold", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-retain-attach-live-"));
+test("attachStagingTemp records the temp path onto a live hold", async t => {
+  const root = await fixtureRoot(t, "acc-retain-attach-live-");
   const hold = await holdStagedGeneration({ root, generationRoot: path.join(root, "generations", "0.4.9-x"),
     pid: process.pid });
   const stagingTemp = path.join(root, "generations", ".staging-abc");
@@ -346,8 +347,8 @@ test("attachStagingTemp records the temp path onto a live hold", async () => {
 // can never reap (no valid pid to confirm dead). No concurrent window needs
 // manufacturing to prove the guard: attachStagingTemp takes the file path
 // directly, so removing it first reproduces the exact precondition.
-test("attachStagingTemp does nothing when the hold it would attach to is already gone", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "acc-retain-attach-gone-"));
+test("attachStagingTemp does nothing when the hold it would attach to is already gone", async t => {
+  const root = await fixtureRoot(t, "acc-retain-attach-gone-");
   const hold = await holdStagedGeneration({ root, generationRoot: path.join(root, "generations", "0.4.9-y"),
     pid: process.pid });
   await rm(hold, { force: true });
@@ -397,26 +398,33 @@ test("a staging hold racing reclaim never loses, across many jittered interleavi
   const DECOYS = 40;
   const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
   for (let trial = 0; trial < TRIALS; trial++) {
+    // Each trial builds 41 generations plus their holds. Deferring cleanup to
+    // the end of the test would hold all 200 trials at once, so a trial clears
+    // its own fixture and peak usage stays at one.
     const root = await mkdtemp(path.join(tmpdir(), `acc-retain-race-${trial}-`));
-    const activeRoot = path.join(root, "generations", "0.4.0-active");
-    await mkdir(activeRoot, { recursive: true });
-    await fixtureControl(root, { active: activeRoot });
-    for (let decoy = 0; decoy < DECOYS; decoy++) {
-      const decoyRoot = path.join(root, "generations", `decoy-${decoy}`);
-      await mkdir(decoyRoot, { recursive: true });
-      await holdStagedGeneration({ root, generationRoot: decoyRoot, pid: process.pid });
+    try {
+      const activeRoot = path.join(root, "generations", "0.4.0-active");
+      await mkdir(activeRoot, { recursive: true });
+      await fixtureControl(root, { active: activeRoot });
+      for (let decoy = 0; decoy < DECOYS; decoy++) {
+        const decoyRoot = path.join(root, "generations", `decoy-${decoy}`);
+        await mkdir(decoyRoot, { recursive: true });
+        await holdStagedGeneration({ root, generationRoot: decoyRoot, pid: process.pid });
+      }
+      const targetName = "0.4.9-racing";
+      const target = path.join(root, "generations", targetName);
+      const writer = (async () => {
+        await sleep(8 + Math.random() * 15);
+        await holdStagedGeneration({ root, generationRoot: target, pid: process.pid });
+        await mkdir(target, { recursive: true }); // stands in for stageOwnGeneration's rename
+      })();
+      const reclaim = reclaimGenerations({ root, active: null, pidIsAlive: () => true });
+      await Promise.all([writer, reclaim]);
+      const survivors = await readdir(path.join(root, "generations"));
+      assert.ok(survivors.includes(targetName),
+        `trial ${trial}: the racing generation was deleted while its hold was landing`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
     }
-    const targetName = "0.4.9-racing";
-    const target = path.join(root, "generations", targetName);
-    const writer = (async () => {
-      await sleep(8 + Math.random() * 15);
-      await holdStagedGeneration({ root, generationRoot: target, pid: process.pid });
-      await mkdir(target, { recursive: true }); // stands in for stageOwnGeneration's rename
-    })();
-    const reclaim = reclaimGenerations({ root, active: null, pidIsAlive: () => true });
-    await Promise.all([writer, reclaim]);
-    const survivors = await readdir(path.join(root, "generations"));
-    assert.ok(survivors.includes(targetName),
-      `trial ${trial}: the racing generation was deleted while its hold was landing`);
   }
 });

--- a/packages/cli/test/managed-runtime-retire.test.mjs
+++ b/packages/cli/test/managed-runtime-retire.test.mjs
@@ -1,14 +1,14 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readdir, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, readdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 
 import { isOwnedRuntimeRoot, retireManagedHolds } from "../src/managed-runtime/retire.mjs";
+import { fixtureRoot } from "../../../tests/helpers/temp-workspace.mjs";
 
-const layout = async () => {
-  const home = await mkdtemp(path.join(tmpdir(), "acc-retire-"));
+const layout = async t => {
+  const home = await fixtureRoot(t, "acc-retire-");
   const root = path.join(home, "runtime");
   const workspaces = path.join(home, "workspaces");
   const bindings = path.join(workspaces, "workspace_a", "bindings");
@@ -21,11 +21,10 @@ const layout = async () => {
   return { root, workspaces, bindings };
 };
 
-// Task 7 (packages/cli/src/managed-runtime/pins.mjs, exporting writePin) has not
-// landed in this worktree's base. retireManagedHolds does not import pins.mjs
-// itself, it only clears *.json files under root/pins directly, so this fixture
-// writes a pin record in exactly the shape Task 7's writePin brief specifies
-// without depending on that module.
+// retireManagedHolds never imports pins.mjs; it clears *.json under root/pins
+// directly. This fixture writes the same record shape writePin produces, so a
+// change in how pins are written cannot quietly make this test pass or fail for
+// a reason that has nothing to do with retirement.
 const writePinFixture = async ({ root, harnessSessionId, runtimeRoot, version, storeVersion,
   clientPid }) => {
   const directory = path.join(root, "pins");
@@ -36,8 +35,8 @@ const writePinFixture = async ({ root, harnessSessionId, runtimeRoot, version, s
     storeVersion, clientPid, createdAt: new Date().toISOString() }));
 };
 
-test("uninstall retires the bindings and pins this manager published", async () => {
-  const { root, workspaces, bindings } = await layout();
+test("uninstall retires the bindings and pins this manager published", async t => {
+  const { root, workspaces, bindings } = await layout(t);
   await writePinFixture({ root, harnessSessionId: "h1",
     runtimeRoot: path.join(root, "generations", "0.4.4-c"), version: "0.4.4",
     storeVersion: 6, clientPid: process.pid });
@@ -47,8 +46,8 @@ test("uninstall retires the bindings and pins this manager published", async () 
   assert.deepEqual(await readdir(path.join(root, "pins")), []);
 });
 
-test("a binding published by another manager is left alone", async () => {
-  const { root, workspaces, bindings } = await layout();
+test("a binding published by another manager is left alone", async t => {
+  const { root, workspaces, bindings } = await layout(t);
   await writeFile(path.join(bindings, "bbbb.json"), JSON.stringify({ schemaVersion: 1,
     harnessSessionId: "h2", accSessionId: "session_b", generation: "generation_b",
     clientVersion: "2.1.267", platform: "darwin-arm64", clientPid: process.pid,
@@ -57,8 +56,8 @@ test("a binding published by another manager is left alone", async () => {
   assert.deepEqual(await readdir(bindings), ["bbbb.json"]);
 });
 
-test("a binding naming a relative runtimeRoot is left alone regardless of the caller's cwd", async () => {
-  const { root, workspaces, bindings } = await layout();
+test("a binding naming a relative runtimeRoot is left alone regardless of the caller's cwd", async t => {
+  const { root, workspaces, bindings } = await layout(t);
   const owned = path.join(root, "generations", "0.4.4-c");
   // Chosen so that resolving it against process.cwd() reconstructs the exact
   // in-bounds generation path: if ownership were decided without requiring an
@@ -73,8 +72,8 @@ test("a binding naming a relative runtimeRoot is left alone regardless of the ca
   assert.deepEqual(await readdir(bindings), ["cccc.json"]);
 });
 
-test("a binding naming the generations directory itself, not a generation inside it, is left alone", async () => {
-  const { root, workspaces, bindings } = await layout();
+test("a binding naming the generations directory itself, not a generation inside it, is left alone", async t => {
+  const { root, workspaces, bindings } = await layout(t);
   await writeFile(path.join(bindings, "dddd.json"), JSON.stringify({ schemaVersion: 1,
     harnessSessionId: "h4", accSessionId: "session_d", generation: "generation_d",
     clientVersion: "2.1.267", platform: "darwin-arm64", clientPid: process.pid,

--- a/packages/cli/test/managed-runtime-store-contract.test.mjs
+++ b/packages/cli/test/managed-runtime-store-contract.test.mjs
@@ -1,34 +1,34 @@
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, realpath } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, realpath } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 
 import { validateRuntime } from "../src/managed-runtime/state.mjs";
+import { fixtureRoot } from "../../../tests/helpers/temp-workspace.mjs";
 
 // realpath avoids a false "outside manager generations" failure on platforms
 // (e.g. macOS) where the OS temp directory is itself a symlink.
-const managerRoot = async () => {
-  const root = await realpath(await mkdtemp(path.join(tmpdir(), "acc-contract-")));
+const managerRoot = async t => {
+  const root = await realpath(await fixtureRoot(t, "acc-contract-"));
   await mkdir(path.join(root, "generations", "0.4.4-abc"), { recursive: true });
   return root;
 };
 
-test("a generation pointer carries the store contract it declares", async () => {
-  const root = await managerRoot();
+test("a generation pointer carries the store contract it declares", async t => {
+  const root = await managerRoot(t);
   const runtime = { version: "0.4.4", root: path.join(root, "generations", "0.4.4-abc"),
     storeVersion: 6 };
   assert.equal((await validateRuntime(root, runtime)).storeVersion, 6);
 });
 
-test("a pointer written before the contract field reads as an unknown contract", async () => {
-  const root = await managerRoot();
+test("a pointer written before the contract field reads as an unknown contract", async t => {
+  const root = await managerRoot(t);
   const runtime = { version: "0.4.2", root: path.join(root, "generations", "0.4.4-abc") };
   assert.equal((await validateRuntime(root, runtime)).storeVersion, null);
 });
 
-test("a malformed contract is refused rather than silently dropped", async () => {
-  const root = await managerRoot();
+test("a malformed contract is refused rather than silently dropped", async t => {
+  const root = await managerRoot(t);
   const runtime = { version: "0.4.4", root: path.join(root, "generations", "0.4.4-abc"),
     storeVersion: "6" };
   await assert.rejects(() => validateRuntime(root, runtime), /invalid control generation/);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/delivery-router/package.json
+++ b/packages/delivery-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/delivery-router",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hook-runner/package.json
+++ b/packages/hook-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/hook-runner",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/installer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/mcp-server",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/protocol",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-can-communicate/storage-filesystem",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/tests/helpers/temp-workspace.mjs
+++ b/tests/helpers/temp-workspace.mjs
@@ -28,3 +28,14 @@ export async function withTempRuntime(run) {
     }
   });
 }
+
+// node:test offers cleanup only through `t.after`, which is reachable from the
+// test's own context, so a disposable root has to be created with `t` in hand.
+// Tests that reached for a bare `mkdtemp` instead left their trees behind: one
+// file alone created 220 roots per run. CI never noticed, because its runners
+// are discarded; a developer's temp directory grew by gigabytes across runs.
+export async function fixtureRoot(t, prefix) {
+  const created = await mkdtemp(join(tmpdir(), prefix));
+  t.after(() => rm(created, { recursive: true, force: true }));
+  return created;
+}

--- a/tests/spikes/claude-channel.test.mjs
+++ b/tests/spikes/claude-channel.test.mjs
@@ -236,8 +236,11 @@ test("the channel refuses a capture directory it cannot trust", async () => {
   const inRepo = mkdtempSync(path.join(path.dirname(channelScript), "acc-capture-"));
   const loose = mkdtempSync(path.join(os.tmpdir(), "acc-channel-loose-"));
   chmodSync(loose, 0o755);
+  // mkdtempSync appends a random suffix, so only the value it returns names the
+  // directory that exists. Created here, with the others, so the finally below
+  // removes the real path rather than rebuilding a prefix that never existed.
+  const long = mkdtempSync(path.join(os.tmpdir(), `acc-channel-${"long-".repeat(20)}`));
   try {
-    const long = mkdtempSync(path.join(os.tmpdir(), `acc-channel-${"long-".repeat(20)}`));
     for (const [dir, pattern] of [
       [inRepo, /must be outside the repository/],
       [loose, /private user-owned directory/],
@@ -253,7 +256,7 @@ test("the channel refuses a capture directory it cannot trust", async () => {
   } finally {
     rmSync(inRepo, { recursive: true, force: true });
     rmSync(loose, { recursive: true, force: true });
-    rmSync(path.join(os.tmpdir(), `acc-channel-${"long-".repeat(20)}`), { recursive: true, force: true });
+    rmSync(long, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
ACC appends its permission block at end of `config.toml` and records the TOML table
enclosing it. It then tells the user to open Codex and trust ACC hooks — and Codex writes
each trusted hook as a new `hooks.state` table, which lands above that block.

ACC compared the enclosing table unconditionally, so its own documented setup step read as
a third-party edit. `acc doctor` reported working sender permissions as unverified and
advised a reinstall that could not repair them, `prepareLivePermissions` returned early,
and `acc uninstall` would have left the block behind for manual review.

The enclosing table is now compared only for a block whose first declaration is a bare
assignment. Only such an assignment takes its meaning from the table above it; a block
that opens with its own header states its full path and is unaffected by what precedes it.
Every other ownership check is unchanged.

Delivery itself was never broken by this. Live bidirectional delivery between Claude Code
2.1.268 and Codex CLI 0.154.0 was captured on a machine wiped of every ACC trace,
installing from the public registry: both directions served natively, peer-to-peer request
to answer in seven seconds, no `acc inbox` polling.

## Second defect, found while wiping the machine

16,578 entries and 3.4 GB of test fixtures had accumulated in the system temp directory.
`node:test` exposes cleanup through `t.after`, reachable only from a test context, and
seven files declared their tests without one. One further fixture escaped because its
cleanup rebuilt the name from the prefix rather than the value `mkdtempSync` returned.
Disposable roots now come from one shared helper; a full suite leaves nothing behind.

## Evidence

| Measurement | Value |
|---|---|
| Built from | `f438cf8de8f2daac16fe975413df1491f3f1f4ae` |
| Archive | `agents-can-communicate-0.5.1.tgz`, 382,983 bytes, 272 files |
| SHA-256 | `ac2d466cafbb5d92f29c6d659b20c80575ef8baae478e2637452669aee2b1027` |
| Packed managed checks | 27/27 |
| Full suite | 2,117 tests, 2,116 passes, 0 failures, 1 skip |

Full detail in `docs/release-evidence/v0.5.1.md`. Not tagged, not published.